### PR TITLE
[0.12.x] Add configurable privacy statement link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
+**/dependency-reduced-pom.xml
 
 # Quarkus .env
 .env

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: Horreum REST API
   description: "Horreum automated change anomaly detection. For more information,\
     \ please see [https://horreum.hyperfoil.io/](https://horreum.hyperfoil.io/)"
-  version: "0.12"
+  version: "0.13"
 tags:
 - name: Config
   description: Endpoint providing configuration for the Horreum System
@@ -4596,6 +4596,10 @@ components:
           description: Timestamp of server startup
           type: integer
           example: 2023-10-18 18:00:57
+        privacyStatement:
+          description: Privacy statement
+          type: string
+          example: link/to/external/privacy/statement
     Watch:
       required:
       - users

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: Horreum REST API
   description: "Horreum automated change anomaly detection. For more information,\
     \ please see [https://horreum.hyperfoil.io/](https://horreum.hyperfoil.io/)"
-  version: "0.13"
+  version: "0.12"
 tags:
 - name: Config
   description: Endpoint providing configuration for the Horreum System

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/ConfigService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/ConfigService.java
@@ -84,6 +84,8 @@ public interface ConfigService {
       @JsonProperty(required = true)
       @Schema(description="Timestamp of server startup", example = "2023-10-18 18:00:57")
       public long startTimestamp;
+      @Schema(description="Privacy statement", example="link/to/external/privacy/statement")
+      public String privacyStatement;
    }
 
    class KeycloakConfig {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ConfigServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ConfigServiceImpl.java
@@ -2,13 +2,10 @@ package io.hyperfoil.tools.horreum.svc;
 
 import io.hyperfoil.tools.horreum.api.Version;
 import io.hyperfoil.tools.horreum.api.data.Access;
-import io.hyperfoil.tools.horreum.api.data.Test;
 import io.hyperfoil.tools.horreum.api.data.datastore.Datastore;
 import io.hyperfoil.tools.horreum.api.services.ConfigService;
 import io.hyperfoil.tools.horreum.datastore.BackendResolver;
-import io.hyperfoil.tools.horreum.datastore.DatastoreResponse;
 import io.hyperfoil.tools.horreum.entity.backend.DatastoreConfigDAO;
-import io.hyperfoil.tools.horreum.entity.data.TestDAO;
 import io.hyperfoil.tools.horreum.mapper.DatasourceMapper;
 import io.hyperfoil.tools.horreum.server.WithRoles;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -18,8 +15,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.Collections;
@@ -28,12 +25,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.keycloak.util.JsonSerialization.mapper;
-
 @ApplicationScoped
 public class ConfigServiceImpl implements ConfigService {
 
     private static final Logger log = Logger.getLogger(ConfigServiceImpl.class);
+
+    @ConfigProperty(name = "horreum.privacy")
+    Optional<String> privacyStatement;
 
     @Inject
     SecurityIdentity identity;
@@ -59,6 +57,7 @@ public class ConfigServiceImpl implements ConfigService {
         VersionInfo info = new VersionInfo();
         info.version = Version.VERSION;
         info.startTimestamp = startTimestamp;
+        info.privacyStatement = privacyStatement.orElse(null);
         return info;
     }
 

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -122,6 +122,9 @@ horreum.transformationlog.check=6h
 # ISO-8601 duration stats with P (the format is P<date>T<time>)
 horreum.transformationlog.max.lifespan=P30d
 
+# Configurable URL pointing to a privacy statement
+horreum.privacy=/link/to/privacy/statement
+
 quarkus.mailer.from=horreum@hyperfoil.io
 quarkus.mailer.host=localhost
 quarkus.mailer.port=2525

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
@@ -6,6 +6,7 @@ import io.hyperfoil.tools.horreum.api.data.datastore.BaseDatastoreConfig;
 import io.hyperfoil.tools.horreum.api.data.datastore.Datastore;
 import io.hyperfoil.tools.horreum.api.data.datastore.ElasticsearchDatastoreConfig;
 import io.hyperfoil.tools.horreum.api.data.datastore.PostgresDatastoreConfig;
+import io.hyperfoil.tools.horreum.api.services.ConfigService;
 import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
 import io.hyperfoil.tools.horreum.test.PostgresResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -32,15 +33,14 @@ public class ConfigServiceTest extends BaseServiceTest {
 
     @org.junit.jupiter.api.Test
     public void getBackends(TestInfo testInfo) {
-        List<Object> backends = RestAssured.given().auth().oauth2(getTesterToken())
+        List<?> backends = RestAssured.given().auth().oauth2(getTesterToken())
                 .get("/api/config/datastore/".concat(TESTER_ROLES[0]))
                 .then()
                 .statusCode(200)
                 .extract().as(List.class);
 
-        Assert.assertNotNull(backends);
-        Assert.assertNotEquals(0, backends.size());
-
+        assertNotNull(backends);
+        assertNotEquals(0, backends.size());
     }
 
 
@@ -107,6 +107,15 @@ public class ConfigServiceTest extends BaseServiceTest {
 
     }
 
+    @org.junit.jupiter.api.Test
+    public void checkPrivacyStatement(TestInfo testInfo) {
+        ConfigService.VersionInfo info = RestAssured.given().auth().oauth2(getTesterToken())
+                .get("/api/config/version/")
+                .then()
+                .statusCode(200)
+                .extract().as(ConfigService.VersionInfo.class);
 
-
+        assertNotNull(info);
+        assertEquals("/link/to/privacy/statement", info.privacyStatement);
+    }
 }

--- a/horreum-web/src/About.tsx
+++ b/horreum-web/src/About.tsx
@@ -13,8 +13,11 @@ import {
 import { QuestionCircleIcon } from "@patternfly/react-icons"
 import {
 	Table,
-	TableBody
+	TableBody,
 } from '@patternfly/react-table/deprecated';
+import {
+    TableText
+} from '@patternfly/react-table';
 
 import { configApi } from "./api"
 import { formatDateTime } from "./utils"
@@ -22,6 +25,7 @@ import { formatDateTime } from "./utils"
 type VersionInfo = {
     version: string
     startTimestamp: number
+    privacyStatement?: string
 }
 
 const VERSION_ERROR = {
@@ -94,6 +98,9 @@ export default function About() {
                         rows={[
                             ["Version", versionInfo.version],
                             ["Up since", formatDateTime(versionInfo.startTimestamp)],
+                            versionInfo.privacyStatement
+                                ? ["Privacy Statement",  <TableText><a href={versionInfo.privacyStatement}>{versionInfo.privacyStatement}</a></TableText>]
+                                : [],
                         ]}
                     >
                         <TableBody />


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1437

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1408

## Changes proposed

Provide additional `privacy` statement in the `About` popup:

![image](https://github.com/Hyperfoil/Horreum/assets/26715795/156e68a8-7def-457a-951e-7ac74f1f6793)

The link/URL is configurable at installation/build level using property `horreum.privacy`.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
