### PR TITLE
disable auto browser tab in dev mode

### DIFF
--- a/horreum-web/vite.config.ts
+++ b/horreum-web/vite.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     base: '/',
     plugins: [react(), viteTsconfigPaths()],
     server: {    
-        // this ensures that the browser opens upon server start
-        open: true,
+        // this ensures that the browser DOES NOT open upon server start
+        open: false,
         // this sets a default port to 3000  
         port: 3000, 
 


### PR DESCRIPTION
The auto open browser tab opens to the nodejs port but that hostname + port combo does not work with the sign on so we end up working with the quarkus port. This disables the auto open tab. We can re-visit whenever the sign on works with requests from the node port.