### PR TITLE
Add group name to notification

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/notification/EmailPlugin.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/notification/EmailPlugin.java
@@ -64,6 +64,7 @@ public class EmailPlugin implements NotificationPlugin {
                .data("testId", String.valueOf(change.variable.testId))
                .data("variable", change.variable.name)
                .data("runId", String.valueOf(change.run.id))
+               .data("group", change.variable.group)
                .render();
          mailer.send(Mail.withHtml(data, subject, content));
       }

--- a/horreum-backend/src/main/resources/templates/change_notification_email.html
+++ b/horreum-backend/src/main/resources/templates/change_notification_email.html
@@ -1,4 +1,4 @@
 <p>Hello {username},</p>
-<p>there has been a recent change in results for test <a href="{baseUrl}/test/{testId}">{testName}</a>, change detection variable {group}/{variable}, introduced with run {runId}.</p>
+<p>there has been a recent change in results for test <a href="{baseUrl}/test/{testId}">{testName}</a>, change detection variable {#if group != null}{group}/{/if}{variable}, introduced with run {runId}.</p>
 <p>Please <a href="{baseUrl}/series?test={testId}&tags={tags}">check it out</a> and provide an explanatory description</p>
 Horreum Alerting

--- a/horreum-backend/src/main/resources/templates/change_notification_email.html
+++ b/horreum-backend/src/main/resources/templates/change_notification_email.html
@@ -1,4 +1,4 @@
 <p>Hello {username},</p>
-<p>there has been a recent change in results for test <a href="{baseUrl}/test/{testId}">{testName}</a>, change detection variable {variable}, introduced with run {runId}.</p>
+<p>there has been a recent change in results for test <a href="{baseUrl}/test/{testId}">{testName}</a>, change detection variable {group}/{variable}, introduced with run {runId}.</p>
 <p>Please <a href="{baseUrl}/series?test={testId}&tags={tags}">check it out</a> and provide an explanatory description</p>
 Horreum Alerting


### PR DESCRIPTION
When tests grouped by similar benchmark name and splitted by dataset then it is hard to distinguish the benchmark out of the notification.