### PR TITLE
Added change to handle null value. 

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/TableReportMapper.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/TableReportMapper.java
@@ -41,7 +41,7 @@ public class TableReportMapper {
         dto.scaleFormatter = trc.scaleFormatter;
         dto.scaleDescription = trc.scaleDescription;
         if (trc.components != null)
-            dto.components = trc.components.stream().map(ReportComponentMapper::from).collect(Collectors.toList());
+            dto.components = trc.components.stream().filter(r -> r.report != null).map(ReportComponentMapper::from).collect(Collectors.toList());
 
         return dto;
     }

--- a/webapp/src/domain/reports/TableReportView.tsx
+++ b/webapp/src/domain/reports/TableReportView.tsx
@@ -439,7 +439,8 @@ export default function TableReportView(props: TableReportViewProps) {
                                 categoryData.forEach(d => {
                                     const componentData = d.values[i2]
                                     if (typeof componentData == "object") {
-                                        const keys = [...Object.keys(componentData)]
+                                        const tmp = componentData || {}
+                                        const keys = [...Object.keys(tmp)]
                                         keys.forEach(k => set.add(k))
                                     } else {
                                         set.add("")


### PR DESCRIPTION
in the situation there is no dataset associated with a Component. Added testcase for this issue.

## Fixes Issue

fixes issue #567 

## Changes proposed

This change will add a null reference check to filter the Report references.  These exist in the situation when a report Component has an associated Label but for whatever reason there is no dataset. It can happen.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
