### PR TITLE
Add plugin to child projects that use buildNumber.

### DIFF
--- a/horreum-backend/pom.xml
+++ b/horreum-backend/pom.xml
@@ -295,6 +295,10 @@
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/horreum-client/pom.xml
+++ b/horreum-client/pom.xml
@@ -109,6 +109,10 @@
                 </systemPropertyVariables>
             </configuration>
         </plugin>
+        <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+        </plugin>
     </plugins>
 
     <testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -256,29 +256,29 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                     <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <id>get-scm-revision</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                            <configuration>
+                                <doCheck>false</doCheck>
+                                <doUpdate>false</doUpdate>
+                                <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
+                                <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <id>get-scm-revision</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                        <configuration>
-                            <doCheck>false</doCheck>
-                            <doUpdate>false</doUpdate>
-                            <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
-                            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
Added buildnumber-maven-plugin to pluginManagement. This allows inherited child projects to reference the plugin and use buildNumber variable.