### PR TITLE
Fix script permissions when client testsuite is used as a dependancy

### DIFF
--- a/horreum-client/src/test/java/io/hyperfoil/tools/HorreumTestBase.java
+++ b/horreum-client/src/test/java/io/hyperfoil/tools/HorreumTestBase.java
@@ -188,8 +188,12 @@ public class HorreumTestBase {
         Files.walkFileTree(source, Collections.emptySet(), 1, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.copy(file, Path.of("target/docker-compose/", file.getFileName().toString()),
+                Path destPath = Path.of("target/docker-compose/", file.getFileName().toString());
+                Files.copy(file, destPath,
                       StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                if(file.toString().endsWith(".sh")){
+                    destPath.toFile().setExecutable(true);
+                }
                 return FileVisitResult.CONTINUE;
             }
         });


### PR DESCRIPTION
fixes #96

This implementation is not very elegant, but operations to check file permissions on a ZipFile throw an UnsupportedOperationException, so there is no easy way to discover the original file permissions.

The other option is to remove the file copy code in `prepareDockerCompose()` and use the maven-dependency-plugin to unpack dependencies in the project importing the testsuite. This would retain the correct permissions, but require each project to declare the maven-dependency-plugin in it's pom.xml