### PR TITLE
Backporting: disable squash and fix version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,8 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backporting
-        uses: kiegroup/git-backporting@main
+        uses: kiegroup/git-backporting@v4.5.1
         with:
           target-branch: 0.11.x
           pull-request: ${{ github.event.pull_request.url }}
           auth: ${{ secrets.BACKPORT_TOKEN }}
+          no-squash: true


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Disable the squashing during automated backporting, this way all commits belonging to the original PR will be part of the backporting PR.

Moreover I suggest to fix the github action version to `v4.5.1` as the `main` branch might be unstable.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
