### PR TITLE
Changed default ordering to Decending and preserve ordering of DTOs. 

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -144,7 +144,7 @@ public class Util {
 
    static void addOrderBy(StringBuilder sql, String sort, SortDirection direction) {
       sort = sort == null || sort.trim().isEmpty() ? "start" : sort;
-      direction = direction == null ? SortDirection.Ascending : direction;
+      direction = direction == null ? SortDirection.Descending : direction;
       sql.append(" ORDER BY ").append(sort);
       addDirection(sql, direction);
    }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -31,6 +31,7 @@ import io.hyperfoil.tools.horreum.api.alerting.Variable;
 import io.hyperfoil.tools.horreum.api.internal.services.AlertingService;
 import io.hyperfoil.tools.horreum.api.report.ReportComponent;
 import io.hyperfoil.tools.horreum.api.report.TableReportConfig;
+import io.hyperfoil.tools.horreum.api.services.DatasetService;
 import io.hyperfoil.tools.horreum.api.services.ExperimentService;
 import io.hyperfoil.tools.horreum.api.services.RunService;
 import io.hyperfoil.tools.horreum.bus.MessageBusChannels;
@@ -1018,5 +1019,18 @@ public class BaseServiceTest {
          array.add(label);
       }
       return array;
+   }
+
+   protected DatasetService.DatasetList listTestDatasets(long id, SortDirection direction){
+      StringBuilder url = new StringBuilder("/api/dataset/list/" + id);
+      if (direction != null) {
+         url.append("?direction=" + direction);
+      }
+      return jsonRequest()
+          .get(url.toString())
+          .then()
+          .statusCode(200)
+          .extract()
+          .as(DatasetService.DatasetList.class);
    }
 }


### PR DESCRIPTION
Preserves DTO object ordering to UI.


## Fixes Issue

 fixes #929  issue

## Changes proposed

[x] - Add testcase to check Runs ordering in ASC or DESC mode.
[x] - Add testcase to check Datasets ordering in ASC or default DESC mode.
[x] - Fix the default ordering to Descending
[x] - Fixs the loss of ordering when creating a list of DTO objects

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

