### PR TITLE
Remove Maybe loading from RunData.tsx and DatasetData.tsx

### DIFF
--- a/webapp/src/domain/runs/DatasetData.tsx
+++ b/webapp/src/domain/runs/DatasetData.tsx
@@ -28,13 +28,11 @@ export default function DatasetData(props: DatasetDataProps) {
     const [editorData, setEditorData] = useState<string>()
     const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
     const [schemas, setSchemas] = useState<SchemaUsage[]>()
-    const [loading, setLoading] = useState(false)
     const [labelValuesOpen, setLabelValuesOpen] = useState(false)
     const [labelsLogOpen, setLabelsLogOpen] = useState(false)
     const [hasExperiments, setHasExperiments] = useState(false)
     const [experimentsOpen, setExperimentsOpen] = useState(false)
     useEffect(() => {
-        setLoading(true)
         Api.datasetServiceGetDataSet(props.datasetId)
             .then(
                 dataset => {
@@ -47,7 +45,7 @@ export default function DatasetData(props: DatasetDataProps) {
                         noop
                     )
             )
-            .finally(() => setLoading(false))
+
     }, [props.datasetId])
     useEffect(() => {
         Api.datasetServiceGetSummary(props.datasetId).then(
@@ -112,7 +110,6 @@ export default function DatasetData(props: DatasetDataProps) {
                     )}
                 </FlexItem>
             </Flex>
-            <MaybeLoading loading={loading}>
                 <Editor
                     height="600px"
                     value={editorData}
@@ -121,7 +118,6 @@ export default function DatasetData(props: DatasetDataProps) {
                         readOnly: true,
                     }}
                 />
-            </MaybeLoading>
         </>
     )
 }

--- a/webapp/src/domain/runs/RunData.tsx
+++ b/webapp/src/domain/runs/RunData.tsx
@@ -11,7 +11,6 @@ import Editor from "../../components/Editor/monaco/Editor"
 
 import Api, { RunExtended } from "../../api"
 import { toString } from "../../components/Editor"
-import MaybeLoading from "../../components/MaybeLoading"
 import ChangeSchemaModal from "./ChangeSchemaModal"
 import JsonPathSearchToolbar from "./JsonPathSearchToolbar"
 import { NoSchemaInRun } from "./NoSchema"
@@ -41,7 +40,6 @@ type RunDataProps = {
 }
 
 export default function RunData(props: RunDataProps) {
-    const [loading, setLoading] = useState(false)
     const [data, setData] = useState()
     const [editorData, setEditorData] = useState<string>()
     const [updateCounter, setUpdateCounter] = useState(0)
@@ -52,7 +50,6 @@ export default function RunData(props: RunDataProps) {
     useEffect(() => {
         const urlParams = new URLSearchParams(window.location.search)
         const token = urlParams.get("token")
-        setLoading(true)
         Api.runServiceGetData(props.run.id, token || undefined)
             .then(
                 data => {
@@ -61,7 +58,6 @@ export default function RunData(props: RunDataProps) {
                 },
                 error => dispatchError(dispatch, error, "FETCH_RUN_DATA", "Failed to fetch run data").catch(noop)
             )
-            .finally(() => setLoading(false))
     }, [dispatch, props.run.id, teams, updateCounter])
 
     const isTester = useTester(props.run.owner)
@@ -109,7 +105,7 @@ export default function RunData(props: RunDataProps) {
                 onRemoteQuery={(query, array) => Api.sqlServiceQueryRunData(props.run.id, query, array)}
                 onDataUpdate={setEditorData}
             />
-            <MaybeLoading loading={loading}>{memoizedEditor}</MaybeLoading>
+            {memoizedEditor}
         </>
     )
 }


### PR DESCRIPTION
Fixes #712

Atm `MaybeLoading` is causing an error when the page is first loaded.  The editor displays a "Loading ..." spinner by default, so for now we can disable the `<MaybeLoading>` element