### PR TITLE
Add baseline change comparison to the report tables

### DIFF
--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -179,7 +179,7 @@ function ComponentTable(props: ComponentTableProps) {
                             </Tr>
                         ))}
                         {props.baseline !== "No Baseline" &&
-                            scales.slice(1, scales.length).map(sc => (
+                            scales.filter(s=>s!== props.baseline).map(sc => (
                                 <Tr key={sc}>
                                     <Th>
                                         {props.data.find(d => d.scale === props.baseline)?.scale +

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -178,30 +178,32 @@ function ComponentTable(props: ComponentTableProps) {
                                 ))}
                             </Tr>
                         ))}
-                        {props.baseline !== "No Baseline" &&
-                            scales.filter(s=>s!== props.baseline).map(sc => (
-                                <Tr key={sc}>
-                                    <Th>
-                                        {props.data.find(d => d.scale === props.baseline)?.scale +
-                                            "->" +
-                                            scaleFormatter(sc)}
-                                    </Th>
-                                    {series.map(s => (
-                                        <Td key={s}>
-                                            <DataViewBaseline
-                                                config={props.config}
-                                                data={props.data.find(d => d.series === s && d.scale === sc)}
-                                                baseline={props.data.find(
-                                                    d => d.series === s && d.scale === props.baseline
-                                                )}
-                                                unit={props.unit}
-                                                selector={props.selector}
-                                                siblingSelector={props.siblingSelector}
-                                            />
-                                        </Td>
-                                    ))}
-                                </Tr>
-                            ))}
+                        {props.baseline !== undefined &&
+                            scales
+                                .filter(s => s !== props.baseline)
+                                .map(sc => (
+                                    <Tr key={sc}>
+                                        <Th>
+                                            {props.data.find(d => d.scale === props.baseline)?.scale +
+                                                "->" +
+                                                scaleFormatter(sc)}
+                                        </Th>
+                                        {series.map(s => (
+                                            <Td key={s}>
+                                                <DataViewBaseline
+                                                    config={props.config}
+                                                    data={props.data.find(d => d.series === s && d.scale === sc)}
+                                                    baseline={props.data.find(
+                                                        d => d.series === s && d.scale === props.baseline
+                                                    )}
+                                                    unit={props.unit}
+                                                    selector={props.selector}
+                                                    siblingSelector={props.siblingSelector}
+                                                />
+                                            </Td>
+                                        ))}
+                                    </Tr>
+                                ))}
                     </Tbody>
                 </TableComposable>
             </LevelItem>
@@ -419,7 +421,7 @@ export default function TableReportView(props: TableReportViewProps) {
     const scaleFormatter = formatter(config.scaleFormatter)
 
     const [dropdownOpen, setDropdownOpen] = useState(false)
-    const [baseline, setBaseline] = useState("No Baseline")
+    const [baseline, setBaseline] = useState<string>()
 
     return (
         <div>

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -173,23 +173,31 @@ function ComponentTable(props: ComponentTableProps) {
                                             unit={props.unit}
                                             selector={props.selector}
                                             siblingSelector={props.siblingSelector}
-                                            />
-                                            </Td>
-                                        ))}
-                                    </Tr>
+                                        />
+                                    </Td>
                                 ))}
-                        {scales.slice(1,scales.length).map((sc) => (
-                            <Tr key={sc} style={ props.baseline === "No Baseline"?{ display: 'none' }:{}}>
-                                <Th>{props.data.find(d => d.scale === props.baseline)?.scale + "->" + scaleFormatter(sc)}</Th>
+                            </Tr>
+                        ))}
+                        {
+                        props.baseline !== "No Baseline" && 
+                        scales.slice(1, scales.length).map(sc => (
+                            <Tr key={sc}>
+                                <Th>
+                                    {props.data.find(d => d.scale === props.baseline)?.scale +
+                                        "->" +
+                                        scaleFormatter(sc)}
+                                </Th>
                                 {series.map(s => (
-                                     <Td key={s}>
-                                         <DataViewBaseline
-                                                    config={props.config}
-                                                    data={props.data.find(d => d.series === s && d.scale === sc)}
-                                                    baseline={props.data.find(d => d.series === s && d.scale === props.baseline)}
-                                                    unit={props.unit}
-                                                    selector={props.selector}
-                                                    siblingSelector={props.siblingSelector}
+                                    <Td key={s}>
+                                        <DataViewBaseline
+                                            config={props.config}
+                                            data={props.data.find(d => d.series === s && d.scale === sc)}
+                                            baseline={props.data.find(
+                                                d => d.series === s && d.scale === props.baseline
+                                            )}
+                                            unit={props.unit}
+                                            selector={props.selector}
+                                            siblingSelector={props.siblingSelector}
                                         />
                                     </Td>
                                 ))}
@@ -253,21 +261,20 @@ function ComponentTable(props: ComponentTableProps) {
 }
 
 function DataViewBaseline(props: DataViewProps) {
-
     if (props.data === undefined) {
         return <>(no data)</>
     }
 
     if (props.baseline === undefined) {
         return <>(no data)</>
-    } 
+    }
 
     const data = parseFloat(props.data.values[0])
     const baseline = parseFloat(props.baseline.values[0])
 
     if (isNaN(data) || isNaN(baseline)) {
         return <>(data error)</>
-    } 
+    }
 
     const change = (data/baseline -1) * 100
     return (
@@ -435,32 +442,24 @@ export default function TableReportView(props: TableReportViewProps) {
                 editable={props.editable}
                 onUpdate={text => update(props.report, comment0, text, 0)}
             />
-
             <div>
-            <Title headingLevel="h2">Baseline scale</Title>
-            <Dropdown
-                isOpen={dropdownOpen}
-                onSelect={event => {
-                    if (event && event.currentTarget) {
-                        setBaseline(event.currentTarget.innerText)
-                    }
-                    setDropdownOpen(false)
-                }}
-                toggle={
-                    <DropdownToggle onToggle={setDropdownOpen}>
-                        {baseline}
-                    </DropdownToggle>
-                }
-                dropdownItems={
-                    scales.map((p, i) => (
-                    <DropdownItem key={i} value={scaleFormatter(p)} component="button">
-                        {scaleFormatter(p)}
-                    </DropdownItem>
-                ))}
-            >
-            </Dropdown>
+                <Title headingLevel="h2">Baseline scale</Title>
+                <Dropdown
+                    isOpen={dropdownOpen}
+                    onSelect={event => {
+                        if (event && event.currentTarget) {
+                            setBaseline(event.currentTarget.innerText)
+                        }
+                        setDropdownOpen(false)
+                    }}
+                    toggle={<DropdownToggle onToggle={setDropdownOpen}>{baseline}</DropdownToggle>}
+                    dropdownItems={scales.map((p, i) => (
+                        <DropdownItem key={i} value={scaleFormatter(p)} component="button">
+                            {scaleFormatter(p)}
+                        </DropdownItem>
+                    ))}
+                ></Dropdown>
             </div>
-
             {categories.map((cat, i1) => {
                 const comment1 = props.report.comments.find(c => c.level === 1 && c.category === cat)
                 return (

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -12,7 +12,7 @@ import {
     Tooltip,
     Dropdown,
     DropdownToggle,
-    DropdownItem
+    DropdownItem,
 } from "@patternfly/react-core"
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from "@patternfly/react-table"
 import { EditIcon, HelpIcon } from "@patternfly/react-icons"
@@ -178,31 +178,30 @@ function ComponentTable(props: ComponentTableProps) {
                                 ))}
                             </Tr>
                         ))}
-                        {
-                        props.baseline !== "No Baseline" && 
-                        scales.slice(1, scales.length).map(sc => (
-                            <Tr key={sc}>
-                                <Th>
-                                    {props.data.find(d => d.scale === props.baseline)?.scale +
-                                        "->" +
-                                        scaleFormatter(sc)}
-                                </Th>
-                                {series.map(s => (
-                                    <Td key={s}>
-                                        <DataViewBaseline
-                                            config={props.config}
-                                            data={props.data.find(d => d.series === s && d.scale === sc)}
-                                            baseline={props.data.find(
-                                                d => d.series === s && d.scale === props.baseline
-                                            )}
-                                            unit={props.unit}
-                                            selector={props.selector}
-                                            siblingSelector={props.siblingSelector}
-                                        />
-                                    </Td>
-                                ))}
-                            </Tr>
-                        ))}
+                        {props.baseline !== "No Baseline" &&
+                            scales.slice(1, scales.length).map(sc => (
+                                <Tr key={sc}>
+                                    <Th>
+                                        {props.data.find(d => d.scale === props.baseline)?.scale +
+                                            "->" +
+                                            scaleFormatter(sc)}
+                                    </Th>
+                                    {series.map(s => (
+                                        <Td key={s}>
+                                            <DataViewBaseline
+                                                config={props.config}
+                                                data={props.data.find(d => d.series === s && d.scale === sc)}
+                                                baseline={props.data.find(
+                                                    d => d.series === s && d.scale === props.baseline
+                                                )}
+                                                unit={props.unit}
+                                                selector={props.selector}
+                                                siblingSelector={props.siblingSelector}
+                                            />
+                                        </Td>
+                                    ))}
+                                </Tr>
+                            ))}
                     </Tbody>
                 </TableComposable>
             </LevelItem>
@@ -276,12 +275,8 @@ function DataViewBaseline(props: DataViewProps) {
         return <>(data error)</>
     }
 
-    const change = (data/baseline -1) * 100
-    return (
-            <Button variant="link">
-                {change.toFixed(2)} %
-            </Button>
-    )
+    const change = (data / baseline - 1) * 100
+    return <Button variant="link">{change.toFixed(2)} %</Button>
 }
 
 function MarkdownCheatSheetLink() {


### PR DESCRIPTION
Scales gets as a baseline options.
Then each row of the table recalculates due to the baseline 

![image](https://user-images.githubusercontent.com/21653197/168082074-a9ac28c6-62f3-4aeb-804a-6d67b3fa2f90.png)
