### PR TITLE
MPL-68: make run_schemas updates asynchronous

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/bus/AsyncEventChannels.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/bus/AsyncEventChannels.java
@@ -15,5 +15,6 @@ public enum AsyncEventChannels {
     RUN_VALIDATED,
     CHANGE_NEW,
     EXPERIMENT_RESULT_NEW,
+    SCHEMA_SYNC,
     FOOBAR
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -10,7 +10,6 @@ import io.hyperfoil.tools.horreum.api.data.TestExport;
 import io.hyperfoil.tools.horreum.api.services.ExperimentService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
 import io.hyperfoil.tools.horreum.entity.data.ActionDAO;
-import io.hyperfoil.tools.horreum.entity.data.SchemaDAO;
 import io.hyperfoil.tools.horreum.events.DatasetChanges;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.Vertx;
@@ -84,6 +83,10 @@ public class ServiceMediator {
     @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 10000)
     @Channel("run-recalc-out")
     Emitter<Integer> runEmitter;
+
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 10000)
+    @Channel("schema-sync-out")
+    Emitter<Integer> schemaEmitter;
 
     private Map<AsyncEventChannels, Map<Integer, BlockingQueue<Object>>> events =  new ConcurrentHashMap<>();
 
@@ -168,6 +171,18 @@ public class ServiceMediator {
         runEmitter.send(runId);
     }
 
+    @Incoming("schema-sync-in")
+    @Blocking(ordered = false, value = "horreum.schema.pool")
+    @ActivateRequestContext
+    public void processSchemaSync(int schemaId) {
+        runService.onNewOrUpdatedSchema(schemaId);
+    }
+
+    @Transactional(Transactional.TxType.NOT_SUPPORTED)
+    void queueSchemaSync(int schemaId) {
+        schemaEmitter.send(schemaId);
+    }
+
     void dataPointsProcessed(DataPoint.DatasetProcessedEvent event) {
         experimentService.onDatapointsCreated(event);
     }
@@ -216,9 +231,6 @@ public class ServiceMediator {
             subscriptionService.importSubscriptions(test);
     }
 
-    public void newOrUpdatedSchema(SchemaDAO schema) {
-        runService.processNewOrUpdatedSchema(schema);
-    }
     public void updateFingerprints(int testId) {
         datasetService.updateFingerprints(testId);
     }
@@ -246,7 +258,7 @@ public class ServiceMediator {
     }
 
     public <T> BlockingQueue<T> getEventQueue(AsyncEventChannels channel, Integer id) {
-        if (testMode ) {
+        if (testMode) {
             events.putIfAbsent(channel, new HashMap<>());
             BlockingQueue<?> queue = events.get(channel).computeIfAbsent(id, k -> new LinkedBlockingQueue<>());
             return (BlockingQueue<T>) queue;

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -46,6 +46,18 @@ mp.messaging.outgoing.run-recalc-out.address=run-recalc
 mp.messaging.outgoing.run-recalc-out.durable=true
 mp.messaging.outgoing.run-recalc-out.container-id=horreum-broker
 mp.messaging.outgoing.run-recalc-out.link-name=run-recalc
+# schema-sync incoming
+mp.messaging.incoming.schema-sync-in.connector=smallrye-amqp
+mp.messaging.incoming.schema-sync-in.address=schema-sync
+mp.messaging.incoming.schema-sync-in.durable=true
+mp.messaging.incoming.schema-sync-in.container-id=horreum-broker
+mp.messaging.incoming.schema-sync-in.link-name=schema-sync
+# schema-sync outgoing
+mp.messaging.outgoing.schema-sync-out.connector=smallrye-amqp
+mp.messaging.outgoing.schema-sync-out.address=schema-sync
+mp.messaging.outgoing.schema-sync-out.durable=true
+mp.messaging.outgoing.schema-sync-out.container-id=horreum-broker
+mp.messaging.outgoing.schema-sync-out.link-name=schema-sync
 
 ## Datasource updated by Liquibase - the same as app but always with superuser credentials
 
@@ -74,8 +86,9 @@ horreum.test-mode=false
 #quarkus.native.additional-build-args=
 
 # thread pool sizes
-smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
-smallrye.messaging.worker.horreum.run.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=7
+smallrye.messaging.worker.horreum.run.pool.max-concurrency=7
+smallrye.messaging.worker.horreum.schema.pool.max-concurrency=7
 
 
 hibernate.jdbc.time_zone=UTC

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
@@ -31,6 +31,7 @@ import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.oidc.server.OidcWiremockTestResource;
 import io.restassured.common.mapper.TypeRef;
 import jakarta.inject.Inject;
+import jakarta.persistence.Tuple;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestInfo;
 
@@ -261,7 +262,7 @@ public class SchemaServiceTest extends BaseServiceTest {
    }
 
    @org.junit.jupiter.api.Test
-   public void testFindUsages(TestInfo info) throws InterruptedException  {
+   public void testFindUsages() throws InterruptedException  {
       Test test = createTest(createExampleTest("nofilter"));
       createComparisonSchema();
       uploadExampleRuns(test);
@@ -273,12 +274,145 @@ public class SchemaServiceTest extends BaseServiceTest {
 
       assertNotEquals(0, report.data.size());
 
-      List<SchemaService.LabelLocation> usages = jsonRequest().get("/api/schema/findUsages?label=".concat("category"))
-                .then().statusCode(200).extract().body().as(List.class);
+      List<SchemaService.LabelLocation> usages =
+              jsonRequest().get("/api/schema/findUsages?label=".concat("category"))
+              .then().statusCode(200).extract().body().as(List.class);
 
       assertNotNull(usages);
-
    }
 
+   @org.junit.jupiter.api.Test
+   public void testCreateSchemaAfterRunWithArrayData() throws InterruptedException {
+      String schemaUri = "urn:unknown:schema";
+      Test test = createTest(createExampleTest("dummy-test"));
 
+      ArrayNode data = JsonNodeFactory.instance.arrayNode();
+      data.addObject().put("$schema", schemaUri).put("foo", "bar");
+      data.addObject().put("$schema", schemaUri).put("foo", "bar");
+      int runId = uploadRun(data.toString(), test.name);
+      assertTrue(runId > 0);
+
+      // no validation errors
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+
+      List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+      assertEquals(0, runSchemasBefore.size());
+
+      // create the schema afterward
+      Schema schema = createSchema("Unknown schema", schemaUri);
+      assertNotNull(schema);
+      assertTrue(schema.id > 0);
+
+      TestUtil.eventually(() -> {
+         Util.withTx(tm, () -> {
+            em.clear();
+            List<?> runSchemas = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+            // two records as the run is an array of two objects, both referencing the same schema
+            assertEquals(2, runSchemas.size());
+            return null;
+         });
+      });
+   }
+
+   @org.junit.jupiter.api.Test
+   public void testCreateSchemaAfterRunWithMultipleSchemas() throws InterruptedException {
+      String firstSchemaUri = "urn:unknown1:schema";
+      String secondSchemaUri = "urn:unknown2:schema";
+      Test test = createTest(createExampleTest("dummy-test"));
+
+      ArrayNode data = JsonNodeFactory.instance.arrayNode();
+      data.addObject().put("$schema", firstSchemaUri).put("foo", "bar");
+      data.addObject().put("$schema", secondSchemaUri).put("foo", "zip");
+      int runId = uploadRun(data.toString(), test.name);
+      assertTrue(runId > 0);
+
+      // no validation errors
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+
+      List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+      assertEquals(0, runSchemasBefore.size());
+
+      // create the schema 1 afterward
+      Schema schema1 = createSchema("Unknown schema 1", firstSchemaUri);
+      assertNotNull(schema1);
+      assertTrue(schema1.id > 0);
+
+      TestUtil.eventually(() -> {
+         Util.withTx(tm, () -> {
+            em.clear();
+            List<Tuple> runSchemas = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1", Tuple.class).setParameter(1, runId).getResultList();
+            // 1 record as the run is an array of two objects referencing different schemas and only the first one is created
+            assertEquals(1, runSchemas.size());
+            assertEquals(schema1.id, (int)runSchemas.get(0).get(3));
+            return null;
+         });
+      });
+   }
+
+   @org.junit.jupiter.api.Test
+   public void testCreateSchemaAfterRunWithObjectData() throws InterruptedException {
+      String schemaUri = "urn:unknown:schema";
+      Test test = createTest(createExampleTest("dummy-test"));
+
+      ObjectNode data = JsonNodeFactory.instance.objectNode();
+      data.put("$schema", schemaUri).put("foo", "bar");
+      int runId = uploadRun(data.toString(), test.name);
+      assertTrue(runId > 0);
+
+      // no validation errors
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+
+      List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+      assertEquals(0, runSchemasBefore.size());
+
+      // create the schema afterward
+      Schema schema = createSchema("Unknown schema", schemaUri);
+      assertNotNull(schema);
+      assertTrue(schema.id > 0);
+
+      TestUtil.eventually(() -> {
+         Util.withTx(tm, () -> {
+            em.clear();
+            List<?> runSchemas = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+            // run has single object data, thus referencing one schema
+            assertEquals(1, runSchemas.size());
+            return null;
+         });
+      });
+   }
+
+   @org.junit.jupiter.api.Test
+   public void testChangeUriForReferencedSchema() throws InterruptedException {
+      String schemaUri = "urn:dummy:schema";
+      Schema schema = createSchema("Dummy schema", schemaUri);
+      assertNotNull(schema);
+      assertTrue(schema.id > 0);
+
+      Test test = createTest(createExampleTest("dummy-test"));
+
+      ArrayNode data = JsonNodeFactory.instance.arrayNode();
+      data.addObject().put("$schema", schemaUri).put("foo", "bar");
+      data.addObject().put("$schema", schemaUri).put("foo", "bar");
+      int runId = uploadRun(data.toString(), test.name);
+      assertTrue(runId > 0);
+
+      // no validation errors
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+
+      List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+      assertEquals(2, runSchemasBefore.size());
+
+      // update the schema uri afterward
+      schema.uri = "urn:new-dummy:schema";
+      Schema updatedSchema = addOrUpdateSchema(schema);
+      assertNotNull(updatedSchema);
+      assertEquals(schema.id, updatedSchema.id);
+
+      List<?> runSchemasAfter = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
+      assertEquals(0, runSchemasAfter.size());
+   }
 }

--- a/horreum-web/src/Banner.tsx
+++ b/horreum-web/src/Banner.tsx
@@ -3,19 +3,58 @@ import { useEffect, useState } from "react"
 import { Alert } from "@patternfly/react-core"
 import {Banner as BannerData, bannerApi} from "./api"
 
-export default function Banner() {
-    const [banner, setBanner] = useState<BannerData>()
-    const [updateCounter, setUpdateCounter] = useState(0)
-    useEffect(() => {
-        setTimeout(() => setUpdateCounter(updateCounter + 1), 60000)
-        bannerApi.get().then(setBanner)
-    }, [updateCounter])
-    if (!banner) {
-        return null
-    }
+function getAlertBanner(banner: BannerData) {
     return (
         <Alert variant={banner.severity as any} title={banner.title} isInline>
             <div dangerouslySetInnerHTML={{ __html: banner.message || "" }}></div>
         </Alert>
     )
+}
+
+// 30 seconds
+const DEFAULT_TIMEOUT = 30000
+export type TimeoutBannerProps = {
+    bannerData: BannerData
+    timeout?: number
+    onTimeout?: () => void
+}
+
+export function TimeoutBanner({bannerData, timeout, onTimeout}: TimeoutBannerProps) {
+    timeout = timeout ?? DEFAULT_TIMEOUT
+    const [banner, setBanner] = useState<BannerData | undefined>(bannerData)
+
+    useEffect(() => {
+        if (banner) {
+            const timeoutId = setTimeout(() => {
+                setBanner(undefined)
+                if (onTimeout) {
+                    onTimeout()
+                }
+            }, timeout)
+
+            return () => clearTimeout(timeoutId);
+        }
+    }, [])
+
+    if (!banner) {
+        return null
+    }
+
+    return getAlertBanner(banner)
+}
+
+export default function Banner() {
+    const [banner, setBanner] = useState<BannerData>()
+    const [updateCounter, setUpdateCounter] = useState(0)
+    useEffect(() => {
+        const timeoutId = setTimeout(() => setUpdateCounter(updateCounter + 1), 60000)
+        bannerApi.get().then(setBanner)
+
+        return () => clearTimeout(timeoutId)
+    }, [updateCounter])
+    if (!banner) {
+        return null
+    }
+
+    return getAlertBanner(banner)
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1579

## Changes proposed

Changes:
- [x] create new channel named `schema-sync-{in, out}` and related event `CreateOrUpdateEvent` (TBH I think this could be simplified further as we just need the `schemaId` value, thus we can remove the event and keep an id only)
- [x] move `newOrUpdatedSchema` from `ServiceMediator` to `SchemaServiceImpl` for coherence (especially as we need the TxManager)
- [x] make `runService.onNewOrUpdatedSchema(event.id);` asynchronous

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
