### PR TITLE
Define sequences and ID generators for each PeristentLog subclasses: …

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/ActionLogDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/ActionLogDAO.java
@@ -1,10 +1,27 @@
 package io.hyperfoil.tools.horreum.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
 @Entity(name = "ActionLog")
 public class ActionLogDAO extends PersistentLogDAO {
+
+   @Id
+   @GenericGenerator(
+           name = "actionlog_id_generator",
+           strategy = "io.hyperfoil.tools.horreum.entity.SeqIdGenerator",
+           parameters = {
+                   @org.hibernate.annotations.Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1"),
+           }
+   )
+   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "actionlog_id_generator")
+   public Long id;
+
    @NotNull
    public int testId;
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/PersistentLogDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/PersistentLogDAO.java
@@ -19,10 +19,6 @@ public abstract class PersistentLogDAO extends PanacheEntityBase {
    public static final int WARN = 2;
    public static final int ERROR = 3;
 
-   @Id
-   @GeneratedValue
-   public Long id;
-
    @NotNull
    public int level;
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/DatasetLogDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/DatasetLogDAO.java
@@ -1,17 +1,14 @@
 package io.hyperfoil.tools.horreum.entity.alerting;
 
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 
 import io.hyperfoil.tools.horreum.entity.PersistentLogDAO;
 import io.hyperfoil.tools.horreum.entity.data.DataSetDAO;
 import io.hyperfoil.tools.horreum.entity.data.RunDAO;
 import io.hyperfoil.tools.horreum.entity.data.TestDAO;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
 /**
  * This table is meant to host logged events with relation to {@link DataSetDAO datasets},
@@ -19,6 +16,17 @@ import io.hyperfoil.tools.horreum.entity.data.TestDAO;
  */
 @Entity(name = "DatasetLog")
 public class DatasetLogDAO extends PersistentLogDAO {
+
+   @Id
+   @GenericGenerator(
+           name = "datasetlog_id_generator",
+           strategy = "io.hyperfoil.tools.horreum.entity.SeqIdGenerator",
+           parameters = {
+                   @org.hibernate.annotations.Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1"),
+           }
+   )
+   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "datasetlog_id_generator")
+   public Long id;
 
    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "testid", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/TransformationLogDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/TransformationLogDAO.java
@@ -1,19 +1,26 @@
 package io.hyperfoil.tools.horreum.entity.alerting;
 
 
-import jakarta.persistence.ConstraintMode;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import io.hyperfoil.tools.horreum.entity.PersistentLogDAO;
 import io.hyperfoil.tools.horreum.entity.data.RunDAO;
 import io.hyperfoil.tools.horreum.entity.data.TestDAO;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
 @Entity(name = "TransformationLog")
 public class TransformationLogDAO extends PersistentLogDAO {
+   @Id
+   @GenericGenerator(
+           name = "transformationlog_id_generator",
+           strategy = "io.hyperfoil.tools.horreum.entity.SeqIdGenerator",
+           parameters = {
+                   @org.hibernate.annotations.Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1"),
+           }
+   )
+   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "transformationlog_id_generator")
+   public Long id;
 
    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "testid", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/report/ReportLogDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/report/ReportLogDAO.java
@@ -1,13 +1,23 @@
 package io.hyperfoil.tools.horreum.entity.report;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import io.hyperfoil.tools.horreum.entity.PersistentLogDAO;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
 
 @Entity(name = "ReportLog")
 public class ReportLogDAO extends PersistentLogDAO {
+   @Id
+   @GenericGenerator(
+           name = "reportlog_id_generator",
+           strategy = "io.hyperfoil.tools.horreum.entity.SeqIdGenerator",
+           parameters = {
+                   @org.hibernate.annotations.Parameter(name = SequenceStyleGenerator.INCREMENT_PARAM, value = "1"),
+           }
+   )
+   @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "reportlog_id_generator")
+   public Long id;
    @ManyToOne(optional = false)
    @JoinColumn(name = "report_id")
    TableReportDAO report;

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4126,4 +4126,17 @@
                                  baseTableName="datapoint" baseColumnNames="dataset_id"
                                  referencedTableName="dataset" referencedColumnNames="id" />
     </changeSet>
+    <changeSet id="109" author="johara">
+        <createSequence sequenceName="actionlog_id_generator" startValue="1" incrementBy="1" cacheSize="1" />
+        <createSequence sequenceName="datasetlog_id_generator" startValue="1" incrementBy="1" cacheSize="1" />
+        <createSequence sequenceName="reportlog_id_generator" startValue="1" incrementBy="1" cacheSize="1" />
+        <createSequence sequenceName="transformationlog_id_generator" startValue="1" incrementBy="1" cacheSize="1" />
+        <sql>
+            select setval('actionlog_id_generator', (select max(id)+1 from actionlog), false);
+            select setval('datasetlog_id_generator', (select max(id)+1 from datasetlog), false);
+            select setval('reportlog_id_generator', (select max(id)+1 from reportlog), false);
+            select setval('transformationlog_id_generator', (select max(id)+1 from transformationlog), false);
+            GRANT ALL ON SEQUENCE actionlog_id_generator, datasetlog_id_generator, reportlog_id_generator, transformationlog_id_generator TO "${quarkus.datasource.username}";
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This is the backport of #854 into 0.9.x branch.   This should only be merged if the reordering strategy in https://github.com/Hyperfoil/Horreum/pull/863 is acceptable, and should only be merged after #863 has been merged