### PR TITLE
Run Horreum dev services with prod db backup

### DIFF
--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -128,8 +128,7 @@ quarkus.qute.content-types.md=text/markdown
 quarkus.qute.content-types."qute.md"=text/markdown
 
 
-horreum-dev.enabled=false
-%dev.horreum.debug=true
+horreum.dev-services.enabled=true
 quarkus.test.enable-callbacks-for-integration-tests=true
 
 ## We don't want quarkus to start a database/keycloak for us in dev mode, we are doing that

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
@@ -1,6 +1,5 @@
 package io.hyperfoil.tools.horreum.it;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.jboss.logging.Logger;
 
@@ -26,10 +25,15 @@ public class ItResource implements QuarkusTestResourceLifecycleManager {
 
                     //todo: pick up from configuration
                     Map<String, String> containerArgs = Map.of(
-                            HORREUM_DEV_KEYCLOAK_IMAGE, "quay.io/keycloak/keycloak:21.1",
-                            HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, "horreum-dev-postgres",
-                            HORREUM_DEV_POSTGRES_IMAGE, "postgres:13",
-                            HORREUM_DEV_POSTGRES_NETWORK_ALIAS, "horreum-dev-keycloak"
+                            HORREUM_DEV_KEYCLOAK_IMAGE, DEFAULT_KEYCLOAK_IMAGE,
+                            HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, DEFAULT_KEYCLOAK_NETWORK_ALIAS,
+                            HORREUM_DEV_POSTGRES_IMAGE, DEFAULT_POSTGRES_IMAGE,
+                            HORREUM_DEV_POSTGRES_NETWORK_ALIAS, DEFAULT_POSTGRES_NETWORK_ALIAS,
+                            HORREUM_DEV_KEYCLOAK_DB_USERNAME, DEFAULT_KC_DB_USERNAME,
+                            HORREUM_DEV_KEYCLOAK_DB_PASSWORD, DEFAULT_KC_DB_PASSWORD,
+                            HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME, DEFAULT_KC_ADMIN_USERNAME,
+                            HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, DEFAULT_KC_ADMIN_PASSWORD
+
                     );
                     return startContainers(containerArgs);
                 } catch (Exception e){

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/HorreumDevServicesProcessor.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/HorreumDevServicesProcessor.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.horreum.dev.services.deployment;
 
-import io.hyperfoil.tools.horreum.dev.services.deployment.config.HorreumDevConfig;
+import io.hyperfoil.tools.horreum.dev.services.deployment.config.DevServicesConfig;
 import io.hyperfoil.tools.horreum.infra.common.HorreumResources;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.IsNormal;
@@ -13,6 +13,7 @@ import io.quarkus.deployment.console.StartupLogCompressor;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import org.jboss.logging.Logger;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
 import java.util.List;
@@ -31,15 +32,13 @@ public class HorreumDevServicesProcessor {
     private static volatile DevServicesResultBuildItem.RunningDevService horreumKeycloakDevService;
     private static volatile DevServicesResultBuildItem.RunningDevService horreumPostgresDevService;
 
-    static volatile HorreumDevConfig devServicesConfiguration;
-
     @BuildStep(onlyIf = {IsDevelopment.class})
     public void startHorreumContainers(
             BuildProducer<DevServicesResultBuildItem> devServicesResultBuildItemBuildProducer,
             DockerStatusBuildItem dockerStatusBuildItem,
             BuildProducer<HorreumDevServicesConfigBuildItem> horreumBuildItemBuildProducer,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
-            HorreumDevConfig horreumBuildTimeConfig,
+            DevServicesConfig horreumBuildTimeConfig,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             LaunchModeBuildItem launchMode,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
@@ -48,113 +47,127 @@ public class HorreumDevServicesProcessor {
     ) {
 
 
-        devServicesConfiguration = horreumBuildTimeConfig;
-
         StartupLogCompressor compressor = new StartupLogCompressor(
                 (launchMode.isTest() ? "(test) " : "") + "Horreum Dev Services Starting:",
                 consoleInstalledBuildItem, loggingSetupBuildItem);
 
         boolean errors = false;
 
-        try {
-            LOG.infof("Starting Horreum dev services");
+        LOG.infof("Horreum dev services (enabled: ".concat(Boolean.toString(horreumBuildTimeConfig.enabled)).concat(")"));
 
-            if (errors = !dockerStatusBuildItem.isDockerAvailable()) {
-                LOG.warn("Docker dev service instance not found");
-            }
+        if ( horreumBuildTimeConfig.enabled ) {
+            try {
 
-            if (!errors) {
-
-                //TODO:: check to see if devServicesConfiguration has changed
-                if (horreumKeycloakDevService == null || horreumPostgresDevService == null) {
-
-
-                    LOG.infof("Starting Horreum containers");
-
-                    Map<String, String> containerArgs = Map.of(
-                            HORREUM_DEV_KEYCLOAK_ENABLED, Boolean.toString(devServicesConfiguration.keycloak.enabled),
-                            HORREUM_DEV_KEYCLOAK_IMAGE, devServicesConfiguration.keycloak.image,
-                            HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, devServicesConfiguration.keycloak.networkAlias,
-                            HORREUM_DEV_POSTGRES_ENABLED, Boolean.toString(devServicesConfiguration.postgres.enabled),
-                            HORREUM_DEV_POSTGRES_IMAGE, devServicesConfiguration.postgres.image,
-                            HORREUM_DEV_POSTGRES_NETWORK_ALIAS, devServicesConfiguration.postgres.networkAlias
-                    );
-
-                    HorreumResources.startContainers(containerArgs);
-
-                    Map<String, String> postrgesConfig = new HashMap<>();
-                    String jdbcUrl = HorreumResources.postgreSQLResource.getJdbcUrl();
-
-                    postrgesConfig.put("quarkus.datasource.jdbc.url", jdbcUrl);
-                    postrgesConfig.put("quarkus.datasource.migration.jdbc.url", jdbcUrl);
-
-                    horreumPostgresDevService = new DevServicesResultBuildItem.RunningDevService(
-                            HorreumResources.postgreSQLResource.getContainer().getContainerName(),
-                            HorreumResources.postgreSQLResource.getContainer().getContainerId(),
-                            HorreumResources.postgreSQLResource.getContainer()::close,
-                            postrgesConfig);
-
-                    Map<String, String> keycloakConfig = new HashMap<>();
-                    Integer keycloakPort = HorreumResources.keycloakResource.getContainer().getMappedPort(8080);
-
-                    keycloakConfig.put("quarkus.oidc.auth-server-url", "http://localhost:" + keycloakPort + "/realms/horreum");
-                    keycloakConfig.put("horreum.keycloak.url", "http://localhost:" + keycloakPort);
-
-                    horreumKeycloakDevService = new DevServicesResultBuildItem.RunningDevService(
-                            HorreumResources.keycloakResource.getContainer().getContainerName(),
-                            HorreumResources.keycloakResource.getContainer().getContainerId(),
-                            HorreumResources.keycloakResource.getContainer()::close,
-                            keycloakConfig);
+                if (errors = !dockerStatusBuildItem.isDockerAvailable()) {
+                    LOG.warn("Docker dev service instance not found");
                 }
 
-            }
-
-            if (horreumKeycloakDevService == null || horreumPostgresDevService == null) {
                 if (!errors) {
+
+                    //TODO:: check to see if devServicesConfiguration has changed
+                    if (horreumKeycloakDevService == null || horreumPostgresDevService == null) {
+
+
+                        LOG.infof("Starting Horreum containers");
+
+                        String backupFilename = horreumBuildTimeConfig.postgres.databaseBackup.isPresent() ?
+                                horreumBuildTimeConfig.postgres.databaseBackup.get().getAbsolutePath() :
+                                null;
+
+                        Map<String, String> containerArgs = Map.of(
+                                HORREUM_DEV_KEYCLOAK_ENABLED, Boolean.toString(horreumBuildTimeConfig.keycloak.enabled),
+                                HORREUM_DEV_KEYCLOAK_IMAGE, horreumBuildTimeConfig.keycloak.image,
+                                HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, horreumBuildTimeConfig.keycloak.networkAlias,
+                                HORREUM_DEV_POSTGRES_ENABLED, Boolean.toString(horreumBuildTimeConfig.postgres.enabled),
+                                HORREUM_DEV_POSTGRES_IMAGE, horreumBuildTimeConfig.postgres.image,
+                                HORREUM_DEV_POSTGRES_NETWORK_ALIAS, horreumBuildTimeConfig.postgres.networkAlias,
+                                HORREUM_DEV_KEYCLOAK_DB_USERNAME, horreumBuildTimeConfig.keycloak.dbUsername,
+                                HORREUM_DEV_KEYCLOAK_DB_PASSWORD, horreumBuildTimeConfig.keycloak.dbPassword,
+                                HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME, horreumBuildTimeConfig.keycloak.adminUsername,
+                                HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, horreumBuildTimeConfig.keycloak.adminPassword
+                        );
+
+                        if (backupFilename != null) {
+                            containerArgs = ImmutableMap.<String, String>builder()
+                                    .putAll(containerArgs)
+                                    .putAll(Map.of(HORREUM_DEV_POSTGRES_BACKUP, backupFilename))
+                                    .build();
+                        }
+                        HorreumResources.startContainers(containerArgs);
+
+                        Map<String, String> postrgesConfig = new HashMap<>();
+                        String jdbcUrl = HorreumResources.postgreSQLResource.getJdbcUrl();
+
+                        postrgesConfig.put("quarkus.datasource.jdbc.url", jdbcUrl);
+                        postrgesConfig.put("quarkus.datasource.migration.jdbc.url", jdbcUrl);
+
+                        horreumPostgresDevService = new DevServicesResultBuildItem.RunningDevService(
+                                HorreumResources.postgreSQLResource.getContainer().getContainerName(),
+                                HorreumResources.postgreSQLResource.getContainer().getContainerId(),
+                                HorreumResources.postgreSQLResource.getContainer()::close,
+                                postrgesConfig);
+
+                        Map<String, String> keycloakConfig = new HashMap<>();
+                        Integer keycloakPort = HorreumResources.keycloakResource.getContainer().getMappedPort(8080);
+
+                        keycloakConfig.put("quarkus.oidc.auth-server-url", "http://localhost:" + keycloakPort + "/realms/horreum");
+                        keycloakConfig.put("horreum.keycloak.url", "http://localhost:" + keycloakPort);
+
+                        horreumKeycloakDevService = new DevServicesResultBuildItem.RunningDevService(
+                                HorreumResources.keycloakResource.getContainer().getContainerName(),
+                                HorreumResources.keycloakResource.getContainer().getContainerId(),
+                                HorreumResources.keycloakResource.getContainer()::close,
+                                keycloakConfig);
+                    }
+
+                }
+
+                if (horreumKeycloakDevService == null || horreumPostgresDevService == null) {
+                    if (!errors) {
+                        compressor.close();
+                    } else {
+                        compressor.closeAndDumpCaptured();
+                    }
+                    return;
+                }
+
+                Runnable closeTask = () -> {
+                    if (horreumKeycloakDevService != null) {
+                        try {
+                            horreumKeycloakDevService.close();
+                        } catch (Throwable t) {
+                            LOG.error("Failed to stop Keycloak container", t);
+                        }
+                    }
+                    if (horreumPostgresDevService != null) {
+                        try {
+                            horreumPostgresDevService.close();
+                        } catch (Throwable t) {
+                            LOG.error("Failed to stop Postgres container", t);
+                        }
+                    }
+                    horreumKeycloakDevService = null;
+                    horreumPostgresDevService = null;
+                };
+                closeBuildItem.addCloseTask(closeTask, true);
+
+                if ((horreumKeycloakDevService != null || horreumPostgresDevService != null) && !errors) {
                     compressor.close();
                 } else {
                     compressor.closeAndDumpCaptured();
                 }
-                return;
-            }
-
-            Runnable closeTask = () -> {
-                if (horreumKeycloakDevService != null) {
-                    try {
-                        horreumKeycloakDevService.close();
-                    } catch (Throwable t) {
-                        LOG.error("Failed to stop Keycloak container", t);
-                    }
-                }
-                if (horreumPostgresDevService != null) {
-                    try {
-                        horreumPostgresDevService.close();
-                    } catch (Throwable t) {
-                        LOG.error("Failed to stop Postgres container", t);
-                    }
-                }
-                horreumKeycloakDevService = null;
-                horreumPostgresDevService = null;
-                devServicesConfiguration = null;
-            };
-            closeBuildItem.addCloseTask(closeTask, true);
-
-            if ((horreumKeycloakDevService != null || horreumPostgresDevService != null) && !errors) {
-                compressor.close();
-            } else {
+            } catch (Throwable t) {
                 compressor.closeAndDumpCaptured();
+                throw new RuntimeException(t);
             }
-        } catch (Throwable t) {
-            compressor.closeAndDumpCaptured();
-            throw new RuntimeException(t);
-        }
 
-        devServicesResultBuildItemBuildProducer.produce(horreumKeycloakDevService.toBuildItem());
-        devServicesResultBuildItemBuildProducer.produce(horreumPostgresDevService.toBuildItem());
+            devServicesResultBuildItemBuildProducer.produce(horreumKeycloakDevService.toBuildItem());
+            devServicesResultBuildItemBuildProducer.produce(horreumPostgresDevService.toBuildItem());
+        }
     }
 
     public static class IsEnabled implements BooleanSupplier {
-        HorreumDevConfig config;
+        DevServicesConfig config;
 
         public boolean getAsBoolean() {
             return config.enabled;

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/DevServicesConfig.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/DevServicesConfig.java
@@ -1,25 +1,24 @@
 package io.hyperfoil.tools.horreum.dev.services.deployment.config;
 
 import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot
-public class HorreumDevConfig {
+@ConfigRoot(prefix = "horreum", phase = ConfigPhase.BUILD_TIME)
+public class DevServicesConfig {
 
     /**
      * Horreum dev services
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem( defaultValue = "true")
     public boolean enabled;
     /**
      * Configuration for Keycloak dev services
      */
-    @ConfigItem
     public HorreumDevServicesKeycloakConfig keycloak;
     /**
      * Configuration for Postrges dev services
      */
-    @ConfigItem
     public HorreumDevServicesPostgresConfig postgres;
 
 }

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesKeycloakConfig.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesKeycloakConfig.java
@@ -3,10 +3,7 @@ package io.hyperfoil.tools.horreum.dev.services.deployment.config;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
-import java.io.File;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
+import static io.hyperfoil.tools.horreum.infra.common.Const.*;
 
 /**
  * Configuration for Horreum dev services.
@@ -23,13 +20,36 @@ public class HorreumDevServicesKeycloakConfig {
     /**
      * Container image name for keycloak service
      */
-    @ConfigItem(defaultValue = "quay.io/keycloak/keycloak:21.1")
+    @ConfigItem(defaultValue = DEFAULT_KEYCLOAK_IMAGE)
     public String image;
 
     /**
      * Container name for keycloak container
      */
-    @ConfigItem(defaultValue = "horreum-dev-keycloak")
+    @ConfigItem(defaultValue = DEFAULT_KEYCLOAK_NETWORK_ALIAS)
     public String networkAlias;
 
+    /**
+     * Databse username for keycloak instance
+     */
+    @ConfigItem(defaultValue = DEFAULT_KC_DB_USERNAME)
+    public String dbUsername;
+
+    /**
+     * Databse password for keycloak instance
+     */
+    @ConfigItem(defaultValue = DEFAULT_KC_DB_PASSWORD)
+    public String dbPassword;
+
+
+    /**
+     * Admin Username password for keycloak
+     */
+    @ConfigItem(defaultValue = DEFAULT_KC_ADMIN_USERNAME)
+    public String adminUsername;
+    /**
+     * Admin Username password for keycloak
+     */
+    @ConfigItem(defaultValue = DEFAULT_KC_ADMIN_PASSWORD)
+    public String adminPassword;
 }

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesPostgresConfig.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesPostgresConfig.java
@@ -4,9 +4,10 @@ import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
 import java.io.File;
-import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
+
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_POSTGRES_IMAGE;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_POSTGRES_NETWORK_ALIAS;
 
 /**
  * Configuration for Horreum dev services.
@@ -23,19 +24,20 @@ public class HorreumDevServicesPostgresConfig {
     /**
      * Container image name for postgres service
      */
-    @ConfigItem(defaultValue = "postgres:13")
+    @ConfigItem(defaultValue = DEFAULT_POSTGRES_IMAGE)
     public String image;
+
+
+    /**
+     * Container name for postgres container
+     */
+    @ConfigItem(defaultValue = DEFAULT_POSTGRES_NETWORK_ALIAS)
+    public String networkAlias;
 
     /**
      * File path to production backup of database
      */
     @ConfigItem()
     public Optional<File> databaseBackup;
-
-    /**
-     * Container name for postgres container
-     */
-    @ConfigItem(defaultValue = "horreum-dev-postgres")
-    public String networkAlias;
 
 }

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/Const.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/Const.java
@@ -1,10 +1,37 @@
 package io.hyperfoil.tools.horreum.infra.common;
 
 public class Const {
-    public static final String HORREUM_DEV_POSTGRES_ENABLED = "horreum.dev.postgres.enabled";
-    public static final String HORREUM_DEV_POSTGRES_IMAGE = "horreum.dev.postgres.image";
-    public static final String HORREUM_DEV_POSTGRES_NETWORK_ALIAS = "horreum.dev.postgres.network-alias";
-    public static final String HORREUM_DEV_KEYCLOAK_ENABLED = "horreum.dev.keycloak.enabled";
-    public static final String HORREUM_DEV_KEYCLOAK_IMAGE = "horreum.dev.keycloak.image";
-    public static final String HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS = "horreum.dev.keycloak.network-alias";
+    public static final String HORREUM_DEV_POSTGRES_ENABLED = "horreum.dev-services.postgres.enabled";
+    public static final String HORREUM_DEV_POSTGRES_BACKUP = "horreum.dev-services.postgres.database-backup";
+    public static final String HORREUM_DEV_POSTGRES_IMAGE = "horreum.dev-services.postgres.image";
+    public static final String HORREUM_DEV_POSTGRES_NETWORK_ALIAS = "horreum.dev-services.postgres.network-alias";
+    public static final String HORREUM_DEV_KEYCLOAK_ENABLED = "horreum.dev-services.keycloak.enabled";
+    public static final String HORREUM_DEV_KEYCLOAK_IMAGE = "horreum.dev-services.keycloak.image";
+    public static final String HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS = "horreum.dev-services.keycloak.network-alias";
+    public static final String HORREUM_DEV_KEYCLOAK_DB_USERNAME = "horreum.dev-services.keycloak.db-username";
+    public static final String HORREUM_DEV_KEYCLOAK_DB_PASSWORD = "horreum.dev-services.keycloak.db-password";
+
+    public static final String HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME = "horreum.dev-services.keycloak.admin-username";
+    public static final String HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD = "horreum.dev-services.keycloak.admin-password";
+
+    public static final String HORREUM_DEV_DB_USERNAME = "horreum.db.username";
+    public static final String HORREUM_DEV_DB_PASSWORD = "horreum.db.password";
+    public static final String HORREUM_DEV_DB_DATABASE = "horreum.db.database";
+
+    public static final String DEFAULT_DB_USERNAME = "dbadmin";
+    public static final String DEFAULT_DB_PASSWORD = "secret";
+    public static final String DEFAULT_DBDATABASE = "horreum";
+
+    public static final String DEFAULT_KC_DB_USERNAME = "keycloak";
+    public static final String DEFAULT_KC_DB_PASSWORD = "secret";
+
+    public static final String DEFAULT_KC_ADMIN_USERNAME = "admin";
+    public static final String DEFAULT_KC_ADMIN_PASSWORD = "secret";
+
+    public static final String DEFAULT_POSTGRES_NETWORK_ALIAS = "horreum-dev-postgres";
+    public static final String DEFAULT_POSTGRES_IMAGE = "postgres:13";
+
+    public static final String DEFAULT_KEYCLOAK_NETWORK_ALIAS = "horreum-dev-keycloak";
+    public static final String DEFAULT_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:21.1";
+
 }

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumPostgreSQLContainer.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumPostgreSQLContainer.java
@@ -1,20 +1,28 @@
 package io.hyperfoil.tools.horreum.infra.common.resources;
 
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.containers.wait.strategy.DockerHealthcheckWaitStrategy;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
 public class HorreumPostgreSQLContainer<SELF extends HorreumPostgreSQLContainer<SELF>> extends PostgreSQLContainer<SELF> {
 
     private final List<String> params = new ArrayList<>();
+    private final Integer startMsgTimes;
 
-    public HorreumPostgreSQLContainer(String dockerImageName) {
+    public HorreumPostgreSQLContainer(String dockerImageName, Integer startMsgTimes) {
         super(dockerImageName);
+        this.startMsgTimes = startMsgTimes;
     }
-    public HorreumPostgreSQLContainer(DockerImageName dockerImageName) {
+    public HorreumPostgreSQLContainer(DockerImageName dockerImageName, Integer startMsgTimes) {
         super(dockerImageName);
+        this.startMsgTimes = startMsgTimes;
     }
 
     public void withParameter(String param) {
@@ -22,10 +30,16 @@ public class HorreumPostgreSQLContainer<SELF extends HorreumPostgreSQLContainer<
     }
     protected void configure() {
         super.configure();
-        StringBuilder sb = new StringBuilder();
-        sb.append("postgres -c fsync=off");
-        params.forEach( param -> sb.append(" -c ").append(param));
-
-        this.setCommand(sb.toString());
+        if ( params.size() > 0 ) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("postgres -c fsync=off");
+            params.forEach(param -> sb.append(" -c ").append(param));
+            this.setCommand(sb.toString());
+        }
+        super.waitStrategy =
+                new LogMessageWaitStrategy()
+                        .withRegEx(".*database system is ready to accept connections.*\\s")
+                        .withTimes(startMsgTimes)
+                        .withStartupTimeout(Duration.of(60, ChronoUnit.SECONDS));
     }
 }

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/KeycloakResource.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/KeycloakResource.java
@@ -29,55 +29,75 @@ public class KeycloakResource implements ResourceLifecycleManager {
         boolean startDevService = !initArgs.containsKey(HORREUM_DEV_KEYCLOAK_ENABLED) || (initArgs.containsKey(HORREUM_DEV_KEYCLOAK_ENABLED) && Boolean.parseBoolean(initArgs.get(HORREUM_DEV_KEYCLOAK_ENABLED)));
         if ( startDevService ) {
 
-            File tempKeycloakRealmFile = null;
-
-            try (InputStream is = KeycloakResource.class.getClassLoader().getResourceAsStream("keycloak-horreum.json")) {
-                tempKeycloakRealmFile = File.createTempFile("horreum-dev-keycloak-", ".json");
-                tempKeycloakRealmFile.deleteOnExit();
-                Files.copy(is, tempKeycloakRealmFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException e) {
-                throw new RuntimeException("Could not extract Horreum Keycloak realm definition", e);
-            }
-
-            if ( tempKeycloakRealmFile == null ){
-                throw new RuntimeException("Failed to load keycloak realm configuration");
-            }
-
             if ( !initArgs.containsKey("quarkus.datasource.jdbc.url") ) {
                 throw new RuntimeException("Arguments did not contain jdbc URL");
             }
 
-            if ( !initArgs.containsKey("horreum.dev.keycloak.image") ) {
+            if ( !initArgs.containsKey(HORREUM_DEV_KEYCLOAK_IMAGE) ) {
                 throw new RuntimeException("Arguments did not contain Keycloak image");
             }
 
             final String JDBC_URL = initArgs.get("quarkus.datasource.jdbc.url.internal");
+            final String DB_PORT = initArgs.get("postgres.container.port");
 
             final String KEYCLOAK_IMAGE = initArgs.get(HORREUM_DEV_KEYCLOAK_IMAGE);
 
             networkAlias = initArgs.get(HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS);
 
-            keycloakContainer = new GenericContainer<>(
-                    new ImageFromDockerfile().withDockerfileFromBuilder(builder ->
-                                    builder
-                                            .from(KEYCLOAK_IMAGE)
-                                            .copy("/tmp/keycloak-horreum.json","/opt/keycloak/data/import/")
-                                            .env("KEYCLOAK_ADMIN", "admin")
-                                            .env("KEYCLOAK_ADMIN_PASSWORD", "secret")
-                                            .env("KC_CACHE", "local")
-                                            .env("KC_DB", "postgres")
-                                            .env("KC_DB_USERNAME", "keycloak")
-                                            .env("KC_DB_PASSWORD", "secret")
-                                            .env("KC_HTTP_ENABLED", "true")
-                                            .env("KC_HOSTNAME_STRICT", "false")
-                                            .env("DB_DATABASE", "keycloak")
-                                            .env("KC_DB_URL",  JDBC_URL)
-                                            .run("/opt/keycloak/bin/kc.sh build")
-                                            .entryPoint("/opt/keycloak/bin/kc.sh ${KEYCLOAK_COMMAND:-start-dev} --import-realm $EXTRA_OPTIONS")
-                                            .build())
-                            .withFileFromFile("/tmp/keycloak-horreum.json", tempKeycloakRealmFile)
+            //TODO: better way of detecting we are using a backup
+            if ( ! initArgs.containsKey(HORREUM_DEV_POSTGRES_BACKUP) ) {
 
-                    ).withExposedPorts(8080)
+                File tempKeycloakRealmFile = null;
+
+                try (InputStream is = KeycloakResource.class.getClassLoader().getResourceAsStream("keycloak-horreum.json")) {
+                    tempKeycloakRealmFile = File.createTempFile("horreum-dev-keycloak-", ".json");
+                    tempKeycloakRealmFile.deleteOnExit();
+                    Files.copy(is, tempKeycloakRealmFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw new RuntimeException("Could not extract Horreum Keycloak realm definition", e);
+                }
+
+                if ( tempKeycloakRealmFile == null ){
+                    throw new RuntimeException("Failed to load keycloak realm configuration");
+                }
+
+                keycloakContainer = new GenericContainer<>(
+                        new ImageFromDockerfile().withDockerfileFromBuilder(builder ->
+                                builder.from(KEYCLOAK_IMAGE)
+                                        .copy("/tmp/keycloak-horreum.json","/opt/keycloak/data/import/")
+                                        .env("KEYCLOAK_ADMIN", "admin")
+                                        .env("KEYCLOAK_ADMIN_PASSWORD", "secret")
+                                        .env("KC_CACHE", "local")
+                                        .env("KC_DB", "postgres")
+                                        .env("KC_DB_USERNAME", "keycloak")
+                                        .env("KC_DB_PASSWORD", initArgs.get(HORREUM_DEV_KEYCLOAK_DB_PASSWORD))
+                                        .env("KC_HTTP_ENABLED", "true")
+                                        .env("KC_HOSTNAME_STRICT", "false")
+                                        .env("DB_DATABASE", "keycloak")
+                                        .env("KC_DB_URL",  JDBC_URL)
+                                        .run("/opt/keycloak/bin/kc.sh build")
+                                        .entryPoint("/opt/keycloak/bin/kc.sh ${KEYCLOAK_COMMAND:-start-dev} --import-realm $EXTRA_OPTIONS")
+                                        .build())
+                                .withFileFromFile("/tmp/keycloak-horreum.json", tempKeycloakRealmFile));
+
+            } else {
+
+                keycloakContainer = new GenericContainer<>(KEYCLOAK_IMAGE)
+                        .withEnv("KC_HTTP_PORT", "8080")
+                        .withEnv("JAVA_OPTS", "-Xms1024m -Xmx1024m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true")
+                        .withEnv("KC_LOG_LEVEL", "info")
+                        .withEnv("KC_DB", "postgres")
+                        .withEnv("KC_HTTP_ENABLED", "true")
+                        .withEnv("KC_DB_USERNAME", "keycloak")
+                        .withEnv("KC_DB_PASSWORD", initArgs.get(HORREUM_DEV_KEYCLOAK_DB_PASSWORD))
+                        .withEnv("KC_DB_URL_HOST",  "")
+                        .withEnv("KC_HOSTNAME_STRICT", "false")
+                        .withEnv("KC_HOSTNAME", "localhost")
+                        .withEnv("KC_DB_URL",  "jdbc:postgresql://172.17.0.1:" + DB_PORT + "/keycloak")
+                        .withCommand("-Dquarkus.http.http2=false", "start-dev");
+            }
+
+            keycloakContainer.withExposedPorts(8080)
                     .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(120)));
 
         }

--- a/infra/horreum-infra-common/src/main/resources/postgres.config.properties
+++ b/infra/horreum-infra-common/src/main/resources/postgres.config.properties
@@ -3,3 +3,4 @@ port=5432
 shared_buffers=256MB
 max_prepared_transactions=100
 max_pred_locks_per_transaction=128
+logging_collector=off


### PR DESCRIPTION
The PR will allow users to start horreum in dev mode using a production backup., e.g.

```
mvn  quarkus:dev -pl '!horreum-integration-tests' \
  -Dhorreum.dev-services.postgres.database-backup=/opt/databases/horreum-prod-db/ \
  -Dhorreum.db.secret='M3g45ecr5t!' \
  -Dhorreum.dev-services.keycloak.db-password='prod-password' \
  -Dhorreum.dev-services.keycloak.admin-password='ui-prod-password' \
  -Dquarkus.datasource.username=user \
  -Dquarkus.datasource.password='prod-password' \
  -Dquarkus.liquibase.migration.migrate-at-start=false  
```

or by creating an `.env` file

```
horreum.dev-services.postgres.database-backup=/opt/databases/horreum-prod-db/
horreum.db.secret=M3g45ecr5t!
horreum.dev-services.keycloak.db-password=prod-password
horreum.dev-services.keycloak.admin-password=ui-prod-password
quarkus.datasource.username=user
quarkus.datasource.password=prod-password
quarkus.liquibase.migration.migrate-at-start=false
```