### PR TITLE
fix #1323 by adding /api/run/{id}/labelValues

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -954,6 +954,75 @@ paths:
             application/json:
               schema:
                 type: string
+  /api/run/{id}/labelValues:
+    get:
+      tags:
+      - Run
+      description: Get all the label values for the run
+      operationId: labelValues
+      parameters:
+      - name: id
+        in: path
+        description: Run Id
+        required: true
+        schema:
+          format: int32
+          type: integer
+        example: 101
+      - name: filter
+        in: query
+        description: either a required json sub-document or path expression
+        schema:
+          default: "{}"
+          type: string
+        examples:
+          object:
+            description: json object that must exist in the values object
+            value:
+              key: requiredValue
+          string:
+            description: valid jsonpath that returns null of not found (not predicates)
+            value: $.count ? (@ < 20 && @ > 10)
+      - name: sort
+        in: query
+        description: label name for sorting
+        schema:
+          default: ""
+          type: string
+      - name: direction
+        in: query
+        description: either Ascending or Descending
+        schema:
+          default: Ascending
+          type: string
+        example: count
+      - name: limit
+        in: query
+        description: the maximum number of results to include
+        schema:
+          format: int32
+          default: 2147483647
+          type: integer
+        example: 10
+      - name: page
+        in: query
+        description: which page to skip to when using a limit
+        schema:
+          format: int32
+          default: 0
+          type: integer
+        example: 2
+      responses:
+        "200":
+          description: label Values
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExportedLabelValues'
+              example: "[ { \"datasetId\" : 101, \"runId\": 201, \"values\" : { [labelName]\
+                \ : labelValue } },...]"
   /api/run/{id}/metadata:
     get:
       tags:
@@ -1967,12 +2036,27 @@ paths:
           type: string
         example:
           key: requiredValue
-      - name: sort
+      - name: before
         in: query
-        description: label name for sorting
+        description: ISO-like date time string or epoch millis
         schema:
           default: ""
           type: string
+        example: 1970-01-01T00:00:00+00:00 or an integer
+      - name: after
+        in: query
+        description: ISO-like date time string or epoch millis
+        schema:
+          default: ""
+          type: string
+        example: 1970-01-01T00:00:00+00:00 or an integer
+      - name: sort
+        in: query
+        description: json path to sortable value or start or stop for sorting by time
+        schema:
+          default: ""
+          type: string
+        example: $.label or start or stop
       - name: direction
         in: query
         description: either Ascending or Descending
@@ -2789,15 +2873,13 @@ components:
     ExportedLabelValues:
       description: A map of label names to label values with the associated datasetId
         and runId
+      required:
+      - start
+      - stop
       type: object
       properties:
         values:
-          description: a map of label name to label value for each label from the
-            dataset
-          type: object
-          example:
-            name: test
-            score: 200
+          $ref: '#/components/schemas/LabelValueMap'
         runId:
           format: int32
           description: the run id that created the dataset
@@ -2808,6 +2890,16 @@ components:
           description: the unique dataset id
           type: integer
           example: 101
+        start:
+          format: date-time
+          description: Start timestamp
+          type: string
+          example: 2019-09-26T07:58:30.996+0200
+        stop:
+          format: date-time
+          description: Stop timestamp
+          type: string
+          example: 2019-09-26T07:58:30.996+0200
     Extractor:
       description: "An Extractor defines how values are extracted from a JSON document,\
         \ for use in Labels etc."

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/ExportedLabelValues.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/ExportedLabelValues.java
@@ -21,9 +21,8 @@ import java.util.stream.StreamSupport;
 @Schema(type = SchemaType.OBJECT,
         description = "A map of label names to label values with the associated datasetId and runId")
 public class ExportedLabelValues {
-    @Schema(type = SchemaType.OBJECT, description = "a map of label name to label value for each label from the dataset",example = "{\"name" +
-            "\":\"test\",\"score\":200}")
-    public ObjectNode values;
+    @Schema
+    public LabelValueMap values;
     @Schema(type = SchemaType.INTEGER,description = "the run id that created the dataset",example = "101")
     public Integer runId;
     @Schema(type = SchemaType.INTEGER,description = "the unique dataset id",example = "101")
@@ -40,7 +39,7 @@ public class ExportedLabelValues {
 
     public ExportedLabelValues() {}
 
-    public ExportedLabelValues(ObjectNode v, Integer runId, Integer datasetId,Instant start,Instant stop) {
+    public ExportedLabelValues(LabelValueMap v, Integer runId, Integer datasetId,Instant start,Instant stop) {
        this.values = v;
        this.runId = runId;
        this.datasetId = datasetId;
@@ -54,13 +53,13 @@ public class ExportedLabelValues {
             return new ArrayList<>();
         List<ExportedLabelValues> fps = new ArrayList<>();
         nodes.forEach(objects->{
-            JsonNode node = (JsonNode)objects[0];
+            ObjectNode node = (ObjectNode)objects[0];
             Integer runId = Integer.parseInt(objects[1]==null?"-1":objects[1].toString());
             Integer datasetId = Integer.parseInt(objects[2]==null?"-1":objects[2].toString());
             Instant start = (Instant)objects[3];
             Instant stop = (Instant)objects[4];
             if(node.isObject()){
-                fps.add(new ExportedLabelValues((ObjectNode) node,runId,datasetId,start,stop));
+                fps.add(new ExportedLabelValues(LabelValueMap.fromObjectNode(node),runId,datasetId,start,stop));
             }else{
                 //TODO alert that something is wrong in the db response
             }

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -3,23 +3,16 @@ package io.hyperfoil.tools.horreum.api.services;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.hyperfoil.tools.horreum.api.ApiIgnore;
 import io.hyperfoil.tools.horreum.api.SortDirection;
-import io.hyperfoil.tools.horreum.api.data.Access;
-import io.hyperfoil.tools.horreum.api.data.ProtectedTimeType;
-import io.hyperfoil.tools.horreum.api.data.Run;
-import io.hyperfoil.tools.horreum.api.data.ValidationError;
+import io.hyperfoil.tools.horreum.api.data.*;
+
 import java.util.List;
 import java.util.Map;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -104,6 +97,42 @@ public interface RunService {
     Object getData(@PathParam("id") int id,
                    @QueryParam("token") String token,
                    @QueryParam("schemaUri") String schemaUri);
+
+    @GET
+    @Path("{id}/labelValues")
+    @Operation(description = "Get all the label values for the run")
+    @Parameters(value = {
+            @Parameter(name = "id", in =ParameterIn.PATH, description = "Run Id", example = "101"),
+            @Parameter(name = "filter", description = "either a required json sub-document or path expression", examples = {
+                    @ExampleObject(name="object", value="{\"key\":\"requiredValue\"}", description = "json object that must exist in the values object"),
+                    @ExampleObject(name="string", value="$.count ? (@ < 20 && @ > 10)",description = "valid jsonpath that returns null of not found (not predicates)")
+            }),
+            @Parameter(name = "sort", description = "label name for sorting"),
+            @Parameter(name = "direction",description = "either Ascending or Descending",example="count"),
+            @Parameter(name = "limit",description = "the maximum number of results to include",example="10"),
+            @Parameter(name = "page",description = "which page to skip to when using a limit",example="2")
+    })
+    @APIResponses(
+            value = {
+                    @APIResponse(responseCode = "200",
+                        description = "label Values",
+                        content = {
+                            @Content(
+                                schema = @Schema(type = SchemaType.ARRAY, implementation = ExportedLabelValues.class),
+                                example = "[ { \"datasetId\" : 101, \"runId\": 201, \"values\" : { [labelName] : labelValue } },...]"
+                            )
+                        }
+                    )
+            }
+    )
+
+    List<ExportedLabelValues> labelValues(
+            @PathParam("id") int runId,
+            @QueryParam("filter") @DefaultValue("{}") String filter,
+            @QueryParam("sort") @DefaultValue("") String sort,
+            @QueryParam("direction") @DefaultValue("Ascending") String direction,
+            @QueryParam("limit") @DefaultValue(""+Integer.MAX_VALUE) int limit,
+            @QueryParam("page") @DefaultValue("0") int page);
 
     @GET
     @Path("{id}/metadata")

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.*;
 
+import com.fasterxml.jackson.databind.node.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.OptimisticLockException;
@@ -30,16 +31,13 @@ import org.eclipse.microprofile.context.ThreadContext;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
+import org.hibernate.query.NativeQuery;
 import org.jboss.logging.Logger;
 import org.postgresql.util.PSQLException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.InvalidPathException;
@@ -662,6 +660,63 @@ public class Util {
       }
       return null;//nothing matched
    }
+
+   /**
+    * used to check if an input can be cast to a target type in the db and return any error messages
+    * Will return a row of all nulls if the input can be cast to the target type.
+    */
+   //tried pg_input_is_valid but it just returns boolean, no messages
+   private static final String CHECK_CAST = "select * from pg_input_error_info(:input,:target)";
+   public static record CheckResult (boolean ok, String message, String detail, String hint) {}
+   /**
+    * returns true (in the CheckResult) if the input can be cast to the target type in psql, otherwise it is false and details are included
+    * @param input
+    * @param target
+    * @param em
+    * @return
+    */
+   public static CheckResult castCheck(String input, String target, EntityManager em){
+      List<Object[]> results = em.createNativeQuery(CHECK_CAST).setParameter("input",input).setParameter("target",target)
+              .unwrap(NativeQuery.class)
+              .addScalar("message",String.class)
+              .addScalar("detail",String.class)
+              .addScalar("hint",String.class)
+              .addScalar("sql_error_code",String.class)
+              .getResultList();
+      //no results or null result row or no message means it passed. no result and 0 lengh result should not happen but being defensive
+      return results.isEmpty() || results.get(0).length == 0 || results.get(0)[0] == null?
+              new CheckResult(true,"","","") :
+              new CheckResult(
+                      false,
+                      results.get(0)[0] == null ? "" : results.get(0)[0].toString(),
+                      results.get(0)[1] == null ? "" : results.get(0)[1].toString(),
+                      results.get(0)[2] == null ? "" : results.get(0)[2].toString()
+              );
+   }
+
+   /**
+    * returns null if no filtering, otherwise returns an object for filtering
+    * @param input
+    * @return
+    */
+   public static Object getFilterObject(String input){
+      if (input == null || input.isBlank()){//not a valid filter
+         return null;
+      }
+      JsonNode filterJson = null;
+      try {
+         filterJson = new ObjectMapper().readTree(input);
+      } catch (JsonProcessingException e) {
+         //TODO what to do with this error
+      }
+      if(filterJson!=null && filterJson.getNodeType() == JsonNodeType.OBJECT) {
+         return filterJson;
+      }else{
+         //TODO validate the jsonpath?
+         return input;
+      }
+   }
+
    interface ExecutionExceptionConsumer<T> {
       void accept(T row, Throwable exception, String code);
    }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
@@ -192,7 +192,7 @@ public class TestServiceTest extends BaseServiceTest {
       assertNotNull(values);
       assertFalse(values.isEmpty());
       assertEquals(2, values.size());
-      assertTrue(values.get(1).values.has("value"));
+      assertTrue(values.get(1).values.containsKey("value"));
    }
    @org.junit.jupiter.api.Test
    public void testImportFromFile() throws JsonProcessingException {


### PR DESCRIPTION
Closes #1323

related to #1092

this adds the `/api/run/{id}/labelValues` endpoint to mirror `/api/test/{id}/labelValues` and it uses a similar format
```
[ { datasetId, values: { [labelName]: labelValue},...]
```

TODO:
- [x] Still needs tests for the new endpoint
- [x] Need to create a reusable record for the return type
<!-- List all the proposed changes in your PR -->
