### PR TITLE
Fix dev services on podman, plus tesing enhancements

### DIFF
--- a/horreum-backend/pom.xml
+++ b/horreum-backend/pom.xml
@@ -209,6 +209,10 @@
                     <properties>
                         <quarkus.container-image.additional-tags>${buildNumber}</quarkus.container-image.additional-tags>
                     </properties>
+                    <systemProperties>
+                        <horreum.dev-services.keycloak.image>${dev.images.keycloak}</horreum.dev-services.keycloak.image>
+                        <horreum.dev-services.postgres.image>${dev.images.postgres}</horreum.dev-services.postgres.image>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>
@@ -235,6 +239,8 @@
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
+                        <horreum.dev-services.keycloak.image>${dev.images.keycloak}</horreum.dev-services.keycloak.image>
+                        <horreum.dev-services.postgres.image>${dev.images.postgres}</horreum.dev-services.postgres.image>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/horreum-integration-tests/pom.xml
+++ b/horreum-integration-tests/pom.xml
@@ -94,6 +94,12 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemProperties>
+                        <horreum.dev-services.keycloak.image>${dev.images.keycloak}</horreum.dev-services.keycloak.image>
+                        <horreum.dev-services.postgres.image>${dev.images.postgres}</horreum.dev-services.postgres.image>
+                    </systemProperties>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -104,6 +110,8 @@
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                         <horreum.commit.id>${buildNumber}</horreum.commit.id>
+                        <horreum.dev-services.keycloak.image>${dev.images.keycloak}</horreum.dev-services.keycloak.image>
+                        <horreum.dev-services.postgres.image>${dev.images.postgres}</horreum.dev-services.postgres.image>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -147,6 +155,8 @@
                                 <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <maven.home>${maven.home}</maven.home>
+                                <horreum.dev-services.keycloak.image>${dev.images.keycloak}</horreum.dev-services.keycloak.image>
+                                <horreum.dev-services.postgres.image>${dev.images.postgres}</horreum.dev-services.postgres.image>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
@@ -5,9 +5,23 @@ import org.jboss.logging.Logger;
 
 import java.util.Map;
 
-import static io.hyperfoil.tools.horreum.infra.common.Const.*;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_ADMIN_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_ADMIN_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_DB_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_DB_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KEYCLOAK_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_POSTGRES_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_DB_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_DB_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_IMAGE;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_POSTGRES_IMAGE;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_POSTGRES_NETWORK_ALIAS;
 import static io.hyperfoil.tools.horreum.infra.common.HorreumResources.startContainers;
 import static io.hyperfoil.tools.horreum.infra.common.HorreumResources.stopContainers;
+import static java.lang.System.getProperty;
 
 public class ItResource implements QuarkusTestResourceLifecycleManager {
 
@@ -23,11 +37,18 @@ public class ItResource implements QuarkusTestResourceLifecycleManager {
                 started = true;
                 try {
 
+                    String keycloakImage = getProperty(HORREUM_DEV_KEYCLOAK_IMAGE);
+                    String postgresImage = getProperty(HORREUM_DEV_POSTGRES_IMAGE);
+
+                    if ( keycloakImage == null || postgresImage == null ){
+                        throw new RuntimeException("Test container images are not defined");
+                    }
+
                     //todo: pick up from configuration
                     Map<String, String> containerArgs = Map.of(
-                            HORREUM_DEV_KEYCLOAK_IMAGE, DEFAULT_KEYCLOAK_IMAGE,
+                            HORREUM_DEV_KEYCLOAK_IMAGE, keycloakImage,
                             HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, DEFAULT_KEYCLOAK_NETWORK_ALIAS,
-                            HORREUM_DEV_POSTGRES_IMAGE, DEFAULT_POSTGRES_IMAGE,
+                            HORREUM_DEV_POSTGRES_IMAGE, postgresImage,
                             HORREUM_DEV_POSTGRES_NETWORK_ALIAS, DEFAULT_POSTGRES_NETWORK_ALIAS,
                             HORREUM_DEV_KEYCLOAK_DB_USERNAME, DEFAULT_KC_DB_USERNAME,
                             HORREUM_DEV_KEYCLOAK_DB_PASSWORD, DEFAULT_KC_DB_PASSWORD,

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/HorreumDevServicesProcessor.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/HorreumDevServicesProcessor.java
@@ -55,7 +55,7 @@ public class HorreumDevServicesProcessor {
 
         LOG.infof("Horreum dev services (enabled: ".concat(Boolean.toString(horreumBuildTimeConfig.enabled)).concat(")"));
 
-        if ( horreumBuildTimeConfig.enabled ) {
+        if (horreumBuildTimeConfig.enabled) {
             try {
 
                 if (errors = !dockerStatusBuildItem.isDockerAvailable()) {
@@ -74,18 +74,20 @@ public class HorreumDevServicesProcessor {
                                 horreumBuildTimeConfig.postgres.databaseBackup.get().getAbsolutePath() :
                                 null;
 
-                        Map<String, String> containerArgs = Map.of(
-                                HORREUM_DEV_KEYCLOAK_ENABLED, Boolean.toString(horreumBuildTimeConfig.keycloak.enabled),
-                                HORREUM_DEV_KEYCLOAK_IMAGE, horreumBuildTimeConfig.keycloak.image,
-                                HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, horreumBuildTimeConfig.keycloak.networkAlias,
-                                HORREUM_DEV_POSTGRES_ENABLED, Boolean.toString(horreumBuildTimeConfig.postgres.enabled),
-                                HORREUM_DEV_POSTGRES_IMAGE, horreumBuildTimeConfig.postgres.image,
-                                HORREUM_DEV_POSTGRES_NETWORK_ALIAS, horreumBuildTimeConfig.postgres.networkAlias,
-                                HORREUM_DEV_KEYCLOAK_DB_USERNAME, horreumBuildTimeConfig.keycloak.dbUsername,
-                                HORREUM_DEV_KEYCLOAK_DB_PASSWORD, horreumBuildTimeConfig.keycloak.dbPassword,
-                                HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME, horreumBuildTimeConfig.keycloak.adminUsername,
-                                HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, horreumBuildTimeConfig.keycloak.adminPassword
-                        );
+                        Map<String, String> containerArgs = new HashMap<>();
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_ENABLED, Boolean.toString(horreumBuildTimeConfig.keycloak.enabled));
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_IMAGE, horreumBuildTimeConfig.keycloak.image);
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS, horreumBuildTimeConfig.keycloak.networkAlias);
+                        containerArgs.put(HORREUM_DEV_POSTGRES_ENABLED, Boolean.toString(horreumBuildTimeConfig.postgres.enabled));
+                        containerArgs.put(HORREUM_DEV_POSTGRES_IMAGE, horreumBuildTimeConfig.postgres.image);
+                        containerArgs.put(HORREUM_DEV_POSTGRES_NETWORK_ALIAS, horreumBuildTimeConfig.postgres.networkAlias);
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_DB_USERNAME, horreumBuildTimeConfig.keycloak.dbUsername);
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_DB_PASSWORD, horreumBuildTimeConfig.keycloak.dbPassword);
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME, horreumBuildTimeConfig.keycloak.adminUsername);
+                        containerArgs.put(HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, horreumBuildTimeConfig.keycloak.adminPassword);
+                        String keyCloakPort = horreumBuildTimeConfig.keycloak.containerPort.orElse(null);
+                        if ( keyCloakPort != null )
+                            containerArgs.put(HORREUM_DEV_KEYCLOAK_CONTAINER_PORT, keyCloakPort);
 
                         if (backupFilename != null) {
                             containerArgs = ImmutableMap.<String, String>builder()

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesKeycloakConfig.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesKeycloakConfig.java
@@ -3,7 +3,13 @@ package io.hyperfoil.tools.horreum.dev.services.deployment.config;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
-import static io.hyperfoil.tools.horreum.infra.common.Const.*;
+import java.util.Optional;
+
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_ADMIN_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_ADMIN_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_DB_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KC_DB_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_KEYCLOAK_NETWORK_ALIAS;
 
 /**
  * Configuration for Horreum dev services.
@@ -20,7 +26,7 @@ public class HorreumDevServicesKeycloakConfig {
     /**
      * Container image name for keycloak service
      */
-    @ConfigItem(defaultValue = DEFAULT_KEYCLOAK_IMAGE)
+    @ConfigItem
     public String image;
 
     /**
@@ -52,4 +58,11 @@ public class HorreumDevServicesKeycloakConfig {
      */
     @ConfigItem(defaultValue = DEFAULT_KC_ADMIN_PASSWORD)
     public String adminPassword;
+
+    /**
+     * Define host port to expose Keycloak service.
+     * Usage of this property is discouraged and should only be enabled in scenarios where the keycloak port can not be dynamic
+     */
+    @ConfigItem()
+    public Optional<String> containerPort;
 }

--- a/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesPostgresConfig.java
+++ b/infra/horreum-dev-services/deployment/src/main/java/io/hyperfoil/tools/horreum/dev/services/deployment/config/HorreumDevServicesPostgresConfig.java
@@ -6,7 +6,6 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import java.io.File;
 import java.util.Optional;
 
-import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_POSTGRES_IMAGE;
 import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_POSTGRES_NETWORK_ALIAS;
 
 /**
@@ -24,7 +23,7 @@ public class HorreumDevServicesPostgresConfig {
     /**
      * Container image name for postgres service
      */
-    @ConfigItem(defaultValue = DEFAULT_POSTGRES_IMAGE)
+    @ConfigItem
     public String image;
 
 

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/Const.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/Const.java
@@ -8,6 +8,8 @@ public class Const {
     public static final String HORREUM_DEV_KEYCLOAK_ENABLED = "horreum.dev-services.keycloak.enabled";
     public static final String HORREUM_DEV_KEYCLOAK_IMAGE = "horreum.dev-services.keycloak.image";
     public static final String HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS = "horreum.dev-services.keycloak.network-alias";
+
+    public static final String HORREUM_DEV_KEYCLOAK_CONTAINER_PORT = "horreum.dev-services.keycloak.container-port";
     public static final String HORREUM_DEV_KEYCLOAK_DB_USERNAME = "horreum.dev-services.keycloak.db-username";
     public static final String HORREUM_DEV_KEYCLOAK_DB_PASSWORD = "horreum.dev-services.keycloak.db-password";
 
@@ -29,9 +31,7 @@ public class Const {
     public static final String DEFAULT_KC_ADMIN_PASSWORD = "secret";
 
     public static final String DEFAULT_POSTGRES_NETWORK_ALIAS = "horreum-dev-postgres";
-    public static final String DEFAULT_POSTGRES_IMAGE = "postgres:13";
 
     public static final String DEFAULT_KEYCLOAK_NETWORK_ALIAS = "horreum-dev-keycloak";
-    public static final String DEFAULT_KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:22.0";
 
 }

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/PostgresResource.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/PostgresResource.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.horreum.infra.common.ResourceLifecycleManager;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.SelinuxContext;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +45,7 @@ public class PostgresResource implements ResourceLifecycleManager {
             ;
 
             if ( initArgs.containsKey(HORREUM_DEV_POSTGRES_BACKUP) ) {
-                postgresContainer.withFileSystemBind(initArgs.get(HORREUM_DEV_POSTGRES_BACKUP), "/var/lib/postgresql/data", BindMode.READ_WRITE);
+                postgresContainer.addFileSystemBind(initArgs.get(HORREUM_DEV_POSTGRES_BACKUP), "/var/lib/postgresql/data", BindMode.READ_WRITE, SelinuxContext.SHARED);
                 prodBackup = true;
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
         <jackson.version>2.15.2</jackson.version>
 
         <module.skipCopyDependencies>false</module.skipCopyDependencies>
+
+        <dev.images.postgres>postgres:13</dev.images.postgres>
+        <dev.images.keycloak>quay.io/keycloak/keycloak:22.0</dev.images.keycloak>
+
     </properties>
 
     <developers>


### PR DESCRIPTION
Dev services now;
- work correctly with podman and cgroups2
- extracts the dev service images up to `application.properties` to allow easier syncing of image versions
- removes hard-coded dev service images
- introduces `horreum.dev-services.keycloak.container-port` config to allow for writing tests against a known keycloak port