### PR TITLE
Add Change Detection Config Discriminators: Fixes #1380

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -2372,8 +2372,19 @@ components:
         config:
           type: object
           oneOf:
-          - $ref: '#/components/schemas/RelativeDifferenceDetection'
-          - $ref: '#/components/schemas/FixedThresholdDetection'
+          - $ref: '#/components/schemas/RelativeDifferenceDetectionConfig'
+          - $ref: '#/components/schemas/FixedThresholdDetectionConfig'
+          discriminator:
+            propertyName: model
+            mapping:
+              relativeDifference: '#/components/schemas/RelativeDifferenceDetectionConfig'
+              fixedThreshold: '#/components/schemas/FixedThresholdDetectionConfig'
+    ChangeDetectionModelType:
+      description: Type of Change Detection Model
+      enum:
+      - FIXED_THRESHOLD
+      - RELATIVE_DIFFERENCE
+      type: string
     ComparisonResult:
       description: Result of performing a Comparison
       type: object
@@ -2961,13 +2972,45 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FingerprintValue'
-    FixedThresholdDetection:
+    FixThresholdConfig:
+      required:
+      - value
+      - enabled
+      - inclusive
       type: object
       properties:
+        value:
+          description: Threshold Value
+          type: integer
+          example: 95
+        enabled:
+          description: Threshold enabled/disabled
+          type: boolean
+          example: true
+        inclusive:
+          description: Is threshold inclusive of defined value?
+          type: boolean
+          example: false
+    FixedThresholdDetectionConfig:
+      required:
+      - builtIn
+      - min
+      - max
+      type: object
+      properties:
+        builtIn:
+          description: Built In
+          type: boolean
         min:
-          $ref: '#/components/schemas/Threshold'
+          description: Lower bound for acceptable datapoint values
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/FixThresholdConfig'
         max:
-          $ref: '#/components/schemas/Threshold'
+          description: Upper bound for acceptable datapoint values
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/FixThresholdConfig'
     GithubIssueCommentAction:
       type: object
       properties:
@@ -3348,20 +3391,39 @@ components:
           description: Total number of generated datasets
           type: integer
           example: 186
-    RelativeDifferenceDetection:
+    RelativeDifferenceDetectionConfig:
+      required:
+      - builtIn
+      - filter
+      - window
+      - threshold
+      - minPrevious
       type: object
       properties:
+        builtIn:
+          description: Built In
+          type: boolean
         filter:
+          description: Relative Difference Detection filter
           type: string
+          example: mean
         window:
           format: int32
+          description: Number of most recent datapoints used for aggregating the value
+            for comparison.
           type: integer
+          example: 5
         threshold:
           format: double
+          description: Maximum difference between the aggregated value of last <window>
+            datapoints and the mean of preceding values.
           type: number
+          example: 0.2
         minPrevious:
           format: int32
+          description: Minimal number of preceding datapoints
           type: integer
+          example: 5
     ReportComponent:
       description: Report Component
       required:
@@ -4322,16 +4384,6 @@ components:
           description: Token description
           type: string
           example: my reporting service token
-    Threshold:
-      type: object
-      properties:
-        value:
-          format: int32
-          type: integer
-        enabled:
-          type: boolean
-        inclusive:
-          type: boolean
     TransformationLog:
       description: Transformation Log
       required:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/alerting/ChangeDetection.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/alerting/ChangeDetection.java
@@ -1,33 +1,16 @@
 package io.hyperfoil.tools.horreum.api.alerting;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.FixedThresholdDetectionConfig;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.RelativeDifferenceDetectionConfig;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 public class ChangeDetection {
 
-    /* This is another hack, it is based on io.hyperfoil.tools.horreum.changedetection.RelativeDifferenceChangeDetectionModel.config
-     * We should coordinate type information with that method but openapi needs statically typed classes and that method
-     * dynamically builds the ConditionConfig
-     */
-    public static class RelativeDifferenceDetection {
-        public String filter;//mean,min,max
-        public Integer window;//1
-        public Double threshold;//0.2
-        public Integer minPrevious;//1
-    }
-    public static class Threshold {
-        Integer value;
-        Boolean enabled;
-        Boolean inclusive;
-    }
-    public static class FixedThresholdDetection {
-        public Threshold min;
-        public Threshold max;
-    }
 
     @JsonProperty( required = true )
     public Integer id;
@@ -35,10 +18,14 @@ public class ChangeDetection {
     public String model;
     @NotNull
     @JsonProperty( required = true )
-    @Schema(type = SchemaType.OBJECT,
+    @Schema(type = SchemaType.OBJECT, discriminatorProperty = "model",
+            discriminatorMapping = {
+                    @DiscriminatorMapping(schema = RelativeDifferenceDetectionConfig.class, value = "relativeDifference"),
+                    @DiscriminatorMapping(schema = FixedThresholdDetectionConfig.class, value = "fixedThreshold")
+            },
         oneOf = {
-                ChangeDetection.RelativeDifferenceDetection.class,
-                ChangeDetection.FixedThresholdDetection.class
+                RelativeDifferenceDetectionConfig.class,
+                FixedThresholdDetectionConfig.class
         }
     )
     public ObjectNode config;

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/ChangeDetectionModelType.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/ChangeDetectionModelType.java
@@ -1,0 +1,35 @@
+package io.hyperfoil.tools.horreum.api.data.changeDetection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.hyperfoil.tools.horreum.api.data.datastore.BaseChangeDetectionConfig;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Schema(type = SchemaType.STRING, required = true,
+        description = "Type of Change Detection Model")
+public enum ChangeDetectionModelType {
+    FIXED_THRESHOLD("fixedThreshold", new TypeReference<FixedThresholdDetectionConfig>() {}),
+    RELATIVE_DIFFERENCE ("relativeDifference", new TypeReference<RelativeDifferenceDetectionConfig>() {});
+    private static final ChangeDetectionModelType[] VALUES = values();
+
+    private final String name;
+    private final TypeReference<? extends BaseChangeDetectionConfig> typeReference;
+
+    private <T extends BaseChangeDetectionConfig> ChangeDetectionModelType(String name, TypeReference<T> typeReference) {
+        this.typeReference = typeReference;
+        this.name = name;
+    }
+
+    public <T extends BaseChangeDetectionConfig> TypeReference<T> getTypeReference(){
+        return (TypeReference<T>) typeReference;
+    }
+
+    @JsonCreator
+    public static ChangeDetectionModelType fromString(String str) {
+        return Arrays.stream(VALUES).filter(v -> v.name.equals(str)).findAny().orElseThrow(() -> new IllegalArgumentException("Unknown model: " + str));
+    }
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/FixThresholdConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/FixThresholdConfig.java
@@ -1,0 +1,23 @@
+package io.hyperfoil.tools.horreum.api.data.changeDetection;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/*
+ * Concrete configuration type for io.hyperfoil.tools.horreum.changedetection.FixedThresholdModel
+ */
+public class FixThresholdConfig {
+    @Schema(type = SchemaType.STRING, required = true, example = "fixedThreshold",
+            description = "model descriminator")
+    public static final String model = "fixedThreshold";
+    @Schema(type = SchemaType.INTEGER, required = true, example = "95",
+            description = "Threshold Value")
+    public Double value;
+    @Schema(type = SchemaType.BOOLEAN, required = true, example = "true",
+            description = "Threshold enabled/disabled")
+    public Boolean enabled;
+    @Schema(type = SchemaType.BOOLEAN, required = true, example = "false",
+            description = "Is threshold inclusive of defined value?")
+    public Boolean inclusive;
+
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/FixedThresholdDetectionConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/FixedThresholdDetectionConfig.java
@@ -1,0 +1,19 @@
+package io.hyperfoil.tools.horreum.api.data.changeDetection;
+
+import io.hyperfoil.tools.horreum.api.data.datastore.BaseChangeDetectionConfig;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public class FixedThresholdDetectionConfig extends BaseChangeDetectionConfig {
+    @Schema(type = SchemaType.OBJECT, required = true,
+            description = "Lower bound for acceptable datapoint values")
+    public FixThresholdConfig min;
+    @Schema(type = SchemaType.OBJECT, required = true,
+            description = "Upper bound for acceptable datapoint values")
+    public FixThresholdConfig max;
+
+    @Override
+    public String validateConfig() {
+        return null;
+    }
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/RelativeDifferenceDetectionConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/changeDetection/RelativeDifferenceDetectionConfig.java
@@ -1,0 +1,31 @@
+package io.hyperfoil.tools.horreum.api.data.changeDetection;
+
+import io.hyperfoil.tools.horreum.api.data.datastore.BaseChangeDetectionConfig;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/*
+ * Concrete configuration type for io.hyperfoil.tools.horreum.changedetection.RelativeDifferenceChangeDetectionModel
+ */
+public class RelativeDifferenceDetectionConfig  extends BaseChangeDetectionConfig {
+    @Schema(type = SchemaType.STRING, required = true, example = "relativeDifference",
+            description = "model descriminator")
+    public static final String model = "relativeDifference";
+    @Schema(type = SchemaType.STRING, required = true, example = "mean",
+            description = "Relative Difference Detection filter")
+    public String filter;
+    @Schema(type = SchemaType.INTEGER, required = true, example = "5",
+            description = "Number of most recent datapoints used for aggregating the value for comparison.")
+    public Integer window;
+    @Schema(type = SchemaType.NUMBER, required = true, example = "0.2",
+            description = "Maximum difference between the aggregated value of last <window> datapoints and the mean of preceding values.")
+    public Double threshold;
+    @Schema(type = SchemaType.INTEGER, required = true, example = "5",
+            description = "Minimal number of preceding datapoints")
+    public Integer minPrevious;
+
+    @Override
+    public String validateConfig() {
+        return null;
+    }
+}

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/BaseChangeDetectionConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/BaseChangeDetectionConfig.java
@@ -1,0 +1,20 @@
+package io.hyperfoil.tools.horreum.api.data.datastore;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public abstract class BaseChangeDetectionConfig {
+
+    @Schema(type = SchemaType.BOOLEAN, required = true,
+            description = "Built In")
+    public Boolean builtIn = true;
+
+    public BaseChangeDetectionConfig() {
+    }
+
+    public BaseChangeDetectionConfig(Boolean builtIn) {
+        this.builtIn = builtIn;
+    }
+
+    public abstract String validateConfig();
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/ChangeDetectionModel.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/ChangeDetectionModel.java
@@ -1,17 +1,18 @@
 package io.hyperfoil.tools.horreum.changedetection;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
 import io.hyperfoil.tools.horreum.entity.alerting.ChangeDAO;
 import io.hyperfoil.tools.horreum.entity.alerting.DataPointDAO;
 
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 public interface ChangeDetectionModel {
     ConditionConfig config();
 
+    ChangeDetectionModelType type();
     void analyze(List<DataPointDAO> dataPoints, JsonNode configuration, Consumer<ChangeDAO> changeConsumer);
 
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/ChangeDetectionModelResolver.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/ChangeDetectionModelResolver.java
@@ -1,0 +1,32 @@
+package io.hyperfoil.tools.horreum.changedetection;
+
+import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
+import io.quarkus.arc.All;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class ChangeDetectionModelResolver {
+    @Inject
+    @All
+    List<ChangeDetectionModel> changeDetectionModels;
+
+    public ChangeDetectionModel getModel(ChangeDetectionModelType type){
+        return changeDetectionModels.stream()
+                .filter( model -> model.type().equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Unknown change detection model type: " + type));
+    }
+
+    public Map<String, ChangeDetectionModel> getModels(){
+        return changeDetectionModels.stream()
+                .collect(Collectors.toMap(model -> ((ChangeDetectionModel)model).type().name(), Function.identity()));
+    }
+
+
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/FixedThresholdModel.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/FixedThresholdModel.java
@@ -1,56 +1,75 @@
 package io.hyperfoil.tools.horreum.changedetection;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.FixedThresholdDetectionConfig;
+import io.hyperfoil.tools.horreum.entity.alerting.ChangeDAO;
+import io.hyperfoil.tools.horreum.entity.alerting.DataPointDAO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.jboss.logging.Logger;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
-import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
-import io.hyperfoil.tools.horreum.entity.alerting.ChangeDAO;
-import io.hyperfoil.tools.horreum.entity.alerting.DataPointDAO;
-
+@ApplicationScoped
 public class FixedThresholdModel implements ChangeDetectionModel {
    private static final Logger log = Logger.getLogger(FixedThresholdModel.class);
    public static final String NAME = "fixedThreshold";
 
+   @Inject
+   ObjectMapper mapper;
+
    @Override
    public ConditionConfig config() {
-      return new ConditionConfig(NAME, "Fixed Threshold", "This model checks that the datapoint value is within fixed bounds.")
-            .addComponent("min", new ConditionConfig.NumberBound(), "Minimum", "Lower bound for acceptable datapoint values.")
-            .addComponent("max", new ConditionConfig.NumberBound(), "Maximum", "Upper bound for acceptable datapoint values.");
+      ConditionConfig conditionConfig = new ConditionConfig(NAME, "Fixed Threshold", "This model checks that the datapoint value is within fixed bounds.")
+              .addComponent("min", new ConditionConfig.NumberBound(), "Minimum", "Lower bound for acceptable datapoint values.")
+              .addComponent("max", new ConditionConfig.NumberBound(), "Maximum", "Upper bound for acceptable datapoint values.");
+      conditionConfig.defaults.put("model", new TextNode(NAME));
+
+      return conditionConfig;
+   }
+
+   @Override
+   public ChangeDetectionModelType type() {
+      return ChangeDetectionModelType.FIXED_THRESHOLD;
    }
 
    @Override
    public void analyze(List<DataPointDAO> dataPoints, JsonNode configuration, Consumer<ChangeDAO> changeConsumer) {
       DataPointDAO dp = dataPoints.get(0);
 
-      JsonNode min = configuration.path("min");
-      boolean minEnabled = min.path("enabled").asBoolean();
-      boolean minInclusive = min.path("inclusive").asBoolean();
-      double minValue = min.path("value").asDouble();
-      JsonNode max = configuration.path("max");
-      boolean maxEnabled = max.path("enabled").asBoolean();
-      boolean maxInclusive = max.path("inclusive").asBoolean();
-      double maxValue = max.path("value").asDouble();
+      try {
+         FixedThresholdDetectionConfig config = mapper.treeToValue(configuration, FixedThresholdDetectionConfig.class);
 
-      if (minEnabled) {
-         if ((!minInclusive && dp.value <= minValue) || dp.value < minValue) {
-            ChangeDAO c = ChangeDAO.fromDatapoint(dp);
-            c.description = String.format("%f is below lower bound %f (%s)", dp.value, minValue, minInclusive ? "inclusive" : "exclusive");
-            log.debug(c.description);
-            changeConsumer.accept(c);
-            return;
+         if (config.min.enabled) {
+            if ((!config.min.inclusive && dp.value <= config.min.value) || dp.value < config.min.value) {
+               ChangeDAO c = ChangeDAO.fromDatapoint(dp);
+               c.description = String.format("%f is below lower bound %f (%s)", dp.value, config.min.value, config.min.inclusive ? "inclusive" : "exclusive");
+               log.debug(c.description);
+               changeConsumer.accept(c);
+               return;
+            }
          }
-      }
-      if (maxEnabled) {
-         if ((!maxInclusive && dp.value >= maxValue) || dp.value > maxValue) {
-            ChangeDAO c = ChangeDAO.fromDatapoint(dp);
-            c.description = String.format("%f is above upper bound %f (%s)", dp.value, maxValue, maxInclusive ? "inclusive" : "exclusive");
-            log.debug(c.description);
-            changeConsumer.accept(c);
+         if (config.max.enabled) {
+            if ((!config.max.inclusive && dp.value >= config.max.value) || dp.value > config.max.value) {
+               ChangeDAO c = ChangeDAO.fromDatapoint(dp);
+               c.description = String.format("%f is above upper bound %f (%s)", dp.value, config.max.value, config.max.inclusive ? "inclusive" : "exclusive");
+               log.debug(c.description);
+               changeConsumer.accept(c);
+            }
          }
+
+      } catch (JsonProcessingException e) {
+         log.errorf("Failed to parse configuration for variable %d", dp.variable.id, e);
+         throw new RuntimeException(e);
       }
+
    }
+
+
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/RelativeDifferenceChangeDetectionModel.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/changedetection/RelativeDifferenceChangeDetectionModel.java
@@ -1,109 +1,132 @@
 package io.hyperfoil.tools.horreum.changedetection;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
+import io.hyperfoil.tools.horreum.api.data.changeDetection.RelativeDifferenceDetectionConfig;
 import io.hyperfoil.tools.horreum.entity.alerting.ChangeDAO;
 import io.hyperfoil.tools.horreum.entity.alerting.DataPointDAO;
-
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.jboss.logging.Logger;
 
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
+@ApplicationScoped
 public class RelativeDifferenceChangeDetectionModel implements ChangeDetectionModel {
 
     public static final String NAME = "relativeDifference";
     private static final Logger log = Logger.getLogger(RelativeDifferenceChangeDetectionModel.class);
 
+    @Inject
+    ObjectMapper mapper;
+
     @Override
     public ConditionConfig config() {
-        return new ConditionConfig(NAME, "Relative difference of means",
-            "This is a generic filter that splits the dataset into two subsets: the 'floating window' " +
-                  "and preceding datapoints. It calculates the mean of preceding datapoints and applies " +
-                  "the 'filter' function on the window of last datapoints; it compares these two values and " +
-                  "if the relative difference is greater than the threshold the change is emitted.\n" +
-                  "In case that window is set to 1 this becomes a simple comparison of the most recent datapoint " +
-                  "against the previous average value.")
-              .addComponent("threshold", new ConditionConfig.LogSliderComponent(100, 1, 1000, 0.2, false, "%"),
-                    "Threshold for relative difference",
-                    "Maximum difference between the aggregated value of last <window> datapoints and the mean of preceding values."
-              )
-              .addComponent("window", new ConditionConfig.LogSliderComponent(1, 1, 1000, 1, true, " "),
-                    "Minimum window",
-                    "Number of most recent datapoints used for aggregating the value for comparison.")
-              .addComponent("minPrevious", new ConditionConfig.LogSliderComponent(1, 1, 1000, 5, true, " "),
-                    "Minimal number of preceding datapoints",
-                    "Number of datapoints preceding the aggregation window.")
-              .addComponent("filter", new ConditionConfig.EnumComponent("mean").add("mean", "Mean value").add("min", "Minimum value").add("max", "Maximum value"),
-                    "Aggregation function for the floating window",
-                    "Function used to aggregate datapoints from the floating window.");
+        ConditionConfig conditionConfig = new ConditionConfig(NAME, "Relative difference of means",
+                "This is a generic filter that splits the dataset into two subsets: the 'floating window' " +
+                        "and preceding datapoints. It calculates the mean of preceding datapoints and applies " +
+                        "the 'filter' function on the window of last datapoints; it compares these two values and " +
+                        "if the relative difference is greater than the threshold the change is emitted.\n" +
+                        "In case that window is set to 1 this becomes a simple comparison of the most recent datapoint " +
+                        "against the previous average value.")
+                .addComponent("threshold", new ConditionConfig.LogSliderComponent(100, 1, 1000, 0.2, false, "%"),
+                        "Threshold for relative difference",
+                        "Maximum difference between the aggregated value of last <window> datapoints and the mean of preceding values."
+                )
+                .addComponent("window", new ConditionConfig.LogSliderComponent(1, 1, 1000, 1, true, " "),
+                        "Minimum window",
+                        "Number of most recent datapoints used for aggregating the value for comparison.")
+                .addComponent("minPrevious", new ConditionConfig.LogSliderComponent(1, 1, 1000, 5, true, " "),
+                        "Minimal number of preceding datapoints",
+                        "Number of datapoints preceding the aggregation window.")
+                .addComponent("filter", new ConditionConfig.EnumComponent("mean").add("mean", "Mean value").add("min", "Minimum value").add("max", "Maximum value"),
+                        "Aggregation function for the floating window",
+                        "Function used to aggregate datapoints from the floating window.");
+        conditionConfig.defaults.put("model", new TextNode(NAME));
+        return conditionConfig;
+    }
+
+    @Override
+    public ChangeDetectionModelType type() {
+        return ChangeDetectionModelType.RELATIVE_DIFFERENCE;
     }
 
     @Override
     public void analyze(List<DataPointDAO> dataPoints, JsonNode configuration, Consumer<ChangeDAO> changeConsumer) {
         DataPointDAO dataPoint = dataPoints.get(0);
 
-        double threshold = Math.max(0, configuration.get("threshold").asDouble());
-        int window = Math.max(1, configuration.get("window").asInt());
-        int minPrevious = Math.max(window, configuration.get("minPrevious").asInt());
-        String filter = configuration.get("filter").asText();
+        try {
+            RelativeDifferenceDetectionConfig config = mapper.treeToValue(configuration, RelativeDifferenceDetectionConfig.class);
 
-        if (dataPoints.size() < minPrevious + window) {
-            log.debugf("Too few (%d) previous datapoints for variable %d, skipping analysis", dataPoints.size() - window, dataPoint.variable.id);
-            return;
-        }
-        SummaryStatistics previousStats = new SummaryStatistics();
-        dataPoints.stream().skip(window).mapToDouble(dp -> dp.value).forEach(previousStats::addValue);
+            int window = Math.max(1, config.window);
+            int minPrevious = Math.max(window, config.minPrevious);
 
-        double filteredValue;
-        switch (filter) {
-            case "min":
-                //noinspection OptionalGetWithoutIsPresent
-                filteredValue = dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).min().getAsDouble();
-                break;
-            case "max":
-                //noinspection OptionalGetWithoutIsPresent
-                filteredValue = dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).max().getAsDouble();
-                break;
-            case "mean":
-                SummaryStatistics windowStats = new SummaryStatistics();
-                dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).forEach(windowStats::addValue);
-                filteredValue = windowStats.getMean();
-                break;
-            default:
-                log.errorf("Unsupported option 'filter'='%s' for variable %d, skipping analysis.", filter, dataPoint.variable.id);
+            if (dataPoints.size() < minPrevious + window) {
+                log.debugf("Too few (%d) previous datapoints for variable %d, skipping analysis", dataPoints.size() - window, dataPoint.variable.id);
                 return;
-        }
-
-        double ratio = filteredValue / previousStats.getMean();
-        log.tracef("Previous mean %f, filtered value %f, ratio %f", previousStats.getMean(), filteredValue, ratio);
-        if (ratio < 1 - threshold || ratio > 1 + threshold) {
-            DataPointDAO dp = null;
-            // We cannot know which datapoint is first with the regression; as a heuristic approach
-            // we'll select first datapoint with value lower than mean (if this is a drop, e.g. throughput)
-            // or above the mean (if this is an increase, e.g. memory usage).
-            for (int i = window - 1; i >= 0; --i) {
-                dp = dataPoints.get(i);
-                if (ratio < 1 && dp.value < previousStats.getMean()) {
-                    break;
-                } else if (ratio > 1 && dp.value > previousStats.getMean()) {
-                    break;
-                }
             }
-            assert dp != null;
-            ChangeDAO change = ChangeDAO.fromDatapoint(dp);
-            DataPointDAO prevDataPoint = dataPoints.get(window - 1);
-            DataPointDAO lastDataPoint = dataPoints.get(0);
-            change.description = String.format("Datasets %d/%d (%s) - %d/%d (%s): %s %f, previous mean %f (stddev %f), relative change %.2f%%",
-                    prevDataPoint.dataset.run.id, prevDataPoint.dataset.ordinal, prevDataPoint.timestamp,
-                    lastDataPoint.dataset.run.id, lastDataPoint.dataset.ordinal, lastDataPoint.timestamp,
-                    filter, filteredValue, previousStats.getMean(), previousStats.getStandardDeviation(), 100 * (ratio - 1));
+            SummaryStatistics previousStats = new SummaryStatistics();
+            dataPoints.stream().skip(window).mapToDouble(dp -> dp.value).forEach(previousStats::addValue);
 
-            log.debug(change.description);
-            changeConsumer.accept(change);
+            double filteredValue;
+            switch (config.filter) {
+                case "min":
+                    //noinspection OptionalGetWithoutIsPresent
+                    filteredValue = dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).min().getAsDouble();
+                    break;
+                case "max":
+                    //noinspection OptionalGetWithoutIsPresent
+                    filteredValue = dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).max().getAsDouble();
+                    break;
+                case "mean":
+                    SummaryStatistics windowStats = new SummaryStatistics();
+                    dataPoints.stream().limit(window).mapToDouble(dp -> dp.value).forEach(windowStats::addValue);
+                    filteredValue = windowStats.getMean();
+                    break;
+                default:
+                    log.errorf("Unsupported option 'filter'='%s' for variable %d, skipping analysis.", config.filter, dataPoint.variable.id);
+                    return;
+            }
+
+            double ratio = filteredValue / previousStats.getMean();
+            log.tracef("Previous mean %f, filtered value %f, ratio %f", previousStats.getMean(), filteredValue, ratio);
+            if (ratio < 1 - config.threshold || ratio > 1 + config.threshold) {
+                DataPointDAO dp = null;
+                // We cannot know which datapoint is first with the regression; as a heuristic approach
+                // we'll select first datapoint with value lower than mean (if this is a drop, e.g. throughput)
+                // or above the mean (if this is an increase, e.g. memory usage).
+                for (int i = window - 1; i >= 0; --i) {
+                    dp = dataPoints.get(i);
+                    if (ratio < 1 && dp.value < previousStats.getMean()) {
+                        break;
+                    } else if (ratio > 1 && dp.value > previousStats.getMean()) {
+                        break;
+                    }
+                }
+                assert dp != null;
+                ChangeDAO change = ChangeDAO.fromDatapoint(dp);
+                DataPointDAO prevDataPoint = dataPoints.get(window - 1);
+                DataPointDAO lastDataPoint = dataPoints.get(0);
+                change.description = String.format("Datasets %d/%d (%s) - %d/%d (%s): %s %f, previous mean %f (stddev %f), relative change %.2f%%",
+                        prevDataPoint.dataset.run.id, prevDataPoint.dataset.ordinal, prevDataPoint.timestamp,
+                        lastDataPoint.dataset.run.id, lastDataPoint.dataset.ordinal, lastDataPoint.timestamp,
+                        config.filter, filteredValue, previousStats.getMean(), previousStats.getStandardDeviation(), 100 * (ratio - 1));
+
+                log.debug(change.description);
+                changeConsumer.accept(change);
+            }
+
+        } catch (JsonProcessingException e) {
+            log.errorf("Failed to parse configuration for variable %d", dataPoint.variable.id, e);
+            throw new RuntimeException(e);
         }
+
 
     }
 }

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4484,4 +4484,13 @@
             CREATE POLICY userinfo_roles_rw ON userinfo_roles FOR ALL USING (has_role(username));
         </sql>
     </changeSet>
+    <changeSet id="119" author="johara">
+        <validCheckSum>ANY</validCheckSum>
+        <sql>
+            UPDATE changedetection
+            SET config=subquery.newConfig
+                FROM (select id as newID,  jsonb_set(config, '{model}', to_jsonb(changedetection.model::text), true) as newConfig from changedetection) AS subquery
+            WHERE changedetection.id=subquery.newID;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/horreum-web/package-lock.json
+++ b/horreum-web/package-lock.json
@@ -857,9 +857,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.4.tgz",
+      "integrity": "sha512-Oud2QPM5dHviZNn4y/WhhYKSXksv+1xLEIsNrAbGcFzUN3ubqWRFT5gwPchNc5NuzILOU4tPBDTZ4VwhL8Y7cw==",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -891,9 +891,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
-      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.23.tgz",
+      "integrity": "sha512-9/4foRoUKp8s96tSkh8DlAAc5A0Ty8vLXld+l9gjKKY6ckwI8G15f0hskGmuLZu78ZlGa1vtsfOa+lnB4vG6Jg==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1395,9 +1395,9 @@
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -2168,9 +2168,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.680",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.680.tgz",
-      "integrity": "sha512-4nToZ5jlPO14W82NkF32wyjhYqQByVaDmLy4J2/tYcAbJfgO2TKJC780Az1V13gzq4l73CJ0yuyalpXvxXXD9A=="
+      "version": "1.4.681",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.681.tgz",
+      "integrity": "sha512-1PpuqJUFWoXZ1E54m8bsLPVYwIVCRzvaL+n5cjigGga4z854abDnFRc+cTa2th4S79kyGqya/1xoR7h+Y5G5lg=="
     },
     "node_modules/entities": {
       "version": "1.0.0",
@@ -4700,9 +4700,9 @@
       "dev": true
     },
     "node_modules/tiny-invariant": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.2.tgz",
-      "integrity": "sha512-oLXoWt7bk7SI3REp16Hesm0kTBTErhk+FWTvuujYMlIbX42bb3yLN98T3OyzFNkZ3WAjVYDL4sWykCR6kD2mqQ=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #1380


This PR adds Descriminators to the openAPI spec, which allows the Typescript generator to generate individual mappings for the different Change Detection Configuration types. 

This is a "partial" fix, in that it restores functionality but still relies on hard-coded values. 

Eventually this needs to be fully dynamic, based in the ChangeDetection implementation type, but that requies a much bigger refactor


<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
