### PR TITLE
[0.11.x] Detect when RLS has been a cause for error.

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -17,6 +17,7 @@ import io.hyperfoil.tools.horreum.server.WithToken;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
 
 import jakarta.annotation.security.PermitAll;
@@ -437,8 +438,12 @@ public class TestServiceImpl implements TestService {
       query.setParameter(1, owner);
       query.setParameter(2, access.ordinal());
       query.setParameter(3, id);
-      if (query.executeUpdate() != 1) {
-         throw ServiceException.serverError("Access change failed (missing permissions?)");
+      try {
+         if (query.executeUpdate() != 1) {
+            throw ServiceException.serverError("Access change failed (missing permissions?)");
+         }
+      } catch ( UnauthorizedException ue) {
+         throw ServiceException.forbidden("Changing access of Test " + id + " is not permitted. You are not defined as a `tester` for the `"+ owner + "` team. Please update your permissions and try again.");
       }
    }
 

--- a/horreum-web/src/domain/runs/Run.tsx
+++ b/horreum-web/src/domain/runs/Run.tsx
@@ -15,7 +15,7 @@ import DatasetData from "./DatasetData"
 import MetaData from "./MetaData"
 import RunData from "./RunData"
 import TransformationLogModal from "../tests/TransformationLogModal"
-import {Access, fetchRunSummary, recalculateDatasets, RunExtended, updateAccess} from "../../api"
+import {Access, fetchRunSummary, recalculateDatasets, RunExtended, updateAccess, updateRunAccess} from "../../api"
 import {AppContext} from "../../context/appContext";
 import { AppContextType} from "../../context/@types/appContextTypes";
 
@@ -58,7 +58,7 @@ export default function Run() {
 
     const accessUpdate = (owner : string, access : Access) => {
         if( run !== undefined) {
-            updateAccess(run.id, owner, access, alerting).then(() => getRunSummary())
+            updateRunAccess(run.id, run.testid, owner, access, alerting).then(() => getRunSummary())
         }
     }
 


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1147

Fixed calling the wrong apis function when updating Run access.


## Fixes Issue

fixes #406 
fixes #1145

## Changes proposed

- [x] Add catch block for unauthorized exception type.
- [x] Swich call to apis to execute the Run access update function.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
