### PR TITLE
Add script to clear out user data.

### DIFF
--- a/infra-legacy/clear-data.sh
+++ b/infra-legacy/clear-data.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script clears the database of user account information
+
+set -o pipefail
+
+psql -h localhost -p 6000 -U horreum-user -W horreum -c "SELECT set_config('horreum.userroles', 'horreum.system' , false);delete from userinfo_teams where username != 'dummy';delete from userinfo_roles where username != 'dummy';delete from userinfo where username != 'dummy';"
+


### PR DESCRIPTION
A simple script that clears out user data from the database. Leaving the 'dummy' account.

## Fixes Issue

Fixes the issue of having personally recognizable data on developers machines.

## Changes proposed

- [x] - Script added
