### PR TITLE
Disable flaky test. Need to resolve transaction issue

### DIFF
--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -350,6 +351,7 @@ public class AlertingServiceTest extends BaseServiceTest {
    }
 
    @org.junit.jupiter.api.Test
+   @Disabled("Disabled until Transaction race condition fixed!")
    public void testMissingRules(TestInfo info) throws InterruptedException {
       NotificationServiceImpl notificationService = Mockito.mock(NotificationServiceImpl.class);
       List<String> notifications = Collections.synchronizedList(new ArrayList<>());


### PR DESCRIPTION
This PR disables a test that passes in local env, but fails in CI.

In order for the CI to be valuable for testing other changes, the test has been disabled until the root cause of the issue can be resolved. 