### PR TITLE
Solve issue with Eclipse build triggering repeatedly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,30 @@
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                           <artifactId>maven-antrun-plugin</artifactId>
+                                           <versionRange>[1.7,)</versionRange>
+                                           <goals>
+                                               <goal>run</goal>
+                                           </goals>
+                                           <action>
+                                               <ignore/>
+                                           </action>
+                                    </pluginExecutionFilter>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This PR changes the configuration for the life-cycle mapping. To explicitly define the run goal as the default.