### PR TITLE
Backport: disable no-squash with backport-squash label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,17 +8,22 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+  NO_SQUASH_OPTION: true
 
 jobs:
   backporting:
     name: "Backporting"
+    concurrency:
+        group: backporting-${{ github.head_ref }}
+        cancel-in-progress: true
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
       github.event.pull_request.merged
       && (
         github.event.action == 'closed'
-          && contains(github.event.pull_request.labels.*.name, 'backport')
+          && (contains(github.event.pull_request.labels.*.name, 'backport')
+            || contains(github.event.pull_request.labels.*.name, 'backport-squash'))
         || (
           github.event.action == 'labeled'
           && contains(github.event.label.name, 'backport')
@@ -26,10 +31,17 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Override no-squash option
+        if: >
+          (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'backport-squash'))
+          || (github.event.action == 'labeled' && contains(github.event.label.name, 'backport-squash'))
+        shell: bash
+        run: |
+          echo "NO_SQUASH_OPTION=false" >> $GITHUB_ENV
       - name: Backporting
         uses: kiegroup/git-backporting@v4.5.1
         with:
           target-branch: 0.12.x
           pull-request: ${{ github.event.pull_request.url }}
           auth: ${{ secrets.BACKPORT_TOKEN }}
-          no-squash: true
+          no-squash: ${{ env.NO_SQUASH_OPTION }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,7 +35,17 @@ docker logout quay.io
 
 Backports are automatically created from PRs against the master branch to the stable branch.
 
-To backport a change, add the `backport` label to the PR that you opened against the master branch.
+To backport a change, add the `backport` (or `backport-squash` but not both) label to the PR that you opened against the master branch.
+
+Which label should I use?
+* `backport`: (default) this uses the `no-squash=true` option so that the tool tries to backport all commits coming
+from the original pull request you are trying to backport.
+> _**Note**_ that in this case the commit SHAs should exist during the backporting, i.e,
+delete the source branch only after the backporting PR got created.
+* `backport-squash`: with this label you set `no-squash=false` option, so that the tool tries to backport the pull request
+`merge_commit_sha`.
+> _**Note**_ the value of the `merge_commit_sha` attribute changes depending on the state of the pull request, see [Github doc](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request)
+  for more details.
 
 After the PR is merged, the backport PR will be automatically created.
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

1. Made `no-squash` option configurable, by default is set to `true` (i.e., using label `backport`) but if you want to force `no-squash: false` for any reason you can simply add label `backport-squash` rather than `backport` one.
2. Added `concurrency` so that if multiple jobs are triggered targeting the same PR only one will be kept alive

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
