### PR TITLE
[0.12.x] Bump @patternfly from 5.1.x to 5.2.x in /horreum-web

### DIFF
--- a/horreum-web/package-lock.json
+++ b/horreum-web/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "4.6.0",
-        "@patternfly/patternfly": "5.1.0",
-        "@patternfly/react-core": "5.1.1",
-        "@patternfly/react-table": "5.1.1",
+        "@patternfly/patternfly": "5.2.1",
+        "@patternfly/react-core": "5.2.3",
+        "@patternfly/react-table": "5.2.4",
         "@types/jsonpath": "0.2.4",
         "@types/luxon": "3.2.0",
         "@types/react": "17.0.74",
@@ -959,18 +959,18 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.1.0.tgz",
-      "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.2.1.tgz",
+      "integrity": "sha512-n5xFjyj1J4eIFZ7XeU6K44POKRAuDlO5yALPbn084y+jPy1j861AaQ+zIUbzCi4IzBlHrvoXVKij7p1zy7Ditg=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.1.tgz",
-      "integrity": "sha512-9DbgQMXYmF8A4aCNLKXwIN1H07SIPoPaVLvx+yiDuJfDx4Qi0T+H7j5cx0VfDfxuCpqea3POJWqBQn1HnwS4wQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.2.3.tgz",
+      "integrity": "sha512-MJeOLyJFbZPV+cj4LjL15nUuhJUwFuqLFiv6f2YubRqHl/+z05oM0byhwfm/qu2VnKByY6X6lu3Hp+hMTZcbOA==",
       "dependencies": {
-        "@patternfly/react-icons": "^5.1.1",
-        "@patternfly/react-styles": "^5.1.1",
-        "@patternfly/react-tokens": "^5.1.1",
+        "@patternfly/react-icons": "^5.2.1",
+        "@patternfly/react-styles": "^5.2.1",
+        "@patternfly/react-tokens": "^5.2.1",
         "focus-trap": "7.5.2",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
@@ -995,14 +995,14 @@
       "integrity": "sha512-GT96hzI1QenBhq6Pfc51kxnj9aVLjL1zSLukKZXcYVe0HPOy0BFm90bT1Fo4e/z7V9cDYw4SqSX1XLc3O4jsTw=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.1.tgz",
-      "integrity": "sha512-9tAtHj16hemJ6YRBWIm2O+QRNoFWYQt8ZLQ1G0KBwpg2t2G2CbGsS2RG+BamO4IVE6IPo3Yoo39p4UCNRiGVpA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.2.4.tgz",
+      "integrity": "sha512-WCt4I6XYKRHXcasDqcOX70ctkgPVBAvlOv67KhaZsedxUU+B2NT1kiI7Jr7tD4SrR+jQs0MCF/bbRk1QM+rBqg==",
       "dependencies": {
-        "@patternfly/react-core": "^5.1.1",
-        "@patternfly/react-icons": "^5.1.1",
-        "@patternfly/react-styles": "^5.1.1",
-        "@patternfly/react-tokens": "^5.1.1",
+        "@patternfly/react-core": "^5.2.3",
+        "@patternfly/react-icons": "^5.2.1",
+        "@patternfly/react-styles": "^5.2.1",
+        "@patternfly/react-tokens": "^5.2.1",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0"
       },

--- a/horreum-web/package.json
+++ b/horreum-web/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "dependencies": {
     "@monaco-editor/react": "4.6.0",
-    "@patternfly/patternfly": "5.1.0",
-    "@patternfly/react-core": "5.1.1",
-    "@patternfly/react-table": "5.1.1",
+    "@patternfly/patternfly": "5.2.1",
+    "@patternfly/react-core": "5.2.3",
+    "@patternfly/react-table": "5.2.4",
     "@types/jsonpath": "0.2.4",
     "@types/luxon": "3.2.0",
     "@types/react": "17.0.74",


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1515

Bumps [@patternfly/patternfly](https://github.com/patternfly/patternfly) from 5.1.0 to 5.2.1.
Bumps [@patternfly/react-core](https://github.com/patternfly/patternfly-react) from 5.1.1 to 5.2.3.
Bumps [@patternfly/react-table](https://github.com/patternfly/react-table) from 5.1.1 to 5.2.4.

