### PR TITLE
[0.11.x] closes #1312 with updated UIService api

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1956,6 +1956,43 @@ paths:
           default: true
           type: boolean
         example: false
+      - name: filter
+        in: query
+        description: either a required json sub-document or path expression
+        schema:
+          default: "{}"
+          type: string
+        example:
+          key: requiredValue
+      - name: sort
+        in: query
+        description: label name for sorting
+        schema:
+          default: ""
+          type: string
+      - name: direction
+        in: query
+        description: either Ascending or Descending
+        schema:
+          default: Ascending
+          type: string
+        example: count
+      - name: limit
+        in: query
+        description: the maximum number of results to include
+        schema:
+          format: int32
+          default: 2147483647
+          type: integer
+        example: 10
+      - name: page
+        in: query
+        description: which page to skip to when using a limit
+        schema:
+          format: int32
+          default: 0
+          type: integer
+        example: 2
       responses:
         "200":
           description: OK

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/internal/services/UIService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/internal/services/UIService.java
@@ -22,7 +22,7 @@ public interface UIService {
 
     @POST
     @Path("view")
-    int updateView(@RequestBody(required = true) View view);
+    View updateView(@RequestBody(required = true) View view);
 
     @POST
     @Path("views")

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/UIServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/UIServiceImpl.java
@@ -28,7 +28,7 @@ public class UIServiceImpl implements UIService {
     @RolesAllowed("tester")
     @WithRoles
     @Transactional
-    public int updateView(View dto) {
+    public View updateView(View dto) {
         if (dto.testId <= 0) {
             throw ServiceException.badRequest("Missing test id on view");
         }
@@ -49,7 +49,7 @@ public class UIServiceImpl implements UIService {
         }
     }
 
-    private int doUpdate(TestDAO test, ViewDAO view) {
+    private View doUpdate(TestDAO test, ViewDAO view) {
         view.ensureLinked();
         view.test = test;
         if (view.id == null || view.id < 0) {
@@ -63,7 +63,7 @@ public class UIServiceImpl implements UIService {
         test.views.add(view);
         test.persist();
         em.flush();
-        return view.id;
+        return ViewMapper.from(view);
     }
 
     @Override

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -388,12 +388,12 @@ public class BaseServiceTest {
               .statusCode(204);
    }
 
-   protected int createView(View view) {
+   protected View createView(View view) {
       return jsonRequest()
               .body(view)
               .post("/api/ui/view")
               .then()
-              .statusCode(200).extract().body().as(Integer.class);
+              .statusCode(200).extract().body().as(View.class);
    }
 
    protected List<View> getViews(int testId) {
@@ -875,7 +875,7 @@ public class BaseServiceTest {
               readFile(p.resolve("roadrunner_view.json").toFile()), View.class);
       assertEquals("Default", view.name);
       view.testId = t.id;
-      view.id = createView(view);
+      view = createView(view);
 
       Schema s = new ObjectMapper().readValue(
               readFile(p.resolve("acme_benchmark_schema.json").toFile()), Schema.class);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
@@ -167,10 +167,10 @@ public class TestServiceTest extends BaseServiceTest {
    }
 
    private void updateView(View view) {
-      Integer viewId = jsonRequest().body(view).post("/api/ui/view")
-            .then().statusCode(200).extract().body().as(Integer.class);
+      View newView = jsonRequest().body(view).post("/api/ui/view")
+            .then().statusCode(200).extract().body().as(View.class);
       if (view.id != null) {
-         assertEquals(view.id, viewId);
+         assertEquals(view.id, newView.id);
       }
    }
 

--- a/horreum-web/src/api.tsx
+++ b/horreum-web/src/api.tsx
@@ -258,7 +258,7 @@ export function fetchViews(testId: number, alerting: AlertContextType): Promise<
 export function updateAccess(id: number, owner: string, access: Access, alerting: AlertContextType) : Promise<void> {
     return apiCall(testApi.updateAccess(id, access, owner), alerting, "UPDATE_ACCESS", "Failed to update test access");
 }
-export function updateView(alerting: AlertContextType, testId: number, view: View): Promise<number> {
+export function updateView(alerting: AlertContextType, testId: number, view: View): Promise<View> {
     for (const c of view.components) {
         if (c.labels.length === 0) {
             alerting.dispatchError(


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1315


Closes #1312

The `UIService` `updateView` now returns the updated `View` not just the `id` because the updated view can contain new `ViewComponents` and the client needs to know the new `ids` for those `ViewComponents`

An alternative could be to fetch all the `Views` after updating any `View` but that would re-fetch data that did not change. It might simplify the client code but would add unnecessary IO to the backend. I think there are better improvements to be made to the client code with where and how views are cached in the javascript but that is for a later PR.

