### PR TITLE
removed lifecycle-mapping plugin, fixes lsp used for vscode/nvim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,30 +233,6 @@
                     <version>${version.maven.resources}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                           <artifactId>maven-antrun-plugin</artifactId>
-                                           <versionRange>[1.7,)</versionRange>
-                                           <goals>
-                                               <goal>run</goal>
-                                           </goals>
-                                           <action>
-                                               <ignore />
-                                           </action>
-                                    </pluginExecutionFilter>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                      <version>3.2.0</version>


### PR DESCRIPTION
This plugin was added to get the eclipse editor working, it's no longer needed.