### PR TITLE
Added fk constraint from datapoint to dataset

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -1219,12 +1219,7 @@ public class AlertingServiceImpl implements AlertingService {
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
    @Transactional
    void onDatasetDeleted(DataSet.Info info) {
-      log.debugf("Removing datasets and changes for dataset %d (%d/%d, test %d)", info.id, info.runId, info.ordinal, info.testId);
-      for (DataPointDAO dp : DataPointDAO.<DataPointDAO>list("dataset.id", info.id)) {
-         messageBus.publish(MessageBusChannels.DATAPOINT_DELETED, info.testId,
-                 new DataPoint.Event(DataPointMapper.from(dp), info.testId, false));
-         dp.delete();
-      }
+      log.debugf("Removing changes for dataset %d (%d/%d, test %d)", info.id, info.runId, info.ordinal, info.testId);
       for (ChangeDAO c: ChangeDAO.<ChangeDAO>list("dataset.id = ?1 AND confirmed = false", info.id)) {
          c.delete();
       }

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4117,4 +4117,13 @@
             GRANT ALL ON SEQUENCE ActionLog_SEQ, AllowedSite_SEQ, Banner_SEQ, Change_SEQ, DataPoint_SEQ, DatasetLog_SEQ, NotificationSettings_SEQ, ReportComment_SEQ, ReportComponent_SEQ, ReportLog_SEQ, Run_Expectation_SEQ, TableReport_SEQ, TableReportConfig_SEQ, TransformationLog_SEQ, changeDetectionIdGenerator, experimentProfileIdGenerator, mdrIdGenerator, subscriptionIdGenerator, tokenIdGenerator, transformerIdGenerator, variableIdGenerator, viewComponentIdGenerator, viewIdGenerator TO "${quarkus.datasource.username}";
         </sql>
     </changeSet>
+
+    <changeSet id="108" author="jwhiting">
+        <sql>
+            alter table dataset drop constraint fk_dataset_run_id;
+        </sql>
+        <addForeignKeyConstraint constraintName="fk_datapoint_dataset_id"
+                                 baseTableName="datapoint" baseColumnNames="dataset_id"
+                                 referencedTableName="dataset" referencedColumnNames="id" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Fixes Issue

fixes #591 

## Changes proposed

This PR adds a DDL statement to remove the existing foreign key constraint named `fk_dataset_run_id`. Also adds the Liquibase configuration that will create a new constraint. A constraint from datapoint table to dataset. 