### PR TITLE
Bump backporting to version 4.5.2

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "NO_SQUASH_OPTION=false" >> $GITHUB_ENV
       - name: Backporting
-        uses: kiegroup/git-backporting@v4.5.1
+        uses: kiegroup/git-backporting@v4.5.2
         with:
           target-branch: 0.12.x
           pull-request: ${{ github.event.pull_request.url }}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

As part f the https://github.com/Hyperfoil/Horreum/issues/1423 resolution

## Changes proposed

<!-- List all the proposed changes in your PR -->

Bump `backporting` to the latest version that runs on `node20`, therefore removing the following warning:

```bash
[run](https://github.com/Hyperfoil/Horreum/actions/runs/8214138182/job/22466298403)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: wow-actions/welcome@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
