### PR TITLE
Remove general use of Elasticsearch dev service

### DIFF
--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -204,6 +204,7 @@ horreum.dev-services.enabled=true
 quarkus.datasource.devservices.enabled=false
 quarkus.datasource.migration.devservices.enabled=false
 quarkus.keycloak.devservices.enabled=false
+quarkus.elasticsearch.devservices.enabled=false
 
 ## Add a dummy administrator in dev mode with name "user" and password "secret" with Basic HTTP authentication
 %dev.quarkus.http.auth.basic=true

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasourceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasourceTest.java
@@ -12,7 +12,7 @@ import io.hyperfoil.tools.horreum.api.services.ConfigService;
 import io.hyperfoil.tools.horreum.bus.MessageBusChannels;
 import io.hyperfoil.tools.horreum.entity.backend.DatastoreConfigDAO;
 import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
-import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
+import io.hyperfoil.tools.horreum.test.ElasticsearchTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-@TestProfile(HorreumTestProfile.class)
+@TestProfile(ElasticsearchTestProfile.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DatasourceTest extends BaseServiceTest{
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/ElasticsearchTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/ElasticsearchTestProfile.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.tools.horreum.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ElasticsearchTestProfile extends HorreumTestProfile {
+
+    @Override public Map<String, String> getConfigOverrides() {
+        Map<String, String> configOverrides = new HashMap<>(super.getConfigOverrides());
+        configOverrides.put("quarkus.elasticsearch.devservices.enabled", "true");
+        return configOverrides;
+    }
+
+}


### PR DESCRIPTION
Create a new test profile, currently only for `DatasourceTest`.