### PR TITLE
[0.12.x] Added links on existing Configure Actions documentation page.

### DIFF
--- a/docs/site/content/en/docs/Concepts/core-concepts/index.md
+++ b/docs/site/content/en/docs/Concepts/core-concepts/index.md
@@ -122,3 +122,15 @@ In Horreum a `Report Configuration` is used for compiling a summary of informati
 
 ## Report
 A `Report` is an instance of a `Report Configuration`. Creation date and time is used for differentiating each `Report`.
+
+## Actions
+An `Action` is the ability by Horreum to send an Event notification to an external system. These are added to a [`Test`](#test).
+
+## Global Action
+Actions that occur globally in `Horreum`
+
+## Test Action
+Actions only for a particular [`Test`](#test)
+
+## Action allow list
+`Horreum` will only allow generic HTTP requests to domains that have been pre-configured in Horreum by an Administrator.

--- a/docs/site/content/en/docs/Tasks/configure-actions/index.md
+++ b/docs/site/content/en/docs/Tasks/configure-actions/index.md
@@ -6,21 +6,35 @@ weight: 7
 ---
 
 
-In the [change detection guide](/docs/tasks/configure-change-detection) you've seen how can you inform users about changes in your project's performance. You can use another mechanism to notify other services about noteworthy events, e.g. bots commenting on version control system, updating status page or triggering another job in CI: the webhooks.
+In the [change detection guide](/docs/tasks/configure-change-detection) you've seen how can you inform users about changes in your project's performance. You can use another mechanism to notify other services about noteworthy events, e.g. bots commenting on version control system, updating status page or triggering another job in CI: the webhooks. Event [`Actions`](/docs/concepts/core-concepts#actions) are produced in the following situations:
 
-Since calling arbitrary services in the intranet is security-sensitive, Horreum administrators have to set up a list of allowed URL prefixes (e.g. domains). As a user with the `admin` role you can see 'Administration' link in the navigation bar on the top; go there and in the 'Global Actions' tab hit the 'Add prefix' button:
+- New Run event
+- New Change Detection event
+- Experiment Result event
+
+Additionally, [`Global Actions`](/docs/concepts/core-concepts#global-action) have one additional event type:
+
+- New Test event
+
+This allows remote systems or users to rely on automation that can reduce the necessity of manual tasks. Since calling arbitrary services in the intranet is security-sensitive, Horreum administrators have to set up an [`Action Allow list`](/docs/concepts/core-concepts#action-allow-list) of URL prefixes (e.g. domains). There are a variety of Webhook implementations provided by Horreum:
+
+- Generic HTTP POST method request
+- Github Issue Comment
+- Create a new Github Issue
+
+As a user with the `admin` role you can see 'Administration' link in the navigation bar on the top; go there and in the [`Global Actions`](/docs/concepts/core-concepts#global-actions) tab hit the 'Add prefix' button:
 
 {{% imgproc prefix Fit "1200x300" %}}
 Define action prefix
 {{% /imgproc %}}
 
-When you save the modal you will see the prefix appearing in the table. Then in the lower half of the screen you can add global actions: whenever a new Test is created, a Run is uploaded or Change is emitted Horreum can issue a HTTP POST request to this URL, using the new JSON-encoded entity as a request body. You can also use a JSON path[^1] wrapped in `${...}`, e.g. `${$.data.foo}` in the URL to refer to the object sent.
+When you save the modal you will see the prefix appearing in the table. Then in the lower half of the screen you can add global actions: whenever a new Test is created, a [`Run`](/docs/concepts/core-concepts#run) is uploaded or Change is emitted Horreum can issue a HTTP POST request to this URL, using the new JSON-encoded entity as a request body. You can also use a JSON path[^1] wrapped in `${...}`, e.g. `${$.data.foo}` in the URL to refer to the object sent.
 
 {{% imgproc globalhook Fit "1200x300" %}}
 Define action prefix
 {{% /imgproc %}}
 
-Test owners can set Actions for individual tests, too. Go to the Test configuration, 'Actions' tab and press the 'New Action' button. This works identically to the global actions.
+Test owners can set [`Actions`](/docs/concepts/core-concepts#actions) for individual tests, too. Go to the Test configuration, 'Actions' tab and press the 'New Action' button. This works identically to the global actions.
 
 {{% imgproc testhook Fit "1200x300" %}}
 Define test webhook


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1464

Added details of webhook types and an event type.

## Fixes Issue

fixes #1177 

## Changes proposed

[x] - Added links to existing Configure Actions page.
[X] - Added more terms on Core Concepts page.
[x] - Added events that can be created in Horreum
[x] - Types of Action
