### PR TITLE
fixes #1332 by using first loaded view as default

### DIFF
--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -208,7 +208,7 @@ export default function TestDatasets() {
                 },
             })
         }
-        const view = views?.find(v => v.id === viewId) || views?.find(v => v.name === "Default")
+        const view = views?.find(v => v.id === viewId) || views?.at(0)
         const components = view?.components || []
         components.forEach(vc => {
             allColumns.push({


### PR DESCRIPTION
I know I already fixed this once but apparently the "default" test can be `default` or `Default` or whatever else we want so now Horreum will just display whatever is shown by default in the view selector until we find the next issue with it

closes #1332