### PR TITLE
fix 1325 with concrete return types

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -2531,8 +2531,12 @@ components:
           type: string
           example: Run on AWS with m7g.large
         view:
-          description: View definition
-          type: string
+          description: map of view component ids to the LabelValueMap to render the
+            component for this dataset
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/IndexedLabelValueMap'
+          example: "{ \"[view_component_id]\": { \"[labelName]\": labelValue} }"
         schemas:
           description: List of Schema usages
           type: array
@@ -2852,6 +2856,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FingerprintValue'
+    IndexedLabelValueMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/LabelValueMap'
     KeycloakConfig:
       type: object
       properties:
@@ -3053,6 +3061,10 @@ components:
             \ array or JSON object"
           type: string
           example: "1724"
+    LabelValueMap:
+      description: a map of label name to value
+      type: object
+      example: "{ \"[labelName]\": labelValue}"
     MissingDataRule:
       required:
       - id

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/IndexedLabelValueMap.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/IndexedLabelValueMap.java
@@ -1,0 +1,36 @@
+package io.hyperfoil.tools.horreum.api.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Schema(description = "a map of view component Id to the label values necessary to render the component")
+public class IndexedLabelValueMap extends HashMap<String, LabelValueMap> {
+
+    public static IndexedLabelValueMap fromObjectNode(ObjectNode node){
+        Map<String, LabelValueMap> rtrn = new HashMap<>();
+        if(node != null){
+            node.fields().forEachRemaining(entry->{
+                String entryKey = entry.getKey();
+                JsonNode entryNode = entry.getValue();
+                if(entryNode.isObject()){
+                    LabelValueMap map = LabelValueMap.fromObjectNode((ObjectNode) entryNode);
+                    rtrn.put(entryKey,map);
+                }else{//this should not happen
+
+                }
+            });
+        }
+        return new IndexedLabelValueMap(rtrn);
+    }
+
+    public IndexedLabelValueMap(){}
+    public IndexedLabelValueMap(Map<String, LabelValueMap> values){
+        super();
+        this.putAll(values);
+    }
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/LabelValueMap.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/LabelValueMap.java
@@ -1,0 +1,25 @@
+package io.hyperfoil.tools.horreum.api.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.HashMap;
+
+/**
+ *
+ */
+@Schema(type = SchemaType.OBJECT, description = "a map of label name to value",example = "{ \"[labelName]\": labelValue}")
+public class LabelValueMap extends HashMap<String, JsonNode> {
+
+    public static LabelValueMap fromObjectNode(ObjectNode node){
+        LabelValueMap rtrn = new LabelValueMap();
+        if(node != null){
+            node.fields().forEachRemaining(field->{
+                rtrn.put(field.getKey(),field.getValue());
+            });
+        }
+        return rtrn;
+    }
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/DatasetService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/DatasetService.java
@@ -2,17 +2,10 @@ package io.hyperfoil.tools.horreum.api.services;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.api.SortDirection;
-import io.hyperfoil.tools.horreum.api.data.Access;
-import io.hyperfoil.tools.horreum.api.data.Dataset;
-import io.hyperfoil.tools.horreum.api.data.Label;
-import io.hyperfoil.tools.horreum.api.data.ProtectedTimeType;
-import io.hyperfoil.tools.horreum.api.data.ProtectedType;
-import io.hyperfoil.tools.horreum.api.data.ValidationError;
-import java.time.Instant;
+import io.hyperfoil.tools.horreum.api.data.*;
+
 import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
@@ -130,8 +123,10 @@ public interface DatasetService {
       @Schema(description="Dataset description",
               example = "Run on AWS with m7g.large")
       public String description;
-      @Schema(implementation = String.class, description = "View definition")
-      public ObjectNode view;
+
+      @Schema(type = SchemaType.OBJECT, description = "map of view component ids to the LabelValueMap to render the component for this dataset", example = "{ \"[view_component_id]\": { \"[labelName]\": labelValue} }")
+      public IndexedLabelValueMap view;
+
       @JsonProperty(required = true)
       @Schema(description = "List of Schema usages")
       public List<SchemaService.SchemaUsage> schemas;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
@@ -1,9 +1,7 @@
 package io.hyperfoil.tools.horreum.svc;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -11,8 +9,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.hyperfoil.tools.horreum.api.data.Access;
-import io.hyperfoil.tools.horreum.api.data.ValidationError;
+import io.hyperfoil.tools.horreum.api.data.*;
 import io.hyperfoil.tools.horreum.bus.MessageBusChannels;
 import io.hyperfoil.tools.horreum.entity.FingerprintDAO;
 import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
@@ -27,8 +24,6 @@ import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
 
 import io.hyperfoil.tools.horreum.api.SortDirection;
-import io.hyperfoil.tools.horreum.api.data.Dataset;
-import io.hyperfoil.tools.horreum.api.data.Label;
 import io.hyperfoil.tools.horreum.entity.data.*;
 import io.hyperfoil.tools.horreum.mapper.DatasetMapper;
 import jakarta.ws.rs.DefaultValue;
@@ -267,7 +262,7 @@ public class DatasetServiceImpl implements DatasetService {
                  summary.stop = Instant.ofEpochMilli((Long) tuples[7]);
                  summary.owner = (String) tuples[8];
                  summary.access = Access.fromInt((int) tuples[9]);
-                 summary.view = (ObjectNode) tuples[10];
+                 summary.view = IndexedLabelValueMap.fromObjectNode((ObjectNode) tuples[10]);
                  summary.schemas = Util.OBJECT_MAPPER.convertValue(tuples[11], new TypeReference<>(){});
                  if(tuples[12] != null && !((ArrayNode) tuples[12]).isEmpty()) {
                     try {
@@ -279,6 +274,7 @@ public class DatasetServiceImpl implements DatasetService {
                  return summary;
               });
    }
+
 
    private void addOrderAndPaging(Integer limit, Integer page, String sort, SortDirection direction, StringBuilder sql) {
       if (sort != null && sort.startsWith("view_data:")) {


### PR DESCRIPTION
openapi.yaml generation from annotations is a dark art I don't yet fully undestand. I would hope the annotations offer the same expression as we can achieve with concrete types or by had writing the yaml but I cannot find the solution.

Instead I changed the data type to a subclass of `HashMap<>` so that openapi will generate a custom schema and reference it for docs and clients.

Closes #1325 

