### PR TITLE
Delete references before variable delete.

### DIFF
--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4074,4 +4074,20 @@
             );
         </sql>
     </changeSet>
+
+    <changeSet id="106" author="jwhiting">
+        <createProcedure>
+            CREATE OR REPLACE FUNCTION before_variable_delete_func() RETURNS TRIGGER AS $$
+            BEGIN
+            DELETE FROM change WHERE variable_id = OLD.id;
+            DELETE FROM datapoint WHERE variable_id = OLD.id;
+            DELETE FROM experiment_comparisons WHERE variable_id = OLD.id;
+            RETURN OLD;
+            END;
+            $$ LANGUAGE plpgsql;
+        </createProcedure>
+        <sql>
+            CREATE TRIGGER before_variable_delete BEFORE DELETE ON variable FOR EACH ROW EXECUTE FUNCTION before_variable_delete_func();
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Delete references in change, datapoint and experiment_comparisons before deleting variable. This fixes #548.


## Fixes Issue

#548

## Changes proposed

Add a before trigger to call a function. The function will delete any dependent referential rows in tables.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
