### PR TITLE
Automate openapi changes notification to Horreum clients

### DIFF
--- a/.github/workflows/notify-clients.yaml
+++ b/.github/workflows/notify-clients.yaml
@@ -1,0 +1,34 @@
+name: Notify clients
+
+on:
+  push:
+    branches:
+      - main
+      - 0.12.x
+    paths:
+      - "docs/site/content/en/openapi/openapi.yaml"
+
+jobs:
+  clients-notification:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        clients:
+          - name: Golang
+            repository: Hyperfoil/horreum-client-golang
+          - name: Python
+            repository: Hyperfoil/horreum-client-python
+
+    steps:
+      - name: Extract trigger branch
+        id: extractor
+        shell: bash
+        run: |
+          echo "current_branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      - name: Notify ${{ matrix.clients.name }} client
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CLIENTS_NOTIFICATION_TOKEN }}
+          repository: ${{ matrix.clients.repository }}
+          event-type: detected-horreum-openapi-change
+          client-payload: '{"branch": "${{ steps.extractor.outputs.current_branch }}"}'

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -150,6 +150,17 @@ on:
   workflow_dispatch:
 ```
 
+Update the Github action to notify openapi changes to the clients on every stable branch push:
+```yaml
+on:
+  push:
+    branches:
+      - main
+      - 0.12.x
+    paths:
+      - "docs/site/content/en/openapi/openapi.yaml"
+```
+
 Commit the changes:
 
 ```bash


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1550
Fixes https://github.com/Hyperfoil/Horreum/issues/1545

## Changes proposed

Automate the clients notification every time there is a change in the `openapi` spec.
The notification is implemented using the `peter-evans/repository-dispatch@v3`.

- [ ] We need to create an additional secret only for this action, as stated in the [doc](https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token) we should created a Personal Access Token with the `public_repo` scope and store it as a secret.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
