### PR TITLE
[0.11.x] Change permissions on retreiving Datastores: Fixes #1204

### DIFF
--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -408,6 +408,11 @@ public class BaseServiceTest {
             .statusCode(204);
    }
 
+   protected RequestSpecification unauthenticatedJsonRequest() {
+      return RestAssured.given()
+              .header(HttpHeaders.CONTENT_TYPE, "application/json");
+   }
+
    protected RequestSpecification jsonRequest() {
       return RestAssured.given().auth().oauth2(getTesterToken())
             .header(HttpHeaders.CONTENT_TYPE, "application/json");

--- a/horreum-web/src/domain/admin/datastore/ModifyDatastoreModal.tsx
+++ b/horreum-web/src/domain/admin/datastore/ModifyDatastoreModal.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react"
+import React, {useContext, useState} from "react"
 
 import {
     Button, Form,
@@ -12,6 +12,8 @@ import {
     Datastore,
     DatastoreTypeEnum, ElasticsearchDatastoreConfig,
 } from "../../../api";
+import {AppContext} from "../../../context/appContext";
+import {AppContextType} from "../../../context/@types/appContextTypes";
 
 type ConfirmDeleteModalProps = {
     isOpen: boolean
@@ -35,6 +37,7 @@ interface datastoreOption {
 
 export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore, dataStore, updateDatastore}: ConfirmDeleteModalProps) {
 
+    const { alerting } = useContext(AppContext) as AppContextType;
     const [enabledURL, setEnableUrl] = useState(false);
     const [enabledToken, setEnableToken] = useState(false);
 
@@ -44,14 +47,22 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
         if ( option ){
             setEnableUrl(option.urlDisabled)
             setEnableToken(option.tokenDisbaled)
+
+            updateDatastore({...dataStore, type: option.value})
         }
     };
 
     const saveBackend = () => {
-        persistDatastore(dataStore).then( () => onClose())
+        persistDatastore(dataStore)
+            .then( () => {
+                onClose();
+                alerting.dispatchInfo("SAVE", "Saved!", "Datastore was successfully updated!", 3000)
+            })
+            .catch(reason => alerting.dispatchError("SAVE", "Saved!", "Failed to save changes to Datastore"))
     }
 
     const options : datastoreOption[] = [
+        { value:  DatastoreTypeEnum.Postgres, label: 'Please select...', disabled: true, urlDisabled: true, usernameDisable: true, tokenDisbaled: true },
         { value:  DatastoreTypeEnum.Elasticsearch, label: 'Elasticsearch', disabled: false, urlDisabled: false, usernameDisable: false, tokenDisbaled: false },
     ];
 


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1226

 - allow unauthenticated users to query public datastores
 - return public datastores for users who not belong to test owning team
 - added tests
 - added success/error messages to UI
 - fixed UI dropdown and updating issues

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #1204

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
