### PR TITLE
Add relative change

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/entity/report/TableReport.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/entity/report/TableReport.java
@@ -72,6 +72,8 @@ public class TableReport extends PanacheEntityBase {
       @NotNull
       public ArrayNode values;
 
+      public boolean baseline;
+
       @Override
       public String toString() {
          return "TableReport.Data{" +
@@ -79,6 +81,7 @@ public class TableReport extends PanacheEntityBase {
                ", category='" + category + '\'' +
                ", series='" + series + '\'' +
                ", label='" + scale + '\'' +
+               ", label='" + baseline + '\'' +
                ", values=" + values +
                '}';
       }

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/entity/report/TableReportConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/entity/report/TableReportConfig.java
@@ -63,6 +63,11 @@ public class TableReportConfig extends PanacheEntityBase {
    public String scaleFormatter;
    public String scaleDescription;
 
+   @Type(type = "io.hyperfoil.tools.horreum.entity.converter.JsonUserType")
+   public ArrayNode baselineLabels;
+   public String baselineFunction;
+
+
    @OneToMany(mappedBy = "report", orphanRemoval = true, cascade = CascadeType.ALL)
    @OrderBy("order ASC")
    public List<ReportComponent> components;

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -696,7 +696,7 @@
                 ));
         </sql>
     </changeSet>
-    
+
     <changeSet id="5" author="rvansa">
         <createTable tableName="userinfo">
             <column name="username" type="text">
@@ -1833,7 +1833,7 @@
                 USING (has_role2((SELECT test.owner FROM test JOIN tablereportconfig trc ON test.id = trc.testid JOIN tablereport tr ON tr.config_id = trc.id WHERE tr.id = report_id), 'tester'));
         </sql>
     </changeSet>
-    
+
     <changeSet id="34" author="rvansa">
         <createTable tableName="reportcomment">
             <column name="id" type="integer">
@@ -2437,7 +2437,7 @@
                 USING (exists(SELECT 1 FROM label WHERE label.id = label_id AND has_role2(label.owner, 'tester')));
         </sql>
     </changeSet>
-    
+
     <changeSet id="60" author="rvansa">
         <createTable tableName="label_values">
             <column name="dataset_id" type="integer">
@@ -3101,6 +3101,15 @@
         <sql>
             CREATE TRIGGER ds_after_schema_update AFTER INSERT OR UPDATE OF uri ON schema FOR EACH ROW EXECUTE FUNCTION ds_after_schema_update_func();
         </sql>
+    </changeSet>
+    <changeSet id="70" author="dupliaka">
+        <addColumn tableName="tablereport_data">
+            <column name="baseline" type="boolean"/>
+        </addColumn>
+        <addColumn tableName="tablereportconfig">
+            <column name="baselinefunction" type="text" />
+            <column name="baselinelabels" type="jsonb" />
+        </addColumn>
     </changeSet>
 </databaseChangeLog>
 

--- a/webapp/src/domain/reports/TableReportConfigPage.tsx
+++ b/webapp/src/domain/reports/TableReportConfigPage.tsx
@@ -130,6 +130,7 @@ export default function TableReportConfigPage() {
         test: {
             id: -1,
         },
+        baselineLabels: [],
         filterLabels: [],
         categoryLabels: [],
         seriesLabels: [],
@@ -298,6 +299,59 @@ export default function TableReportConfigPage() {
                                 />
                             </FormGroup>
                         </FormSection>
+
+                        <FormSection
+                            title={
+                                <>
+                                    Baseline
+                                    <Popover
+                                        headerContent="Baseline labels and function"
+                                        bodyContent={
+                                            <div>
+                                                Baseline lets you to get relative change in %. A difference between the
+                                                baseline and the new score is ((new/baseline)-1) * 100%
+                                                <List>
+                                                    <ListItem>
+                                                        Labels select data from the dataset based on its{" "}
+                                                        <NavLink to="/schema">schema(s)</NavLink>.
+                                                    </ListItem>
+                                                    <ListItem>
+                                                        Baseline function takes the label value (in case of single
+                                                        label) or object keyed by label names (in case of multiple
+                                                        labels) as its only parameter and returns <code>true</code> if
+                                                        the run should be considered as a refferenced baseline.
+                                                    </ListItem>
+                                                </List>
+                                            </div>
+                                        }
+                                    >
+                                        <HelpButton />
+                                    </Popover>
+                                </>
+                            }
+                        >
+
+                            <FormGroup label="Labels" fieldId="baselineLabels">
+                                <Labels
+                                    labels={config.baselineLabels || []}
+                                    onChange={labels => setConfig({ ...config, baselineLabels: labels })}
+                                    isReadOnly={!isTester}
+                                    defaultMetrics={false}
+                                    defaultFiltering={true}
+                                />
+                            </FormGroup>
+                            <FormGroup label="Function" fieldId="baselineFunction">
+                                <OptionalFunction
+                                    func={config?.baselineFunction}
+                                    onChange={func => setConfig({ ...config, baselineFunction: func })}
+                                    readOnly={!isTester}
+                                    undefinedText="Filtering baseline not defined."
+                                    addText="Add baseline function..."
+                                    defaultFunc="value => value"
+                                />
+                            </FormGroup>
+                        </FormSection>
+
                         <FormSection
                             title={
                                 <>

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -30,9 +30,35 @@ function formatter(func: string | undefined) {
 type DataViewProps = {
     config: TableReportConfig
     data?: TableReportData
+    baseline?: TableReportData
     unit?: string
     selector(d: TableReportData): number
     siblingSelector(d: TableReportData, index: number): number
+}
+
+function DataViewBaseline(props: DataViewProps) {
+
+    if (props.data === undefined) {
+        return <>(no data)</>
+    }
+
+    if (props.baseline === undefined) {
+        return <>(no data)</>
+    } 
+
+    const data = parseFloat(props.data.values[0])
+    const baseline = parseFloat(props.baseline.values[0])
+
+    if (isNaN(data) || isNaN(baseline)) {
+        return <>(data error)</>
+    } 
+
+    const change = (data/baseline -1) * 100
+    return (
+            <Button variant="link">
+                {change.toFixed(2)} %
+            </Button>
+    )
 }
 
 function DataView(props: DataViewProps) {
@@ -165,6 +191,23 @@ function ComponentTable(props: ComponentTableProps) {
                                         <DataView
                                             config={props.config}
                                             data={props.data.find(d => d.series === s && d.scale === sc)}
+                                            unit={props.unit}
+                                            selector={props.selector}
+                                            siblingSelector={props.siblingSelector}
+                                        />
+                                    </Td>
+                                ))}
+                            </Tr>
+                        ))}
+                        {scales.slice(1,scales.length).map((sc,i) => (
+                            <Tr key={sc}>
+                                <Th>{props.data.find(d => d.baseline === true)?.scale + "->" + scaleFormatter(sc)}</Th>
+                                {series.map(s => (
+                                    <Td key={s}>
+                                        <DataViewBaseline
+                                            config={props.config}
+                                            data={props.data.find(d => d.series === s && d.scale === sc)}
+                                            baseline={props.data.find(d => d.series === s && d.baseline === true)}
                                             unit={props.unit}
                                             selector={props.selector}
                                             siblingSelector={props.siblingSelector}

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -199,7 +199,7 @@ function ComponentTable(props: ComponentTableProps) {
                                 ))}
                             </Tr>
                         ))}
-                        {scales.slice(1,scales.length).map((sc,i) => (
+                        {scales.slice(1,scales.length).map((sc) => (
                             <Tr key={sc}>
                                 <Th>{props.data.find(d => d.baseline === true)?.scale + "->" + scaleFormatter(sc)}</Th>
                                 {series.map(s => (

--- a/webapp/src/domain/reports/api.tsx
+++ b/webapp/src/domain/reports/api.tsx
@@ -23,6 +23,9 @@ export type TableReportConfig = {
     scaleFormatter?: string
     scaleDescription?: string
 
+    baselineLabels: string[] | null
+    baselineFunction?: string
+
     components: ReportComponent[]
 }
 
@@ -58,6 +61,7 @@ export type TableReportData = {
     category: string
     series: string
     scale: string
+    baseline: boolean
     values: any[]
 }
 


### PR DESCRIPTION
This change adds relative change feature to Reports

Baseline setup is getting stored in report edit window at report config tabel
When report gets generated the runs related to baseline marks as baseline (stores in report data table)
The calculation is made in UI

I did backend and uI changes + db migration

I did not wrote tests and hide baseline if it was not declared (Need some help)

![image](https://user-images.githubusercontent.com/21653197/164715615-079d94f0-766c-45ad-9d34-d22d9739fc4e.png)
[sqlFile.zip](https://github.com/Hyperfoil/Horreum/files/8541078/sqlFile.zip)

