### PR TITLE
update labelValues openapi examples and grafana tutorial

### DIFF
--- a/docs/site/content/en/docs/Tutorials/grafana/index.md
+++ b/docs/site/content/en/docs/Tutorials/grafana/index.md
@@ -85,31 +85,21 @@ The `/labelValues` endpoint supports a `filter` query parameter to filter out da
 There are 2 ways to filter:
 1. provide a json object that must exist in the label values.
    
-   For example, if `version` is a label we can pass in `{"version":"1.2.3"}` to only include datasets where the version value is `1.2.3` 
+   For example, if `version` and `txRate` are label names then `{"version":"1.2.3"}` will only include labelValues where `version=1.2.3` 
+   and `{"version":"1.2.3","txRate":2000}` will add the `txRate=2000` requirement.
+
+> curl --query-param "filter={\"version\":\"1.2.3\",\"txRate\":2000}" <horreum>:/api/test/{id}/labelValues
+ 
 
 2. provide a json path (an extractor path from labels) that needs to evaluate to true  
 
    For example, if `count` is a label we can pass in `$.count ? (@ > 10 && @ < 20)` to only include datasets where count is between 10 and 20.
 
-We set the `filter` parameter by editing the Query for the grafana panel.
+> curl --query-param "filter=\"$.count ? (@ > 10 && @ < 20)\"" <horreum>:/api/test/{id}/labelValues
+
+We set the `filter` parameter by editing the Query for the grafana panel but it will depend .
 
 {{% imgproc json_api_panel_filter Fit "865x331" %}}
 Define filter for query
 {{% /imgproc %}}
 
-
-> docker run -d --name=grafana -p 3030:3000 grafana/grafana
-> docker exec -it grafana /bin/bash
-> e7ff10503ffb:/usr/share/grafana$ grafana cli plugins install marcusolsson-json-datasource
->> ✔ Downloaded and extracted marcusolsson-json-datasource v1.3.10 zip successfully to /var/lib/grafana/plugins/marcusolsson-json-datasource
->> Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
-
-
-> docker run -d --name=grafana --env --network="host" grafana/grafana
-
-if you need to access horreum running on localhost (dev mode). Then grafana needs to run on host network so that localhost references
-will also need to set a port other than 3000 becuase local dev mode uses 3000
-
-> docker run -d --name=grafana --env GF_SERVER_HTTP_PORT=3030 --network="host" grafana/grafana
-
-infinity datasource

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -978,10 +978,10 @@ paths:
         examples:
           object:
             description: json object that must exist in the values object
-            value:
-              key: requiredValue
+            value: "{labelName:necessaryValue,...}"
           string:
-            description: valid jsonpath that returns null of not found (not predicates)
+            description: valid filtering jsonpath that returns null if not found (not
+              predicates)
             value: $.count ? (@ < 20 && @ > 10)
       - name: sort
         in: query
@@ -2056,8 +2056,14 @@ paths:
         schema:
           default: "{}"
           type: string
-        example:
-          key: requiredValue
+        examples:
+          object:
+            description: json object that must exist in the values object
+            value: "{labelName:necessaryValue,...}"
+          string:
+            description: valid filtering jsonpath that returns null if not found (not
+              predicates)
+            value: $.count ? (@ < 20 && @ > 10)
       - name: before
         in: query
         description: ISO-like date time string or epoch millis

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -104,8 +104,8 @@ public interface RunService {
     @Parameters(value = {
             @Parameter(name = "id", in =ParameterIn.PATH, description = "Run Id", example = "101"),
             @Parameter(name = "filter", description = "either a required json sub-document or path expression", examples = {
-                    @ExampleObject(name="object", value="{\"key\":\"requiredValue\"}", description = "json object that must exist in the values object"),
-                    @ExampleObject(name="string", value="$.count ? (@ < 20 && @ > 10)",description = "valid jsonpath that returns null of not found (not predicates)")
+                    @ExampleObject(name="object", value="{labelName:necessaryValue,...}", description = "json object that must exist in the values object"),
+                    @ExampleObject(name="string", value="$.count ? (@ < 20 && @ > 10)",description = "valid filtering jsonpath that returns null if not found (not predicates)")
             }),
             @Parameter(name = "sort", description = "label name for sorting"),
             @Parameter(name = "direction",description = "either Ascending or Descending",example="count"),

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
@@ -202,7 +203,14 @@ public interface TestService {
            @Parameter(name = "id", description = "Test ID to retrieve Label Values for", example = "101"),
            @Parameter(name = "filtering", description = "Retrieve values for Filtering Labels", example = "true"),
            @Parameter(name = "metrics", description = "Retrieve values for Metric Labels", example = "false"),
-           @Parameter(name = "filter", description = "either a required json sub-document or path expression", example = "{\"key\":\"requiredValue\"} or $.count ? (@ < 20 && @ > 10)"),
+           @Parameter(
+                   name = "filter",
+                   description = "either a required json sub-document or path expression",
+                   examples = {
+                           @ExampleObject(name="object", value="{labelName:necessaryValue,...}", description = "json object that must exist in the values object"),
+                           @ExampleObject(name="string", value="$.count ? (@ < 20 && @ > 10)",description = "valid filtering jsonpath that returns null if not found (not predicates)")
+                   }
+           ),
            @Parameter(name = "before", description = "ISO-like date time string or epoch millis", example = "1970-01-01T00:00:00+00:00 or an integer"),
            @Parameter(name = "after", description = "ISO-like date time string or epoch millis", example = "1970-01-01T00:00:00+00:00 or an integer"),
            @Parameter(name = "sort", description = "json path to sortable value or start or stop for sorting by time",example = "$.label or start or stop"),


### PR DESCRIPTION
This improves the openapi docs for the `labelValues` endpoints on `/api/test` and `/api/run` as well as giving more details on `/labelValues` filtering in the grafana tutorial.
