### PR TITLE
[0.12.x] Make UserService backend runtime configurable: Fixes #1445

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/RolesAugmentor.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/RolesAugmentor.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.horreum.entity.user.TeamMembership;
 import io.hyperfoil.tools.horreum.entity.user.UserInfo;
 import io.hyperfoil.tools.horreum.entity.user.UserRole;
 import io.hyperfoil.tools.horreum.svc.ServiceException;
+import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.arc.profile.UnlessBuildProfile;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.security.identity.AuthenticationRequestContext;
@@ -17,7 +18,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 @UnlessBuildProfile("test")
-@IfBuildProperty(name = "horreum.roles.provider", stringValue = "database")
+@LookupIfProperty(name = "horreum.roles.provider", stringValue = "database")
 public class RolesAugmentor implements SecurityIdentityAugmentor {
 
     @Inject RoleManager roleManager;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityMigration.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityMigration.java
@@ -28,6 +28,10 @@ public class SecurityMigration {
     @ConfigProperty(name = "quarkus.keycloak.admin-client.server-url") Optional<String> keycloakURL;
     @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
 
+    @ConfigProperty(name = "horreum.roles.provider", defaultValue = "keycloak") String provider;
+
+    private static final String MIGRATION_PROVIDER = "database";
+
     @Inject RoleManager roleManager;
 
     void onStart(@Observes StartupEvent event, Keycloak keycloak) {
@@ -42,9 +46,10 @@ public class SecurityMigration {
 
     private boolean performRolesMigration() {
         // an empty `userinfo_teams` table is the hint to perform migration of roles from keycloak
+        // only migrate if we users have defined the "database" provider
         try {
             roleManager.setRoles(Roles.HORREUM_SYSTEM);
-            return TeamMembership.count() == 0;
+            return MIGRATION_PROVIDER.equals(provider) && TeamMembership.count() == 0;
         } finally {
             roleManager.setRoles("");
         }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/UserServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/UserServiceImpl.java
@@ -1,68 +1,32 @@
 package io.hyperfoil.tools.horreum.svc;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
-
-import io.quarkus.arc.properties.IfBuildProperty;
-import io.quarkus.security.Authenticated;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ClientErrorException;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.Response;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.resource.RoleMappingResource;
-import org.keycloak.admin.client.resource.RoleResource;
-import org.keycloak.admin.client.resource.RoleScopeResource;
-import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.CredentialRepresentation;
-import org.keycloak.representations.idm.RoleRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
-
 import io.hyperfoil.tools.horreum.api.internal.services.UserService;
 import io.hyperfoil.tools.horreum.entity.user.UserInfo;
 import io.hyperfoil.tools.horreum.server.WithRoles;
+import io.hyperfoil.tools.horreum.svc.user.UserBackEnd;
+import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.vertx.core.Vertx;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import java.util.List;
+import java.util.Map;
 
 @PermitAll
 @ApplicationScoped
-@IfBuildProperty(name = "horreum.roles.provider", stringValue = "keycloak", enableIfMissing = true)
 public class UserServiceImpl implements UserService {
    private static final Logger log = Logger.getLogger(UserServiceImpl.class);
-   private static final String[] ROLE_TYPES = new String[] { "team", Roles.VIEWER, Roles.TESTER, Roles.UPLOADER, Roles.MANAGER };
-
-   @ConfigProperty(name="horreum.keycloak.realm", defaultValue="horreum")
-   String realm;
-
-   @Inject
-   Keycloak keycloak;
-
    @Inject
    SecurityIdentity identity;
 
    @Inject
-   Vertx vertx;
-
-   private static UserData toUserInfo(UserRepresentation rep) {
-      return new UserData(rep.getId(), rep.getUsername(), rep.getFirstName(), rep.getLastName(), rep.getEmail());
-   }
+   Instance<UserBackEnd> backend;
 
    @Authenticated
    @Override public List<String> getRoles() {
@@ -71,11 +35,11 @@ public class UserServiceImpl implements UserService {
 
    @Override
    public List<UserData> searchUsers(String query) {
+
       if (identity.isAnonymous()) {
          throw ServiceException.forbidden("Please log in and try again");
       }
-      return keycloak.realm(realm).users().search(query, null, null).stream()
-                     .map(UserServiceImpl::toUserInfo).collect(Collectors.toList());
+      return backend.get().searchUsers(query);
    }
 
    @RolesAllowed({Roles.VIEWER, Roles.TESTER, Roles.ADMIN})
@@ -84,22 +48,7 @@ public class UserServiceImpl implements UserService {
       if (identity.isAnonymous()) {
          throw ServiceException.forbidden("Please log in and try again");
       }
-      List<UserData> users = new ArrayList<>();
-      for (String username: usernames) {
-            try {
-               List<UserRepresentation> res = keycloak.realm(realm).users().search(username);
-               for (var u : res) {
-                  if (username.equals(u.getUsername())) {
-                     users.add(toUserInfo(u));
-                  }
-               }
-            } catch (Exception e) {
-               log.errorf(e, "Failed to fetch info for user %s", username);
-               throw ServiceException.serverError(String.format("Failed to fetch info for user %s", username));
-            }
-
-      }
-      return users;
+      return backend.get().info(usernames);
    }
 
    @Override
@@ -110,59 +59,8 @@ public class UserServiceImpl implements UserService {
       } else if (user.team != null && !user.team.endsWith("-team")) {
          throw ServiceException.badRequest("Team must end with -team: " + user.team);
       }
-      String prefix = user.team == null ? null : user.team.substring(0, user.team.length() - 4);
-      if (prefix != null && !identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
-         throw ServiceException.forbidden("This user is not a manager for team " + user.team);
-      }
-      // do not blindly use the existing representation
-      UserRepresentation rep = new UserRepresentation();
-      rep.setUsername(user.user.username);
-      rep.setEmail(user.user.email);
-      rep.setFirstName(user.user.firstName);
-      rep.setLastName(user.user.lastName);
-      rep.setEnabled(true);
 
-      CredentialRepresentation credentials = new CredentialRepresentation();
-      credentials.setType(CredentialRepresentation.PASSWORD);
-      credentials.setTemporary(true);
-      credentials.setValue(user.password);
-      rep.setCredentials(Collections.singletonList(credentials));
-
-      Response response = keycloak.realm(realm).users().create(rep);
-      if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-         log.errorf("Failed to create new user %s: %s", rep, response);
-         if (!keycloak.realm(realm).users().search(rep.getUsername(), true).isEmpty()) {
-            throw ServiceException.badRequest("User exists with same username.");
-         } else if (!keycloak.realm(realm).users().searchByEmail(rep.getEmail(), true).isEmpty()) {
-            throw ServiceException.badRequest("User exists with same email.");
-         } else {
-            throw ServiceException.badRequest("Failed to create new user: " + response.getStatusInfo().getReasonPhrase());
-         }
-      }
-      List<UserRepresentation> matchingUsers = keycloak.realm(realm).users().search(rep.getUsername(), true);
-      if (matchingUsers == null || matchingUsers.isEmpty()) {
-         throw ServiceException.badRequest("User " + rep.getUsername() + " does not exist.");
-      } else if (matchingUsers.size() > 1) {
-         throw ServiceException.serverError("More than one user with username " + rep.getUsername());
-      }
-      String userId = matchingUsers.get(0).getId();
-
-      if (prefix != null) {
-         List<RoleRepresentation> addedRoles = new ArrayList<>();
-         for (String role : user.roles) {
-            addedRoles.add(ensureRole(prefix + role));
-         }
-         keycloak.realm(realm).users().get(userId).roles().realmLevel().add(addedRoles);
-      }
-
-      ClientRepresentation account = keycloak.realm(realm).clients().query("account").stream()
-                                             .filter(c -> "account".equals(c.getName())).findFirst().orElse(null);
-      if (account != null) {
-         RoleRepresentation viewProfile = keycloak.realm(realm).clients().get(account.getId()).roles().get("view-profile").toRepresentation();
-         if (viewProfile != null) {
-            keycloak.realm(realm).users().get(userId).roles().clientLevel(account.getClientId()).add(Collections.singletonList(viewProfile));
-         }
-      }
+      backend.get().createUser(user);
    }
 
    @Override
@@ -170,8 +68,7 @@ public class UserServiceImpl implements UserService {
       if (identity.isAnonymous()) {
          throw ServiceException.forbidden("Please log in and try again");
       }
-      return keycloak.realm(realm).roles().list().stream().map(RoleRepresentation::getName)
-                     .filter(n -> n.endsWith("-team")).collect(Collectors.toList());
+      return backend.get().getTeams();
    }
 
    @WithRoles(addUsername = true)
@@ -190,177 +87,30 @@ public class UserServiceImpl implements UserService {
       userInfo.persistAndFlush();
    }
 
-   private String findMatchingUserId(String username) {
-      List<UserRepresentation> matchingUsers = keycloak.realm(realm).users().search(username, true);
-      if (matchingUsers == null || matchingUsers.isEmpty()) {
-         log.errorf("Cannot find user with username %s", username);
-         throw ServiceException.badRequest("User " + username + " does not exist.");
-      } else if (matchingUsers.size() > 1) {
-         log.errorf("Multiple matches for exact search for username %s: %s", username, matchingUsers);
-         throw ServiceException.serverError("More than one user with username " + username);
-      }
-      return matchingUsers.get(0).getId();
-   }
-
    @Override
    public Map<String, List<String>> teamMembers(String team) {
-      String prefix = getTeamPrefix(team);
-      if (!identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
-         throw ServiceException.badRequest("This user is not a manager for team " + team);
-      }
-      Map<String, List<String>> userMap = new HashMap<>();
-      for (String role : ROLE_TYPES) {
-         try {
-            // The call below does not consider transitivity with composite roles
-            Set<UserRepresentation> users = keycloak.realm(realm).roles().get(prefix + role).getRoleUserMembers();
-            for (UserRepresentation user : users) {
-               List<String> userRoles = userMap.computeIfAbsent(user.getUsername(), u -> new ArrayList<>());
-               userRoles.add(role);
-            }
-         } catch (NotFoundException e) {
-            // Was there a failure when creating the team?
-            log.warnf("Cannot find role %s%s in Keycloak", prefix, role);
-         } catch (Exception e) {
-            log.warnf("Error querying keycloak: %s", e.getMessage());
-            ServiceException.serverError("Failed to retrieve role users from Keycloak.");
-         }
-      }
-      return userMap;
+      return backend.get().teamMembers(team);
    }
 
    @Override
    public void updateTeamMembers(String team, Map<String, List<String>> roles) {
-      String prefix = getTeamPrefix(team);
-      if (!identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
-         throw ServiceException.forbidden("This user is does not have the manager role for team " + team);
-      }
-      CountDownFuture<Void> future = new CountDownFuture<>(null, roles.size() + ROLE_TYPES.length);
-      ConcurrentMap<String, RoleRepresentation> roleMap = new ConcurrentHashMap<>();
-      for (var entry : roles.entrySet()) {
-         vertx.executeBlocking(promise -> { //leave call to vertx.executeBlocking as this will make calls to keycloack in parrallel
-            String userId = findMatchingUserId(entry.getKey());
-            RoleMappingResource rolesMappingResource = keycloak.realm(realm).users().get(userId).roles();
-            List<RoleRepresentation> userRoles = rolesMappingResource.getAll().getRealmMappings();
-            if (userRoles == null) {
-               userRoles = Collections.emptyList();
-            }
-            List<RoleRepresentation> removed = null;
-            Set<String> existingTeamRoles = new HashSet<>();
-            for (RoleRepresentation role : userRoles) {
-               if (!role.getName().startsWith(prefix)) {
-                  // other team
-                  continue;
-               }
-               String roleWithoutPrefix = role.getName().substring(prefix.length());
-               if (entry.getValue().contains(roleWithoutPrefix)) {
-                  // already has this role
-                  existingTeamRoles.add(roleWithoutPrefix);
-                  continue;
-               }
-               if (removed == null) {
-                  removed = new ArrayList<>();
-               }
-               removed.add(role);
-            }
-            if (removed != null) {
-               rolesMappingResource.realmLevel().remove(removed);
-            }
-            List<RoleRepresentation> added = null;
-            for (String role : entry.getValue()) {
-               if (!existingTeamRoles.contains(role)) {
-                  if (added == null) {
-                     added = new ArrayList<>();
-                  }
-                  RoleRepresentation rep = roleMap.computeIfAbsent(role, r -> ensureRole(prefix + role));
-                  if (rep != null) {
-                     added.add(rep);
-                  } else {
-                     log.errorf("Role %s is not present!", prefix + role);
-                     promise.fail(ServiceException.serverError("Cannot add role " + prefix + role + " to user " + entry.getKey()));
-                     return;
-                  }
-               }
-            }
-            if (added != null) {
-               rolesMappingResource.realmLevel().add(added);
-            }
-            promise.complete();
-         }).onSuccess(future).onFailure(t -> {
-            log.errorf(t, "Cannot update roles for user %s", entry.getKey());
-            future.completeExceptionally(ServiceException.serverError("Cannot update roles for user " + entry.getKey()));
-         });
-      }
-      for (String type : ROLE_TYPES) {
-         vertx.executeBlocking(promise -> {
-            String roleName = prefix + type;
-            RoleResource roleResource = keycloak.realm(realm).roles().get(roleName);
-            RoleRepresentation role = roleResource.toRepresentation();
-            for (var user : roleResource.getRoleUserMembers()) {
-               if (!roles.containsKey(user.getUsername())) {
-                  keycloak.realm(realm).users().get(user.getId()).roles().realmLevel().remove(
-                     Collections.singletonList(role));
-               }
-            }
-            promise.complete();
-         }).onSuccess(future).onFailure(t -> future.completeExceptionally(ServiceException.serverError("Cannot remove user roles")));
-      }
-      try {
-         future.join();
-      } catch (Exception e){
-         throw new WebApplicationException(e);
-      }
-   }
-
-   private RoleRepresentation ensureRole(String roleName) {
-      try {
-         return keycloak.realm(realm).roles().get(roleName).toRepresentation();
-      } catch (NotFoundException e) {
-         keycloak.realm(realm).roles().create(new RoleRepresentation(roleName, null, false));
-         return keycloak.realm(realm).roles().get(roleName).toRepresentation();
-      }
+      backend.get().updateTeamMembers(team, roles);
    }
 
    @RolesAllowed(Roles.ADMIN)
    @Override
    public List<String> getAllTeams() {
-      List<String> teams;
-      try {
-         teams = keycloak.realm(realm).roles().list().stream()
-                         .map(RoleRepresentation::getName).filter(role -> role.endsWith("-team")).collect(Collectors.toList());
-      } catch (Exception e) {
-         throw ServiceException.serverError("Please check with the System Administrators that you have the correct permissions.");
-      }
-      return teams;
+      return backend.get().getAllTeams();
    }
 
    @RolesAllowed(Roles.ADMIN)
    @Override
    public void addTeam(String team) {
-      String prefix = getTeamPrefix(team);
-         createRole(team, null);
-         for (String type : Arrays.asList(Roles.MANAGER, Roles.TESTER, Roles.VIEWER, Roles.UPLOADER)) {
-            createRole(prefix + type, Set.of(type, team));
-         }
+      backend.get().addTeam(team);
    }
 
-   private void createRole(String roleName, Set<String> compositeRoles) {
-      RoleRepresentation role = new RoleRepresentation(roleName, null, false);
-      if (compositeRoles != null) {
-         role.setComposite(true);
-         var composites = new RoleRepresentation.Composites();
-         composites.setRealm(compositeRoles);
-         role.setComposites(composites);
-      }
-      try {
-         keycloak.realm(realm).roles().create(role);
-      } catch (ClientErrorException e) {
-         if (e.getResponse().getStatus() == Response.Status.CONFLICT.getStatusCode()) {
-            log.warnf("Role %s already exists, registration failed", roleName);
-         }
-      }
-   }
 
-   private String getTeamPrefix(String team) {
+   public static  String getTeamPrefix(String team) {
       if (team == null || team.isBlank()) {
          throw ServiceException.badRequest("No team name!");
       } else if (team.startsWith("horreum.")) {
@@ -376,81 +126,18 @@ public class UserServiceImpl implements UserService {
    @RolesAllowed(Roles.ADMIN)
    @Override
    public void deleteTeam(String team) {
-      String prefix = getTeamPrefix(team);
-      for (String type : ROLE_TYPES) {
-         try {
-            keycloak.realm(realm).roles().deleteRole(prefix + type);
-         } catch (NotFoundException e) {
-            log.warnf("Role %s%s was not found when we tried to delete it", prefix, type);
-         } catch (Exception e) {
-            throw ServiceException.serverError(String.format("unable to delete team: %s", team));
-         }
-      }
+      backend.get().deleteTeam(team);
    }
 
    @RolesAllowed(Roles.ADMIN)
    @Override
    public List<UserData> administrators() {
-         List<UserData> admins = new ArrayList<>();
-         try {
-            for (var user : keycloak.realm(realm).roles().get(Roles.ADMIN).getRoleUserMembers()) {
-               admins.add(new UserData(user.getId(), user.getUsername(), user.getFirstName(), user.getLastName(), user.getEmail()));
-            }
-            return admins;
-         } catch (Exception e){
-            throw ServiceException.serverError("Please verify with the System Administrators that you have the correct permissions");
-         }
+      return backend.get().administrators();
    }
 
    @RolesAllowed(Roles.ADMIN)
    @Override
    public void updateAdministrators(List<String> newAdmins) {
-      if (!newAdmins.contains(identity.getPrincipal().getName())) {
-         throw ServiceException.badRequest("Cannot remove yourselves from administrator list");
-      }
-      RoleResource roleResource = keycloak.realm(realm).roles().get(Roles.ADMIN);
-
-      CountDownFuture<Void> future = new CountDownFuture<>(null, 1 + newAdmins.size());
-      vertx.<RoleRepresentation>executeBlocking(promise ->
-         promise.complete(roleResource.toRepresentation())
-      ).onSuccess(adminRole -> {
-         for (String username : newAdmins) {
-            vertx.executeBlocking(promise -> {
-               String userId = findMatchingUserId(username);
-               RoleScopeResource userRoles = keycloak.realm(realm).users().get(userId).roles().realmLevel();
-               for (var role : userRoles.listAll()) {
-                  if (Roles.ADMIN.equals(role.getName())) {
-                     promise.complete();
-                     return;
-                  }
-               }
-               userRoles.add(Collections.singletonList(adminRole));
-               promise.complete();
-            }).onSuccess(future).onFailure(t -> {
-               log.errorf(t, "Cannot add admin role to user %s", username);
-               future.completeExceptionally(ServiceException.serverError("Cannot add admin role to user " + username));
-            });
-         }
-         vertx.executeBlocking(promise -> {
-            Set<UserRepresentation> oldAdmins = roleResource.getRoleUserMembers();
-            for (UserRepresentation user : oldAdmins) {
-               if (!newAdmins.contains(user.getUsername())) {
-                  keycloak.realm(realm).users().get(user.getId()).roles().realmLevel().remove(Collections.singletonList(adminRole));
-               }
-            }
-            promise.complete();
-         }).onSuccess(future).onFailure(t -> {
-            log.error("Cannot remove admin role", t);
-            future.completeExceptionally(ServiceException.serverError("Cannot remove admin role"));
-         });
-      }).onFailure(t -> {
-         log.error("Cannot fetch representation for admin role", t);
-         future.completeExceptionally(ServiceException.serverError("Cannot find admin role"));
-      });
-      try {
-         future.join();
-      } catch (Exception e){
-         throw ServiceException.serverError(e.getMessage());
-      }
+      backend.get().updateAdministrators(newAdmins);
    }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/DatabaseUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/DatabaseUserBackend.java
@@ -1,4 +1,4 @@
-package io.hyperfoil.tools.horreum.svc;
+package io.hyperfoil.tools.horreum.svc.user;
 
 import io.hyperfoil.tools.horreum.api.internal.services.UserService;
 import io.hyperfoil.tools.horreum.entity.user.Team;
@@ -7,12 +7,10 @@ import io.hyperfoil.tools.horreum.entity.user.TeamRole;
 import io.hyperfoil.tools.horreum.entity.user.UserInfo;
 import io.hyperfoil.tools.horreum.entity.user.UserRole;
 import io.hyperfoil.tools.horreum.server.WithRoles;
-import io.quarkus.arc.Unremovable;
-import io.quarkus.arc.properties.IfBuildProperty;
-import io.quarkus.security.Authenticated;
+import io.hyperfoil.tools.horreum.svc.Roles;
+import io.hyperfoil.tools.horreum.svc.ServiceException;
+import io.quarkus.arc.lookup.LookupIfProperty;
 import io.quarkus.security.identity.SecurityIdentity;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -27,46 +25,39 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static io.hyperfoil.tools.horreum.svc.UserServiceImpl.getTeamPrefix;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
-@PermitAll
 @ApplicationScoped
-@Unremovable
-@IfBuildProperty(name = "horreum.roles.provider", stringValue = "database")
-public class DatabaseUserServiceImpl implements UserService {
+@LookupIfProperty(name = "horreum.roles.provider", stringValue = "database")
+public class DatabaseUserBackend implements UserBackEnd {
 
-   private static final Logger LOG = Logger.getLogger(DatabaseUserServiceImpl.class);
+   @Inject
+   SecurityIdentity identity;
 
-   @Inject SecurityIdentity identity;
+   private static final Logger LOG = Logger.getLogger(DatabaseUserBackend.class);
 
-   private static UserData toUserInfo(UserInfo info) {
-      return new UserData("", info.username, info.fistName, info.lastName, info.email);
+   private static UserService.UserData toUserInfo(UserInfo info) {
+      return new UserService.UserData("", info.username, info.fistName, info.lastName, info.email);
    }
 
-   @Authenticated
-   @Override public List<String> getRoles() {
-      return identity.getRoles().stream().toList();
-   }
-
-   @Authenticated
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
-   @Override public List<UserData> searchUsers(String query) {
+   @Override public List<UserService.UserData> searchUsers(String query) {
       List<UserInfo> users = UserInfo.list("username like ?1", "%" + query + "%");
-      return users.stream().map(DatabaseUserServiceImpl::toUserInfo).collect(toList());
+      return users.stream().map(DatabaseUserBackend::toUserInfo).collect(toList());
    }
 
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
-   @RolesAllowed({Roles.VIEWER, Roles.TESTER, Roles.ADMIN})
-   @Override public List<UserData> info(List<String> usernames) {
+   @Override public List<UserService.UserData> info(List<String> usernames) {
       List<UserInfo> users = UserInfo.list("username in ?1", usernames);
-      return users.stream().map(DatabaseUserServiceImpl::toUserInfo).collect(toList());
+      return users.stream().map(DatabaseUserBackend::toUserInfo).collect(toList());
    }
 
    @Transactional
    @WithRoles(fromParams = NewUserParameterConverter.class)
-   @RolesAllowed({Roles.MANAGER, Roles.ADMIN})
-   @Override public void createUser(NewUser user) {
+   @Override
+   public void createUser(UserService.NewUser user) {
       if (user == null) {
          throw ServiceException.badRequest("Missing user as the request body");
       } else if (user.team != null && !user.team.endsWith("-team")) {
@@ -104,43 +95,22 @@ public class DatabaseUserServiceImpl implements UserService {
       userInfo.persist();
    }
 
+   public static final class NewUserParameterConverter implements Function<Object[], String[]> {
+      @Override public String[] apply(Object[] objects) {
+         return new String[] { ((UserService.NewUser) objects[0]).user.username };
+      }
+   }
    private void addTeamMembership(UserInfo userInfo, String teamName, TeamRole role) {
       Optional<Team> storedTeam = Team.find("teamName", teamName).firstResultOptional();
       userInfo.teams.add(new TeamMembership(userInfo, storedTeam.orElseGet(() -> Team.getEntityManager().merge(new Team(teamName))), role));
    }
-
-   public static final class NewUserParameterConverter implements Function<Object[], String[]> {
-      @Override public String[] apply(Object[] objects) {
-         return new String[] { ((NewUser) objects[0]).user.username };
-      }
-   }
-
-   @Authenticated
    @Override public List<String> getTeams() {
       List<Team> teams = Team.listAll();
       return teams.stream().map(t -> t.teamName + "-team").collect(toList());
    }
-
-   @WithRoles(addUsername = true)
-   @Override public String defaultTeam() {
-      UserInfo userInfo = UserInfo.findById(identity.getPrincipal().getName());
-      return userInfo != null ? userInfo.defaultTeam : null;
-   }
-
-   @Transactional
-   @WithRoles(addUsername = true)
-   @Override public void setDefaultTeam(String team) {
-      UserInfo userInfo = UserInfo.findById(identity.getPrincipal().getName());
-      userInfo.defaultTeam = Util.destringify(team);
-      userInfo.persistAndFlush();
-   }
-
-   @Authenticated
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
-   @Override public Map<String, List<String>> teamMembers(String team) {
-      if (!identity.getRoles().contains(getTeamPrefix(team) + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
-         throw ServiceException.badRequest("This user is not a manager for team " + team);
-      }
+   @Override
+   public Map<String, List<String>> teamMembers(String team) {
       Team teamEntity = Team.find("teamName", team.substring(0, team.length() - 5)).firstResult();
       if (teamEntity == null) {
          throw ServiceException.notFound("The team " + team + " does not exist");
@@ -152,12 +122,8 @@ public class DatabaseUserServiceImpl implements UserService {
    }
 
    @Transactional
-   @Authenticated
    @WithRoles(fromParams = UpdateTeamMembersParameterConverter.class)
    @Override public void updateTeamMembers(String team, Map<String, List<String>> roles) {
-      if (!identity.getRoles().contains(getTeamPrefix(team) + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
-         throw ServiceException.forbidden("This user is does not have the manager role for team " + team);
-      }
       Team teamEntity = Team.find("teamName", team.substring(0, team.length() - 5)).firstResult();
       if (teamEntity != null) {
          roles.forEach((username, teamRoles) -> {
@@ -174,28 +140,26 @@ public class DatabaseUserServiceImpl implements UserService {
          throw ServiceException.notFound("The team " + team + " does not exist");
       }
    }
-   
+
    public static final class UpdateTeamMembersParameterConverter implements Function<Object[], String[]> {
       @SuppressWarnings("unchecked") @Override public String[] apply(Object[] objects) {
          return ((Map<String, List<String>>) objects[1]).keySet().toArray(new String[0]);
       }
    }
 
-   @RolesAllowed(Roles.ADMIN)
+   @WithRoles(extras = Roles.HORREUM_SYSTEM)
    @Override public List<String> getAllTeams() {
       List<Team> teams = Team.listAll();
       return teams.stream().map(t -> t.teamName + "-team").collect(toList());
    }
-
    @Transactional
-   @RolesAllowed(Roles.ADMIN)
+   @WithRoles(extras = Roles.HORREUM_SYSTEM)
    @Override public void addTeam(String team) {
       Team.getEntityManager().merge(new Team(team.substring(0, team.length() - 5)));
    }
 
    @Transactional
-   @RolesAllowed(Roles.ADMIN)
-   @WithRoles
+   @WithRoles(extras = Roles.HORREUM_SYSTEM)
    @Override public void deleteTeam(String team) {
       String prefix = getTeamPrefix(team);
       Team teamEntity = Team.find("teamName", prefix.substring(0, prefix.length() - 1)).firstResult();
@@ -207,27 +171,12 @@ public class DatabaseUserServiceImpl implements UserService {
       }
    }
 
-   private String getTeamPrefix(String team) {
-      if (team == null || team.isBlank()) {
-         throw ServiceException.badRequest("No team name!");
-      } else if (team.startsWith("horreum.")) {
-         throw ServiceException.badRequest("Team name starting with 'horreum.' is illegal; this is reserved for internal use.");
-      } else if (!team.endsWith("-team")) {
-         throw ServiceException.badRequest("Team name must end with '-team' suffix");
-      } else if (team.length() > 64) {
-         throw ServiceException.badRequest("C'mon, can you think on a shorter team name?");
-      }
-      return team.substring(0, team.length() - 4);
-   }
-
-   @RolesAllowed(Roles.ADMIN)
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
-   @Override public List<UserData> administrators() {
-      return getAdministratorUsers().stream().map(DatabaseUserServiceImpl::toUserInfo).collect(toList());
+   @Override public List<UserService.UserData> administrators() {
+      return getAdministratorUsers().stream().map(DatabaseUserBackend::toUserInfo).collect(toList());
    }
 
    @Transactional
-   @RolesAllowed(Roles.ADMIN)
    @WithRoles(extras = Roles.HORREUM_SYSTEM)
    @Override public void updateAdministrators(List<String> newAdmins) {
       if (!newAdmins.contains(identity.getPrincipal().getName())) {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
@@ -1,0 +1,405 @@
+package io.hyperfoil.tools.horreum.svc.user;
+
+import io.hyperfoil.tools.horreum.api.internal.services.UserService;
+import io.hyperfoil.tools.horreum.svc.CountDownFuture;
+import io.hyperfoil.tools.horreum.svc.Roles;
+import io.hyperfoil.tools.horreum.svc.ServiceException;
+import io.quarkus.arc.lookup.LookupIfProperty;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static io.hyperfoil.tools.horreum.svc.UserServiceImpl.getTeamPrefix;
+
+@ApplicationScoped
+@LookupIfProperty(name = "horreum.roles.provider", stringValue = "keycloak")
+public class KeycloakUserBackend implements UserBackEnd {
+   private static final Logger log = Logger.getLogger(KeycloakUserBackend.class);
+   private static final String[] ROLE_TYPES = new String[] { "team", Roles.VIEWER, Roles.TESTER, Roles.UPLOADER, Roles.MANAGER };
+
+   @ConfigProperty(name="horreum.keycloak.realm", defaultValue="horreum")
+   String realm;
+
+   @Inject
+   Keycloak keycloak;
+
+   @Inject
+   SecurityIdentity identity;
+
+   @Inject
+   Vertx vertx;
+
+
+   @Override
+   public List<UserService.UserData> searchUsers(String query) {
+
+      return keycloak.realm(realm).users().search(query, null, null).stream()
+                     .map(KeycloakUserBackend::toUserInfo).collect(Collectors.toList());
+   }
+
+   @Override
+   public List<UserService.UserData> info(List<String> usernames) {
+      List<UserService.UserData> users = new ArrayList<>();
+      for (String username: usernames) {
+            try {
+               List<UserRepresentation> res = keycloak.realm(realm).users().search(username);
+               for (var u : res) {
+                  if (username.equals(u.getUsername())) {
+                     users.add(toUserInfo(u));
+                  }
+               }
+            } catch (Exception e) {
+               log.errorf(e, "Failed to fetch info for user %s", username);
+               throw ServiceException.serverError(String.format("Failed to fetch info for user %s", username));
+            }
+
+      }
+      return users;
+   }
+
+   public void createUser(UserService.NewUser user) {
+      if (user == null) {
+         throw ServiceException.badRequest("Missing user as the request body");
+      } else if (user.team != null && !user.team.endsWith("-team")) {
+         throw ServiceException.badRequest("Team must end with -team: " + user.team);
+      }
+      String prefix = user.team == null ? null : user.team.substring(0, user.team.length() - 4);
+      if (prefix != null && !identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
+         throw ServiceException.forbidden("This user is not a manager for team " + user.team);
+      }
+      // do not blindly use the existing representation
+      UserRepresentation rep = new UserRepresentation();
+      rep.setUsername(user.user.username);
+      rep.setEmail(user.user.email);
+      rep.setFirstName(user.user.firstName);
+      rep.setLastName(user.user.lastName);
+      rep.setEnabled(true);
+
+      CredentialRepresentation credentials = new CredentialRepresentation();
+      credentials.setType(CredentialRepresentation.PASSWORD);
+      credentials.setTemporary(true);
+      credentials.setValue(user.password);
+      rep.setCredentials(Collections.singletonList(credentials));
+
+      Response response = keycloak.realm(realm).users().create(rep);
+      if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+         log.errorf("Failed to create new user %s: %s", rep, response);
+         if (!keycloak.realm(realm).users().search(rep.getUsername(), true).isEmpty()) {
+            throw ServiceException.badRequest("User exists with same username.");
+         } else if (!keycloak.realm(realm).users().searchByEmail(rep.getEmail(), true).isEmpty()) {
+            throw ServiceException.badRequest("User exists with same email.");
+         } else {
+            throw ServiceException.badRequest("Failed to create new user: " + response.getStatusInfo().getReasonPhrase());
+         }
+      }
+      List<UserRepresentation> matchingUsers = keycloak.realm(realm).users().search(rep.getUsername(), true);
+      if (matchingUsers == null || matchingUsers.isEmpty()) {
+         throw ServiceException.badRequest("User " + rep.getUsername() + " does not exist.");
+      } else if (matchingUsers.size() > 1) {
+         throw ServiceException.serverError("More than one user with username " + rep.getUsername());
+      }
+      String userId = matchingUsers.get(0).getId();
+
+      if (prefix != null) {
+         List<RoleRepresentation> addedRoles = new ArrayList<>();
+         for (String role : user.roles) {
+            addedRoles.add(ensureRole(prefix + role));
+         }
+         keycloak.realm(realm).users().get(userId).roles().realmLevel().add(addedRoles);
+      }
+
+      ClientRepresentation account = keycloak.realm(realm).clients().query("account").stream()
+                                             .filter(c -> "account".equals(c.getName())).findFirst().orElse(null);
+      if (account != null) {
+         RoleRepresentation viewProfile = keycloak.realm(realm).clients().get(account.getId()).roles().get("view-profile").toRepresentation();
+         if (viewProfile != null) {
+            keycloak.realm(realm).users().get(userId).roles().clientLevel(account.getClientId()).add(Collections.singletonList(viewProfile));
+         }
+      }
+   }
+   @Override
+   public List<String> getTeams() {
+      if (identity.isAnonymous()) {
+         throw ServiceException.forbidden("Please log in and try again");
+      }
+      return keycloak.realm(realm).roles().list().stream().map(RoleRepresentation::getName)
+                     .filter(n -> n.endsWith("-team")).collect(Collectors.toList());
+   }
+   private String findMatchingUserId(String username) {
+      List<UserRepresentation> matchingUsers = keycloak.realm(realm).users().search(username, true);
+      if (matchingUsers == null || matchingUsers.isEmpty()) {
+         log.errorf("Cannot find user with username %s", username);
+         throw ServiceException.badRequest("User " + username + " does not exist.");
+      } else if (matchingUsers.size() > 1) {
+         log.errorf("Multiple matches for exact search for username %s: %s", username, matchingUsers);
+         throw ServiceException.serverError("More than one user with username " + username);
+      }
+      return matchingUsers.get(0).getId();
+   }
+
+   @Override
+   public Map<String, List<String>> teamMembers(String team) {
+      String prefix = getTeamPrefix(team);
+      if (!identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
+         throw ServiceException.badRequest("This user is not a manager for team " + team);
+      }
+      Map<String, List<String>> userMap = new HashMap<>();
+      for (String role : ROLE_TYPES) {
+         try {
+            // The call below does not consider transitivity with composite roles
+            Set<UserRepresentation> users = keycloak.realm(realm).roles().get(prefix + role).getRoleUserMembers();
+            for (UserRepresentation user : users) {
+               List<String> userRoles = userMap.computeIfAbsent(user.getUsername(), u -> new ArrayList<>());
+               userRoles.add(role);
+            }
+         } catch (NotFoundException e) {
+            // Was there a failure when creating the team?
+            log.warnf("Cannot find role %s%s in Keycloak", prefix, role);
+         } catch (Exception e) {
+            log.warnf("Error querying keycloak: %s", e.getMessage());
+            ServiceException.serverError("Failed to retrieve role users from Keycloak.");
+         }
+      }
+      return userMap;
+   }
+
+   @Override
+   public void updateTeamMembers(String team, Map<String, List<String>> roles) {
+      String prefix = getTeamPrefix(team);
+      if (!identity.getRoles().contains(prefix + Roles.MANAGER) && !identity.getRoles().contains(Roles.ADMIN)) {
+         throw ServiceException.forbidden("This user is does not have the manager role for team " + team);
+      }
+      CountDownFuture<Void> future = new CountDownFuture<>(null, roles.size() + ROLE_TYPES.length);
+      ConcurrentMap<String, RoleRepresentation> roleMap = new ConcurrentHashMap<>();
+      for (var entry : roles.entrySet()) {
+         vertx.executeBlocking(promise -> { //leave call to vertx.executeBlocking as this will make calls to keycloack in parrallel
+            String userId = findMatchingUserId(entry.getKey());
+            RoleMappingResource rolesMappingResource = keycloak.realm(realm).users().get(userId).roles();
+            List<RoleRepresentation> userRoles = rolesMappingResource.getAll().getRealmMappings();
+            if (userRoles == null) {
+               userRoles = Collections.emptyList();
+            }
+            List<RoleRepresentation> removed = null;
+            Set<String> existingTeamRoles = new HashSet<>();
+            for (RoleRepresentation role : userRoles) {
+               if (!role.getName().startsWith(prefix)) {
+                  // other team
+                  continue;
+               }
+               String roleWithoutPrefix = role.getName().substring(prefix.length());
+               if (entry.getValue().contains(roleWithoutPrefix)) {
+                  // already has this role
+                  existingTeamRoles.add(roleWithoutPrefix);
+                  continue;
+               }
+               if (removed == null) {
+                  removed = new ArrayList<>();
+               }
+               removed.add(role);
+            }
+            if (removed != null) {
+               rolesMappingResource.realmLevel().remove(removed);
+            }
+            List<RoleRepresentation> added = null;
+            for (String role : entry.getValue()) {
+               if (!existingTeamRoles.contains(role)) {
+                  if (added == null) {
+                     added = new ArrayList<>();
+                  }
+                  RoleRepresentation rep = roleMap.computeIfAbsent(role, r -> ensureRole(prefix + role));
+                  if (rep != null) {
+                     added.add(rep);
+                  } else {
+                     log.errorf("Role %s is not present!", prefix + role);
+                     promise.fail(ServiceException.serverError("Cannot add role " + prefix + role + " to user " + entry.getKey()));
+                     return;
+                  }
+               }
+            }
+            if (added != null) {
+               rolesMappingResource.realmLevel().add(added);
+            }
+            promise.complete();
+         }).onSuccess(future).onFailure(t -> {
+            log.errorf(t, "Cannot update roles for user %s", entry.getKey());
+            future.completeExceptionally(ServiceException.serverError("Cannot update roles for user " + entry.getKey()));
+         });
+      }
+      for (String type : ROLE_TYPES) {
+         vertx.executeBlocking(promise -> {
+            String roleName = prefix + type;
+            RoleResource roleResource = keycloak.realm(realm).roles().get(roleName);
+            RoleRepresentation role = roleResource.toRepresentation();
+            for (var user : roleResource.getRoleUserMembers()) {
+               if (!roles.containsKey(user.getUsername())) {
+                  keycloak.realm(realm).users().get(user.getId()).roles().realmLevel().remove(
+                     Collections.singletonList(role));
+               }
+            }
+            promise.complete();
+         }).onSuccess(future).onFailure(t -> future.completeExceptionally(ServiceException.serverError("Cannot remove user roles")));
+      }
+      try {
+         future.join();
+      } catch (Exception e){
+         throw new WebApplicationException(e);
+      }
+   }
+
+   private RoleRepresentation ensureRole(String roleName) {
+      try {
+         return keycloak.realm(realm).roles().get(roleName).toRepresentation();
+      } catch (NotFoundException e) {
+         keycloak.realm(realm).roles().create(new RoleRepresentation(roleName, null, false));
+         return keycloak.realm(realm).roles().get(roleName).toRepresentation();
+      }
+   }
+
+   @Override
+   public List<String> getAllTeams() {
+      List<String> teams;
+      try {
+         teams = keycloak.realm(realm).roles().list().stream()
+                         .map(RoleRepresentation::getName).filter(role -> role.endsWith("-team")).collect(Collectors.toList());
+      } catch (Exception e) {
+         throw ServiceException.serverError("Please check with the System Administrators that you have the correct permissions.");
+      }
+      return teams;
+   }
+
+   @Override
+   public void addTeam(String team) {
+      String prefix = getTeamPrefix(team);
+         createRole(team, null);
+         for (String type : Arrays.asList(Roles.MANAGER, Roles.TESTER, Roles.VIEWER, Roles.UPLOADER)) {
+            createRole(prefix + type, Set.of(type, team));
+         }
+   }
+
+   private void createRole(String roleName, Set<String> compositeRoles) {
+      RoleRepresentation role = new RoleRepresentation(roleName, null, false);
+      if (compositeRoles != null) {
+         role.setComposite(true);
+         var composites = new RoleRepresentation.Composites();
+         composites.setRealm(compositeRoles);
+         role.setComposites(composites);
+      }
+      try {
+         keycloak.realm(realm).roles().create(role);
+      } catch (ClientErrorException e) {
+         if (e.getResponse().getStatus() == Response.Status.CONFLICT.getStatusCode()) {
+            log.warnf("Role %s already exists, registration failed", roleName);
+         }
+      }
+   }
+
+
+   @Override
+   public void deleteTeam(String team) {
+      String prefix = getTeamPrefix(team);
+      for (String type : ROLE_TYPES) {
+         try {
+            keycloak.realm(realm).roles().deleteRole(prefix + type);
+         } catch (NotFoundException e) {
+            log.warnf("Role %s%s was not found when we tried to delete it", prefix, type);
+         } catch (Exception e) {
+            throw ServiceException.serverError(String.format("unable to delete team: %s", team));
+         }
+      }
+   }
+
+   @Override
+   public List<UserService.UserData> administrators() {
+         List<UserService.UserData> admins = new ArrayList<>();
+         try {
+            for (var user : keycloak.realm(realm).roles().get(Roles.ADMIN).getRoleUserMembers()) {
+               admins.add(new UserService.UserData(user.getId(), user.getUsername(), user.getFirstName(), user.getLastName(), user.getEmail()));
+            }
+            return admins;
+         } catch (Exception e){
+            throw ServiceException.serverError("Please verify with the System Administrators that you have the correct permissions");
+         }
+   }
+
+   @Override
+   public void updateAdministrators(List<String> newAdmins) {
+      if (!newAdmins.contains(identity.getPrincipal().getName())) {
+         throw ServiceException.badRequest("Cannot remove yourselves from administrator list");
+      }
+      RoleResource roleResource = keycloak.realm(realm).roles().get(Roles.ADMIN);
+
+      CountDownFuture<Void> future = new CountDownFuture<>(null, 1 + newAdmins.size());
+      vertx.<RoleRepresentation>executeBlocking(promise ->
+         promise.complete(roleResource.toRepresentation())
+      ).onSuccess(adminRole -> {
+         for (String username : newAdmins) {
+            vertx.executeBlocking(promise -> {
+               String userId = findMatchingUserId(username);
+               RoleScopeResource userRoles = keycloak.realm(realm).users().get(userId).roles().realmLevel();
+               for (var role : userRoles.listAll()) {
+                  if (Roles.ADMIN.equals(role.getName())) {
+                     promise.complete();
+                     return;
+                  }
+               }
+               userRoles.add(Collections.singletonList(adminRole));
+               promise.complete();
+            }).onSuccess(future).onFailure(t -> {
+               log.errorf(t, "Cannot add admin role to user %s", username);
+               future.completeExceptionally(ServiceException.serverError("Cannot add admin role to user " + username));
+            });
+         }
+         vertx.executeBlocking(promise -> {
+            Set<UserRepresentation> oldAdmins = roleResource.getRoleUserMembers();
+            for (UserRepresentation user : oldAdmins) {
+               if (!newAdmins.contains(user.getUsername())) {
+                  keycloak.realm(realm).users().get(user.getId()).roles().realmLevel().remove(Collections.singletonList(adminRole));
+               }
+            }
+            promise.complete();
+         }).onSuccess(future).onFailure(t -> {
+            log.error("Cannot remove admin role", t);
+            future.completeExceptionally(ServiceException.serverError("Cannot remove admin role"));
+         });
+      }).onFailure(t -> {
+         log.error("Cannot fetch representation for admin role", t);
+         future.completeExceptionally(ServiceException.serverError("Cannot find admin role"));
+      });
+      try {
+         future.join();
+      } catch (Exception e){
+         throw ServiceException.serverError(e.getMessage());
+      }
+   }
+
+   private static UserService.UserData toUserInfo(UserRepresentation rep) {
+      return new UserService.UserData(rep.getId(), rep.getUsername(), rep.getFirstName(), rep.getLastName(), rep.getEmail());
+   }
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/UserBackEnd.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/UserBackEnd.java
@@ -1,0 +1,24 @@
+package io.hyperfoil.tools.horreum.svc.user;
+
+import io.hyperfoil.tools.horreum.api.internal.services.UserService;
+
+import java.util.List;
+import java.util.Map;
+
+public interface UserBackEnd {
+
+    List<UserService.UserData> searchUsers(String query);
+    List<UserService.UserData> info(List<String> usernames);
+
+    void createUser(UserService.NewUser user);
+    List<String> getTeams();
+
+    Map<String, List<String>> teamMembers(String team);
+    void updateTeamMembers(String team, Map<String, List<String>> roles);
+    List<String> getAllTeams();
+    void addTeam(String team);
+
+    void deleteTeam(String team);
+    List<UserService.UserData> administrators();
+    void updateAdministrators(List<String> newAdmins);
+}

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -107,7 +107,7 @@ horreum.db.secret=secret
 ## horreum.keycloak.url=http://localhost:8180
 horreum.keycloak.realm=horreum
 horreum.keycloak.clientId=horreum-ui
-horreum.roles.provider=database
+horreum.roles.provider=keycloak
 
 # Address used in links to Horreum
 horreum.url=http://localhost:3000


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1450

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #1445 
Fixes #1419

This PR makes the UserService "backend" (keycloak/database) runtime configurable; 

- The same property selects the backend, but is resolved at runtime not build time. We only have to build one image 
- defaults back to keycloak behaviour - the upgrade from keycloak to database will be an admin choice
- there is an additional check for migration, that the database backend has been selected AND the tables are empty
- prevents a "split-mode" - Fixes #1419

Once migrated from keycloak -> database, everything continues to function with the roles resolved from the database