### PR TITLE
Added python and go code generation as part of the api build, fixes #1278

### DIFF
--- a/horreum-api/pom.xml
+++ b/horreum-api/pom.xml
@@ -117,6 +117,7 @@
                 <version>7.2.0</version>
                 <executions>
                     <execution>
+                        <id>typescript</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>generate</goal>
@@ -139,6 +140,45 @@
                                 <typescriptThreePlus>true</typescriptThreePlus>
                                 <prefixParameterInterfaces>true</prefixParameterInterfaces>
                             </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>python</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.build.directory}/generated/openapi.yaml</inputSpec>
+                            <output>${project.build.directory}/generated/python</output>
+                            <generatorName>python</generatorName>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <globalProperties>
+                                <skipFormModel>false</skipFormModel>
+                            </globalProperties>
+                            <modelNameMappings>
+                                <modelNameMapping>Tag=Label</modelNameMapping>
+                            </modelNameMappings>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>go</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.build.directory}/generated/openapi.yaml</inputSpec>
+                            <output>${project.build.directory}/generated/go</output>
+                            <generatorName>go</generatorName>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <typeMappings>Array=any</typeMappings>
+                            <globalProperties>
+                                <skipFormModel>false</skipFormModel>
+                            </globalProperties>
+                            <modelNameMappings>
+                                <modelNameMapping>Tag=Label</modelNameMapping>
+                            </modelNameMappings>
                         </configuration>
                     </execution>
                 </executions>
@@ -167,7 +207,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
The generated  code is located in horreum-api/target/generated.
The generation itself does not add much to the build time, still not sure if we should run it on every build in the future, but to avoid breaking the clients (again) I think we should have it enabled for now.
