### PR TITLE
Do not filter report config if report is not peristed: Fixes #877

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/ReportComponentMapper.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/ReportComponentMapper.java
@@ -12,7 +12,7 @@ public class ReportComponentMapper {
         dto.unit = rc.unit;
         dto.labels = rc.labels;
         dto.order = rc.order;
-        dto.reportId = rc.report.id;
+        dto.reportId = rc.report == null ? null : rc.report.id;
 
         return dto;
     }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/TableReportMapper.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/TableReportMapper.java
@@ -42,7 +42,7 @@ public class TableReportMapper {
         dto.scaleFormatter = trc.scaleFormatter;
         dto.scaleDescription = trc.scaleDescription;
         if (trc.components != null)
-            dto.components = trc.components.stream().filter(r -> r.report != null).map(ReportComponentMapper::from).collect(Collectors.toList());
+            dto.components = trc.components.stream().map(ReportComponentMapper::from).collect(Collectors.toList());
 
         return dto;
     }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ReportServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ReportServiceTest.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.horreum.svc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -246,6 +247,12 @@ public class ReportServiceTest extends BaseServiceTest {
       TableReport preview = jsonRequest().body(config).post("/api/report/table/preview?edit=" + report.id)
           .then().statusCode(200).extract().body().as(TableReport.class);
       assertNotNull(preview);
+      assertNotNull(preview.config.components);
+
+      preview = jsonRequest().body(config).post("/api/report/table/preview")
+              .then().statusCode(200).extract().body().as(TableReport.class);
+      assertNotNull(preview);
+      assertNotEquals(0, preview.config.components.size());
    }
 
 }


### PR DESCRIPTION
Backport of https://github.com/Hyperfoil/Horreum/pull/918