### PR TITLE
[0.11.x] Display datastore config to managers in Admin tab: Fixes #1275

### DIFF
--- a/horreum-web/src/App.tsx
+++ b/horreum-web/src/App.tsx
@@ -22,7 +22,7 @@ import {
 import {Provider, useSelector} from "react-redux"
 
 import store from "./store"
-import {isAdminSelector, LoginLogout} from "./auth"
+import {isAdminSelector, isManagerSelector, LoginLogout} from "./auth"
 import {initKeycloak} from "./keycloak"
 import {UserProfileLink, UserSettings} from "./domain/user/UserSettings"
 
@@ -92,6 +92,7 @@ export default function App() {
 
 function Main() {
     const isAdmin = useSelector(isAdminSelector)
+    const isManager = useSelector(isManagerSelector)
 
 
     return (
@@ -120,7 +121,7 @@ function Main() {
                                     <NavItem itemId={3}>
                                         <NavLink to="/reports">Reports</NavLink>
                                     </NavItem>
-                                    {isAdmin && (
+                                    { (isAdmin || isManager) && (
                                         <NavItem itemId={4}>
                                             <NavLink to="/admin">Administration</NavLink>
                                         </NavItem>

--- a/horreum-web/src/auth.tsx
+++ b/horreum-web/src/auth.tsx
@@ -111,6 +111,10 @@ export const isAdminSelector = (state: State) => {
     return state.auth.roles.includes("admin")
 }
 
+export const isManagerSelector = (state: State) => {
+    return managedTeamsSelector(state).length > 0
+}
+
 export const teamsSelector = (state: State): string[] => {
     return state.auth.teams
 }

--- a/horreum-web/src/domain/admin/Admin.tsx
+++ b/horreum-web/src/domain/admin/Admin.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react"
-import { Card, CardBody, PageSection } from "@patternfly/react-core"
+import {useRef} from "react"
+import {Card, CardBody, NavItem, PageSection} from "@patternfly/react-core"
 
-import SavedTabs, { SavedTab, TabFunctions, saveFunc, resetFunc, modifiedFunc } from "../../components/SavedTabs"
-import { FragmentTab } from "../../components/FragmentTabs"
+import SavedTabs, {SavedTab, TabFunctions, saveFunc, resetFunc, modifiedFunc} from "../../components/SavedTabs"
+import FragmentTabs, {FragmentTab} from "../../components/FragmentTabs"
 import AllowedSiteList from "../actions/AllowedSiteList"
 import ActionList from "../actions/ActionList"
 import BannerConfig from "./BannerConfig"
@@ -10,13 +10,19 @@ import Notifications from "./Notifications"
 import Teams from "./Teams"
 import Administrators from "./Administrators"
 import {useSelector} from "react-redux";
-import {isAdminSelector} from "../../auth";
+import {isAdminSelector, isManagerSelector} from "../../auth";
 import Datastores from "./Datastores";
+import {NavLink} from "react-router-dom";
+import DatasetData from "../runs/DatasetData";
+import RunData from "../runs/RunData";
+import MetaData from "../runs/MetaData";
 
 export default function Admin() {
     const adminFuncsRef = useRef<TabFunctions>()
     const teamsFuncsRef = useRef<TabFunctions>()
     const isAdmin = useSelector(isAdminSelector)
+    const isManager = useSelector(isManagerSelector)
+
     if (isAdmin) {
         return (
             <PageSection>
@@ -60,6 +66,21 @@ export default function Admin() {
                 </Card>
             </PageSection>
         )
+    } else if (isManager) {
+        return (
+            <PageSection>
+                <Card>
+                    <CardBody>
+                        <FragmentTabs>
+                            <FragmentTab title="Datastores" fragment="datastores">
+                                <Datastores/>
+                            </FragmentTab>
+                        </FragmentTabs>
+                    </CardBody>
+                </Card>
+            </PageSection>
+        )
+
     } else {
         return (
             <PageSection>


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1276

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #1275

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
