### PR TITLE
[0.12.x] fix 1514 with empty string check

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -634,6 +634,9 @@ public class Util {
          return Instant.ofEpochMilli(((Number) time).longValue());
       } else {
          String str = time.toString().trim();
+         if(str.isBlank()){
+            return null;
+         }
          if(str.matches("\\d+")){
             try {
                return Instant.ofEpochMilli(Long.parseLong((String) time));
@@ -653,7 +656,7 @@ public class Util {
          try {
             return ZonedDateTime.parse(str, DateTimeFormatter.ISO_DATE_TIME).toInstant();
          } catch (DateTimeParseException e) {
-            log.warn("failed to convert "+time+" to timestamp using "+str,e);
+            log.debug("failed to convert "+time+" to timestamp using "+str);
          }
       }
       return null;//nothing matched


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1536

Check if the string value of the time passed to Util.toInstant is blank before trying to convert the value. This will prevent logging the error message when toInstant should not attempt a conversion. Also changed from warn to debug when logging the failed conversion because failed user conversions are expected rather than something that requires a warning.

closes #1514