### PR TITLE
python-client: add Schema + impl to ObjectNode api returns

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1967,12 +1967,27 @@ paths:
           type: string
         example:
           key: requiredValue
-      - name: sort
+      - name: before
         in: query
-        description: label name for sorting
+        description: ISO-like date time string or epoch millis
         schema:
           default: ""
           type: string
+        example: 1970-01-01T00:00:00+00:00 or an integer
+      - name: after
+        in: query
+        description: ISO-like date time string or epoch millis
+        schema:
+          default: ""
+          type: string
+        example: 1970-01-01T00:00:00+00:00 or an integer
+      - name: sort
+        in: query
+        description: json path to sortable value or start or stop for sorting by time
+        schema:
+          default: ""
+          type: string
+        example: $.label or start or stop
       - name: direction
         in: query
         description: either Ascending or Descending
@@ -2220,6 +2235,7 @@ components:
       - event
       - type
       - config
+      - secrets
       - testId
       - active
       - runAlways
@@ -2233,7 +2249,15 @@ components:
         type:
           type: string
         config:
-          type: array
+          type: object
+          oneOf:
+          - $ref: '#/components/schemas/HttpAction'
+          - $ref: '#/components/schemas/GithubIssueCommentAction'
+          - $ref: '#/components/schemas/GithubIssueCreateAction'
+        secrets:
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/Secret'
         testId:
           format: int32
           type: integer
@@ -2241,8 +2265,6 @@ components:
           type: boolean
         runAlways:
           type: boolean
-        secrets:
-          type: array
     ActionLog:
       description: Action Log
       required:
@@ -2279,7 +2301,10 @@ components:
         model:
           type: string
         config:
-          type: array
+          type: object
+          oneOf:
+          - $ref: '#/components/schemas/RelativeDifferenceDetection'
+          - $ref: '#/components/schemas/FixedThresholdDetection'
     ComparisonResult:
       description: Result of performing a Comparison
       type: object
@@ -2789,6 +2814,9 @@ components:
     ExportedLabelValues:
       description: A map of label names to label values with the associated datasetId
         and runId
+      required:
+      - start
+      - stop
       type: object
       properties:
         values:
@@ -2808,6 +2836,16 @@ components:
           description: the unique dataset id
           type: integer
           example: 101
+        start:
+          format: date-time
+          description: Start timestamp
+          type: string
+          example: 2019-09-26T07:58:30.996+0200
+        stop:
+          format: date-time
+          description: Stop timestamp
+          type: string
+          example: 2019-09-26T07:58:30.996+0200
     Extractor:
       description: "An Extractor defines how values are extracted from a JSON document,\
         \ for use in Labels etc."
@@ -2856,6 +2894,42 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FingerprintValue'
+    FixedThresholdDetection:
+      type: object
+      properties:
+        min:
+          $ref: '#/components/schemas/Threshold'
+        max:
+          $ref: '#/components/schemas/Threshold'
+    GithubIssueCommentAction:
+      type: object
+      properties:
+        issueUrl:
+          type: string
+        owner:
+          type: string
+        repo:
+          type: string
+        issue:
+          type: string
+        formatter:
+          type: string
+    GithubIssueCreateAction:
+      type: object
+      properties:
+        owner:
+          type: string
+        repo:
+          type: string
+        title:
+          type: string
+        formatter:
+          type: string
+    HttpAction:
+      type: object
+      properties:
+        url:
+          type: string
     IndexedLabelValueMap:
       type: object
       additionalProperties:
@@ -3207,6 +3281,20 @@ components:
           description: Total number of generated datasets
           type: integer
           example: 186
+    RelativeDifferenceDetection:
+      type: object
+      properties:
+        filter:
+          type: string
+        window:
+          format: int32
+          type: integer
+        threshold:
+          format: double
+          type: number
+        minPrevious:
+          format: int32
+          type: integer
     ReportComponent:
       description: Report Component
       required:
@@ -3642,6 +3730,13 @@ components:
           description: Does schema have a JSON validation schema defined?
           type: boolean
           example: false
+    Secret:
+      type: object
+      properties:
+        token:
+          type: string
+        modified:
+          type: boolean
     SortDirection:
       enum:
       - Ascending
@@ -4160,6 +4255,16 @@ components:
           description: Token description
           type: string
           example: my reporting service token
+    Threshold:
+      type: object
+      properties:
+        value:
+          format: int32
+          type: integer
+        enabled:
+          type: boolean
+        inclusive:
+          type: boolean
     TransformationLog:
       description: Transformation Log
       required:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/alerting/ChangeDetection.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/alerting/ChangeDetection.java
@@ -2,21 +2,51 @@ package io.hyperfoil.tools.horreum.api.alerting;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 public class ChangeDetection {
+
+    /* This is another hack, it is based on io.hyperfoil.tools.horreum.changedetection.RelativeDifferenceChangeDetectionModel.config
+     * We should coordinate type information with that method but openapi needs statically typed classes and that method
+     * dynamically builds the ConditionConfig
+     */
+    public static class RelativeDifferenceDetection {
+        public String filter;//mean,min,max
+        public Integer window;//1
+        public Double threshold;//0.2
+        public Integer minPrevious;//1
+    }
+    public static class Threshold {
+        Integer value;
+        Boolean enabled;
+        Boolean inclusive;
+    }
+    public static class FixedThresholdDetection {
+        public Threshold min;
+        public Threshold max;
+    }
+
     @JsonProperty( required = true )
     public Integer id;
     @JsonProperty( required = true )
     public String model;
     @NotNull
     @JsonProperty( required = true )
-    public JsonNode config;
+    @Schema(type = SchemaType.OBJECT,
+        oneOf = {
+                ChangeDetection.RelativeDifferenceDetection.class,
+                ChangeDetection.FixedThresholdDetection.class
+        }
+    )
+    public ObjectNode config;
 
     public ChangeDetection() {
     }
 
-    public ChangeDetection(Integer id, String model, JsonNode config) {
+    public ChangeDetection(Integer id, String model, ObjectNode config) {
         this.id = id;
         this.model = model;
         this.config = config;

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Action.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Action.java
@@ -7,8 +7,32 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+
 
 public class Action {
+
+    public static class HttpAction {
+        public String url;
+    }
+    public static class GithubIssueCommentAction {
+        public String issueUrl;
+        public String owner;
+        public String repo;
+        public String issue;
+        public String formatter;
+    }
+    public static class GithubIssueCreateAction {
+        public String owner;
+        public String repo;
+        public String title;
+        public String formatter;
+    }
+    public static class Secret {
+        public String token;
+        public boolean modified;
+    }
+
     @JsonProperty( required = true )
     public Integer id;
     @NotNull
@@ -17,12 +41,26 @@ public class Action {
     @NotNull
     @JsonProperty( required = true )
     public String type;
+
     @NotNull
     @JsonProperty( required = true )
-    public JsonNode config;
+    @Schema(type = SchemaType.OBJECT,
+            oneOf = {
+                    Action.HttpAction.class,
+                    Action.GithubIssueCommentAction.class,
+                    Action.GithubIssueCreateAction.class
+            }
+    )
+    public ObjectNode config;
+
     @NotNull
     @JsonIgnore
-    public JsonNode secrets;
+    @Schema(type = SchemaType.OBJECT,
+            allOf = {
+                    Action.Secret.class
+            }
+    )
+    public ObjectNode secrets;
     @NotNull
     @JsonProperty( required = true )
     public Integer testId;
@@ -36,7 +74,7 @@ public class Action {
     public Action() {
     }
 
-    public Action(Integer id, String event, String type, JsonNode config, JsonNode secrets,
+    public Action(Integer id, String event, String type, ObjectNode config, ObjectNode secrets,
                   Integer testId, boolean active, boolean runAlways) {
         this.id = id;
         this.event = event;
@@ -49,7 +87,7 @@ public class Action {
     }
 
     @JsonProperty("secrets")
-    public void setSecrets(JsonNode secrets) {
+    public void setSecrets(ObjectNode secrets) {
         this.secrets = secrets;
     }
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/ChangeDetectionDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/ChangeDetectionDAO.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.horreum.entity.alerting;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,12 +37,18 @@ public class ChangeDetectionDAO extends PanacheEntityBase {
    public Integer id;
 
    @NotNull
-   public String model;
+   public String model;//current db options: [fixedThreshold, relativeDifference]
 
+   /*
+    * I see two basic shapes atm:
+    * model=relativeDifference: {"filter": "mean", "window": 1, "threshold": 0.2, "minPrevious": 5}
+    * model=fixedThreshold: {"max": {"value": null, "enabled": false, "inclusive": true}, "min": {"value": 95, "enabled": true, "inclusive": true}}
+    */
    @NotNull
    @Type(JsonBinaryType.class)
    @Column(columnDefinition = "jsonb")
-   public JsonNode config;
+   public ObjectNode config;
+
 
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "variable_id")

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/ActionDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/ActionDAO.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.horreum.entity.data;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
@@ -31,19 +32,34 @@ public class ActionDAO extends PanacheEntityBase {
    @Column(name = "event")
    public String event;
 
+   /* The type options were found in horreum-web/src/domain/actions/ActionComponentForm.tsx#L73
+    * http, github-issue-comment, github-issue-create
+    *
+    */
    @NotNull
    @Column(name = "type")
    public String type;
 
+
+   /*
+    * Notes on where I found the config options
+    * type=http: HttpActionUrlSelector.tsx : {url: string }
+    * type=github-issue-comment: { issueUrl: string|undefined, owner: string, repo: string, issue: string, formatter: string }
+    * type=github-issue-create: {owner: string, repo: string, title: string, formatter: string }
+    */
    @NotNull
    @Column(name = "config", columnDefinition = "jsonb")
    @Type(JsonBinaryType.class)
-   public JsonNode config;
+   public ObjectNode config;
 
+   /*
+    * horreum-web/src/domain/actions/ActionComponentForm.tsx#L278
+    * { token: string, modified: boolean } are the possible values of secret but I don't think modified gets persisted
+    */
    @NotNull
    @Column(name = "secrets", columnDefinition = "jsonb")
    @Type(JsonBinaryType.class)
-   public JsonNode secrets;
+   public ObjectNode secrets;
 
    @NotNull
    @Column(name = "test_id")
@@ -59,7 +75,7 @@ public class ActionDAO extends PanacheEntityBase {
 
    public ActionDAO() {
    }
-    public ActionDAO(Integer id, String event, String type, JsonNode config, JsonNode secrets,
+    public ActionDAO(Integer id, String event, String type, ObjectNode config, ObjectNode secrets,
                      Integer testId, boolean active, boolean runAlways) {
        this.id = id;
        this.event = event;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionServiceImpl.java
@@ -187,7 +187,7 @@ public class ActionServiceImpl implements ActionService {
       return action;
    }
 
-   public JsonNode ensureNotNull(JsonNode node) {
+   ObjectNode ensureNotNull(ObjectNode node) {
       return node == null || node.isNull() || node.isMissingNode() ? JsonNodeFactory.instance.objectNode() : node;
    }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
@@ -869,7 +869,7 @@ public class RunServiceTest extends BaseServiceTest {
          ChangeDetection changeDetection = new ChangeDetection();
          changeDetection.model = "relativeDifference";
 
-         changeDetection.config = mapper.readTree("{" +
+         changeDetection.config = (ObjectNode) mapper.readTree("{" +
                  "          \"window\": 1," +
                  "          \"filter\": \"mean\"," +
                  "          \"threshold\": 0.2," +

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -194,7 +194,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             ChangeDetection changeDetection = new ChangeDetection();
             changeDetection.model = "relativeDifference";
 
-            changeDetection.config = mapper.readTree("{" +
+            changeDetection.config = (ObjectNode) mapper.readTree("{" +
                     "          \"window\": 1," +
                     "          \"filter\": \"mean\"," +
                     "          \"threshold\": 0.2," +

--- a/horreum-web/src/domain/actions/ActionComponentForm.tsx
+++ b/horreum-web/src/domain/actions/ActionComponentForm.tsx
@@ -19,8 +19,7 @@ import {
 } from "@patternfly/react-core"
 import { HelpIcon } from "@patternfly/react-icons"
 import { ReactElement, useState } from "react"
-
-import { Action } from "../../api"
+import { Action, HttpAction as Http, GithubIssueCommentAction as GithubIssueComment, GithubIssueCreateAction as GithubIssueCreate} from "../../api"
 import EnumSelect from "../../components/EnumSelect"
 import HttpActionUrlSelector from "../../components/HttpActionUrlSelector"
 import { CHANGE_NEW, EXPERIMENT_RESULT_NEW } from "./reducers"
@@ -101,7 +100,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
             {props.action.type === "http" && (
                 <HttpActionUrlSelector
                     active={props.isTester}
-                    value={props.action.config?.url || ""}
+                    value={(props.action.config as Http).url || ""}
                     setValue={value => {
                         update({ config: { url: value } })
                     }}
@@ -123,7 +122,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                     name="issue"
                                     id="url"
                                     label="Use issue URL"
-                                    isChecked={props.action.config.issueUrl !== undefined}
+                                    isChecked={(props.action.config as GithubIssueComment).issueUrl !== undefined}
                                     onChange={(_event, checked) => updateConfig({ issueUrl: checked ? "" : undefined })}
                                 />
                             </FlexItem>
@@ -132,18 +131,18 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                     name="issue"
                                     id="components"
                                     label="Use owner/repo/issue"
-                                    isChecked={props.action.config.issueUrl === undefined}
+                                    isChecked={(props.action.config as GithubIssueComment).issueUrl === undefined}
                                     onChange={(_event, checked) => updateConfig({ issueUrl: checked ? undefined : "" })}
                                 />
                             </FlexItem>
                         </Flex>
                     </FormGroup>
 
-                    {props.action.config.issueUrl !== undefined ? (
+                    {(props.action.config as GithubIssueComment).issueUrl !== undefined ? (
                         <FormGroup label="Issue URL" labelIcon={<ExpressionHelp {...props} />} fieldId="issueUrl">
                             <TextInput
                                 id="issueUrl"
-                                value={props.action.config.issueUrl}
+                                value={(props.action.config as GithubIssueComment).issueUrl}
                                 onChange={(_event, issueUrl) => update({ config: { ...props.action.config, issueUrl } })}
                             />
                         </FormGroup>
@@ -152,21 +151,21 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                             <FormGroup label="Owner" labelIcon={<ExpressionHelp {...props} />} fieldId="owner">
                                 <TextInput
                                     id="owner"
-                                    value={props.action.config.owner}
+                                    value={(props.action.config as GithubIssueComment).owner}
                                     onChange={(_event, owner) => updateConfig({ owner })}
                                 />
                             </FormGroup>
                             <FormGroup label="Repository" labelIcon={<ExpressionHelp {...props} />} fieldId="repo">
                                 <TextInput
                                     id="repo"
-                                    value={props.action.config.repo}
+                                    value={(props.action.config as GithubIssueComment).repo}
                                     onChange={(_event, repo) => updateConfig({ repo })}
                                 />
                             </FormGroup>
                             <FormGroup label="Issue" labelIcon={<ExpressionHelp {...props} />} fieldId="issue">
                                 <TextInput
                                     id="issue"
-                                    value={props.action.config.issue}
+                                    value={(props.action.config as GithubIssueComment).issue}
                                     onChange={(_event, issue) => updateConfig({ issue })}
                                 />
                             </FormGroup>
@@ -179,7 +178,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                     ? { experimentResultToMarkdown: "Experiment result to Markdown" }
                                     : {}
                             }
-                            selected={props.action.config.formatter}
+                            selected={(props.action.config as GithubIssueComment).formatter}
                             onSelect={formatter => updateConfig({ formatter })}
                         />
                     </FormGroup>
@@ -195,21 +194,21 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                     <FormGroup label="Owner" labelIcon={<ExpressionHelp {...props} />} fieldId="owner">
                         <TextInput
                             id="owner"
-                            value={props.action.config.owner}
+                            value={(props.action.config as GithubIssueCreate).owner}
                             onChange={(_event, owner) => updateConfig({ owner })}
                         />
                     </FormGroup>
                     <FormGroup label="Repository" labelIcon={<ExpressionHelp {...props} />} fieldId="repo">
                         <TextInput
                             id="repo"
-                            value={props.action.config.repo}
+                            value={(props.action.config as GithubIssueCreate).repo}
                             onChange={(_event, repo) => updateConfig({ repo })}
                         />
                     </FormGroup>
                     <FormGroup label="Title" labelIcon={<ExpressionHelp {...props} />} fieldId="title">
                         <TextInput
                             id="title"
-                            value={props.action.config.title}
+                            value={(props.action.config as GithubIssueCreate).title}
                             onChange={(_event, title) => updateConfig({ title })}
                         />
                     </FormGroup>
@@ -218,7 +217,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                             options={
                                 props.action.event === CHANGE_NEW ? { changeToMarkdown: "Change to Markdown" } : {}
                             }
-                            selected={props.action.config.formatter}
+                            selected={(props.action.config as GithubIssueCreate).formatter}
                             onSelect={formatter => updateConfig({ formatter })}
                         />
                     </FormGroup>

--- a/horreum-web/src/domain/tests/ActionsUI.tsx
+++ b/horreum-web/src/domain/tests/ActionsUI.tsx
@@ -13,7 +13,7 @@ import {
 } from "@patternfly/react-core"
 
 import { useTester } from "../../auth"
-import {Action, getTestActions, updateActions} from "../../api"
+import {Action, getTestActions, updateActions, HttpAction as Http} from "../../api"
 import { TabFunctionsRef } from "../../components/SavedTabs"
 import { testEventTypes } from "../actions/reducers"
 import ActionComponentForm from "../actions/ActionComponentForm"
@@ -35,7 +35,7 @@ export default function ActionsUI({ testId, testOwner, funcsRef, onModified }: A
     const [actions, setActions] = useState<Action[]>([])
     const [logModalOpen, setLogModalOpen] = useState(false)
     const isTester = useTester(testOwner)
-    const hasDuplicates = new Set(actions.map(h => h.event + "_" + h.config.url)).size !== actions.length
+    const hasDuplicates = new Set(actions.map(h => h.event + "_" + (h.config as Http).url)).size !== actions.length
 
     useEffect(() => {
         if (!testId || !isTester) {

--- a/horreum-web/src/domain/tests/VariableForm.tsx
+++ b/horreum-web/src/domain/tests/VariableForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, ReactNode } from "react"
 
-import {ChangeDetection, ConditionConfig, Variable} from "../../api"
+import {ChangeDetection, ConditionConfig, Variable, } from "../../api"
 
 import {
 	ActionList,
@@ -227,9 +227,12 @@ export default function VariableForm(props: VariableFormProps) {
                         <ConditionComponent
                             {...comp}
                             isTester={props.isTester}
+                            //we are using ignore because we don't know the model type to cast or declare the type info
+                            // @ts-ignore
                             value={changeDetection.config[comp.name]}
                             onChange={value => {
                                 const copy = { ...changeDetection }
+                                // @ts-ignore
                                 copy.config[comp.name] = value
                                 update(copy)
                             }}


### PR DESCRIPTION
This gets us to only 2 python client generation warnings, both about `text/plain` body content in a `post`

```
#> openapi-python-client generate --path /tmp/openapi.yaml
Generating horreum-rest-api-client
Warning(s) encountered while generating. Client was generated, but some pieces may be missing

WARNING parsing POST /api/run/{id}/description within run. Endpoint will not be generated.

Unsupported content type text/plain


WARNING parsing POST /api/run/{id}/schema within run. Endpoint will not be generated.

Unsupported content type text/plain


If you believe this was a mistake or this tool is missing a feature you need, please open an issue at https://github.com/openapi-generators/openapi-python-client/issues/new/choose
```
The issue is already opened with `openapi-python-client` 
https://github.com/openapi-generators/openapi-python-client/discussions/821