### PR TITLE
add include and exclude to test and run service labelValues endpoint

### DIFF
--- a/docs/site/content/en/docs/Tutorials/grafana/index.md
+++ b/docs/site/content/en/docs/Tutorials/grafana/index.md
@@ -103,3 +103,24 @@ We set the `filter` parameter by editing the Query for the grafana panel but it 
 Define filter for query
 {{% /imgproc %}}
 
+## Filtering labels
+
+Another common consideration is the amount of data in the `/labelValues` response. Tests with lots of labels, or labels that produce a lot of data,
+can see the `/labelValues` transfer json size grow well beyond what they need for a particular integration. Horreum has the `include` and `exclude`
+query parameter options on the `/labelValues` endpoint.
+
+### Include
+Adding `include=foo` to the `/labelValues` endpoint query tells Horreum to only include the `foo` label and its value in the `values` part of the 
+`/labelValues` response. You can specify multiple labels with `incude=foo&include=bar` or `include=foo,bar` using url encoding or with curl:
+```bash
+curl --query-param "include=foo" --query-param "include=bar" ...
+```
+
+Note: any `include` that is also mentioned in `exclude` will not be part of the response `values`
+
+### Exclude
+This functions similar to `include` except that it removes a label name from the response `values` field for the `/labelValues` endpoint. This filter
+option leaves all other labels in the `values` field.
+If a user specifies both `include` and `exclude` then the response will only contain the `include` label names that are not also in `exclude`. If all
+`include` are also in `exclude` then the `exclude` takes priority and the response will contain all labels that are not mentioned in `exclude`.
+Horreum uses this default behavior to avoid sending any data that is explicitly excluded. 

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1012,6 +1012,22 @@ paths:
           default: 0
           type: integer
         example: 2
+      - name: include
+        in: query
+        description: name of a label to include in the result
+        schema:
+          type: array
+          items:
+            type: string
+        example: id
+      - name: exclude
+        in: query
+        description: name of a label to exclude from the result
+        schema:
+          type: array
+          items:
+            type: string
+        example: id
       responses:
         "200":
           description: label Values
@@ -2008,7 +2024,7 @@ paths:
       tags:
       - Test
       description: List all Label Values for a Test
-      operationId: listLabelValues
+      operationId: labelValues
       parameters:
       - name: id
         in: path
@@ -2090,6 +2106,22 @@ paths:
           default: 0
           type: integer
         example: 2
+      - name: include
+        in: query
+        description: name of a label to include in the result
+        schema:
+          type: array
+          items:
+            type: string
+        example: id
+      - name: exclude
+        in: query
+        description: name of a label to exclude from the result
+        schema:
+          type: array
+          items:
+            type: string
+        example: id
       responses:
         "200":
           description: OK

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.Separator;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 @Path("/api/run")
@@ -110,7 +111,17 @@ public interface RunService {
             @Parameter(name = "sort", description = "label name for sorting"),
             @Parameter(name = "direction",description = "either Ascending or Descending",example="count"),
             @Parameter(name = "limit",description = "the maximum number of results to include",example="10"),
-            @Parameter(name = "page",description = "which page to skip to when using a limit",example="2")
+            @Parameter(name = "page",description = "which page to skip to when using a limit",example="2"),
+            @Parameter(name = "include", description = "label name(s) to include in the result as scalar or comma separated",
+                    examples = {
+                            @ExampleObject(name="single", value="id", description = "including a single label"),
+                            @ExampleObject(name="multiple", value="id,count", description = "including multiple labels")
+                    }),
+            @Parameter(name = "exclude", description = "label name(s) to exclude from the result as scalar or comma separated",
+                    examples = {
+                            @ExampleObject(name="single", value="id", description = "excluding a single label"),
+                            @ExampleObject(name="multiple", value="id,count", description = "excluding multiple labels")
+                    })
     })
     @APIResponses(
             value = {
@@ -132,7 +143,9 @@ public interface RunService {
             @QueryParam("sort") @DefaultValue("") String sort,
             @QueryParam("direction") @DefaultValue("Ascending") String direction,
             @QueryParam("limit") @DefaultValue(""+Integer.MAX_VALUE) int limit,
-            @QueryParam("page") @DefaultValue("0") int page);
+            @QueryParam("page") @DefaultValue("0") int page,
+            @QueryParam("include") @Separator(",") List<String> include,
+            @QueryParam("exclude") @Separator(",") List<String> exclude);
 
     @GET
     @Path("{id}/metadata")

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.Separator;
 
 import java.util.Collection;
 import java.util.List;
@@ -216,7 +217,17 @@ public interface TestService {
            @Parameter(name = "sort", description = "json path to sortable value or start or stop for sorting by time",example = "$.label or start or stop"),
            @Parameter(name = "direction",description = "either Ascending or Descending",example="count"),
            @Parameter(name = "limit",description = "the maximum number of results to include",example="10"),
-           @Parameter(name = "page",description = "which page to skip to when using a limit",example="2")
+           @Parameter(name = "page",description = "which page to skip to when using a limit",example="2"),
+           @Parameter(name = "include", description = "label name(s) to include in the result as scalar or comma separated",
+                   examples = {
+                           @ExampleObject(name="single", value="id", description = "including a single label"),
+                           @ExampleObject(name="multiple", value="id,count", description = "including multiple labels")
+                   }),
+           @Parameter(name = "exclude", description = "label name(s) to exclude from the result as scalar or comma separated",
+                   examples = {
+                           @ExampleObject(name="single", value="id", description = "excluding a single label"),
+                           @ExampleObject(name="multiple", value="id,count", description = "excluding multiple labels")
+                   })
    })
    @APIResponses(
            value = { @APIResponse( responseCode = "200",
@@ -224,7 +235,7 @@ public interface TestService {
                            @Content ( schema = @Schema(type = SchemaType.ARRAY, implementation = ExportedLabelValues.class)) }
            )}
    )
-   List<ExportedLabelValues> listLabelValues(
+   List<ExportedLabelValues> labelValues(
            @PathParam("id") int testId,
            @QueryParam("filter") @DefaultValue("{}") String filter,
            @QueryParam("before") @DefaultValue("") String before,
@@ -234,7 +245,9 @@ public interface TestService {
            @QueryParam("sort") @DefaultValue("") String sort,
            @QueryParam("direction") @DefaultValue("Ascending") String direction,
            @QueryParam("limit") @DefaultValue(""+Integer.MAX_VALUE) int limit,
-           @QueryParam("page") @DefaultValue("0") int page);
+           @QueryParam("page") @DefaultValue("0") int page,
+           @QueryParam("include") @Separator(",") List<String> include,
+           @QueryParam("exclude") @Separator(",") List<String> exclude);
 
    @POST
    @Consumes(MediaType.APPLICATION_JSON)

--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -232,7 +232,7 @@ export default function TestDatasets() {
     }
 
     const labelsSource = useCallback(() => {
-        return testApi.listLabelValues(testIdInt)
+        return testApi.labelValues(testIdInt)
             .then((result: Array<ExportedLabelValues>) => {
                 return flattenLabelValues(result);
             })


### PR DESCRIPTION
`labelValues` can contain a large number of entries or a large amount of data depending on how a team uses labels. Including all labels for every request can create large json responses and impact the performance of Horreum and the perceived peformance of services that consume the endpoint. 
This adds the `include` and `exclude` query parameters to the `labelValues` endpoint for both runs and tests so that users have more control over what data they fetch from Horreum.

Closes #1530 