### PR TITLE
#393-Add column type info to NativeQuery when listing runs by Schema

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -790,6 +790,8 @@ public class RunServiceImpl implements RunService {
       Util.addPaging(sql, limit, page, sort, direction);
       Query query = em.createNativeQuery(sql.toString());
       query.setParameter(1, uri);
+      initTypes(query);
+
       @SuppressWarnings("unchecked")
       List<Object[]> runs = query.getResultList();
 


### PR DESCRIPTION
This PR looks to solve #393. By adding type information to the NativeQuery the resultset can be processed without causing an exception. Reported due to an unrecognized type 1111. A Types.OTHER type.