### PR TITLE
[0.11.x] fix default view not rendering additional components on load : Fixes #529

### DIFF
--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -148,7 +148,6 @@ export default function TestDatasets() {
     const [direction, setDirection] = useState("Descending")
     const [viewId, setViewId] = useState<number>()
     const pagination = useMemo(() => ({ page, perPage, sort, direction }), [page, perPage, sort, direction])
-
     const [loading, setLoading] = useState(false)
     const [datasets, setDatasets] = useState<DatasetList>()
     const [comparedDatasets, setComparedDatasets] = useState<DatasetSummary[]>()
@@ -156,7 +155,6 @@ export default function TestDatasets() {
     const token = useSelector(tokenSelector)
 
     const [views, setViews] = useState<View[]>([])
-
     useEffect(() => {
         fetchTest(testIdInt, alerting)
             .then(setTest)
@@ -225,8 +223,7 @@ export default function TestDatasets() {
             })
         })
         return allColumns
-    }, [test, token, comparedDatasets, viewId])
-
+    }, [test, token, comparedDatasets, viewId, views])
     const flattenLabelValues = (labelValues: Array<ExportedLabelValues>) => {
         const resultArr : any = [];
         labelValues.forEach( (labelValue) => {


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1318


Test Datasets would not correctly show any custom View Components on the Default view until the user selected `Default` from the `ViewSelector`.

closes #529