### PR TITLE
[0.11.x] Configure overflow setting to render a better UI. 

### DIFF
--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -309,7 +309,7 @@ export default function TestDatasets() {
                         </ToolbarGroup>
                     </Toolbar>
                 </CardHeader>
-                <CardHeader style={{ margin: 0 }}>
+                <CardHeader style={{ margin: 0, overflowX: "auto" }}>
                     <ExpandableSection
                         isDetached
                         isExpanded={filterExpanded}


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1170

When number of filters exceeds window width.
Currently the filters disappear off the screen.

## Fixes Issue

fixes #960 

## Changes proposed

Now the window will render a horizontal scroll bar.

![horizontal-scroll-bar](https://github.com/Hyperfoil/Horreum/assets/708428/5bccadbf-72e0-4010-ba92-c313b6d0e827)



- [x] My code follows the code style of this project.
