### PR TITLE
[0.12.x] Disable the privacy statement by default

### DIFF
--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -123,7 +123,8 @@ horreum.transformationlog.check=6h
 horreum.transformationlog.max.lifespan=P30d
 
 # Configurable URL pointing to a privacy statement
-horreum.privacy=/link/to/privacy/statement
+# Uncomment next line and set the proper link to enable privacy statement
+#horreum.privacy=/link/to/privacy/statement
 
 quarkus.mailer.from=horreum@hyperfoil.io
 quarkus.mailer.host=localhost

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
@@ -116,6 +116,6 @@ public class ConfigServiceTest extends BaseServiceTest {
                 .extract().as(ConfigService.VersionInfo.class);
 
         assertNotNull(info);
-        assertEquals("/link/to/privacy/statement", info.privacyStatement);
+        assertEquals("/path/to/privacy/statement/link", info.privacyStatement);
     }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
@@ -15,7 +15,8 @@ public class HorreumTestProfile implements QuarkusTestProfile {
             "quarkus.oidc.token.issuer", "https://server.example.com",
             "smallrye.jwt.sign.key.location", "/privateKey.jwk",
             "horreum.url", "http://localhost:8081",
-            "horreum.test-mode", "true");
+            "horreum.test-mode", "true",
+            "horreum.privacy", "/path/to/privacy/statement/link");
    }
    @Override
    public boolean disableGlobalTestResources() {


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1440

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Followup of https://github.com/Hyperfoil/Horreum/pull/1437

Disable by default the privacy statement link so that by default it is not shown in the webpage.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
