### PR TITLE
[0.12.x] MPL-68: make run_schemas updates asynchronous

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/bus/MessageBusChannels.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/bus/MessageBusChannels.java
@@ -15,5 +15,6 @@ public enum MessageBusChannels {
     RUN_VALIDATED,
     CHANGE_NEW,
     EXPERIMENT_RESULT_NEW,
+    SCHEMA_SYNC,
     FOOBAR
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
@@ -187,17 +187,22 @@ public class SchemaServiceImpl implements SchemaService {
                     .setParameter(1, schema.id).executeUpdate();
             em.createNativeQuery("DELETE FROM dataset_schemas WHERE schema_id = ?1")
                     .setParameter(1, schema.id).executeUpdate();
-            mediator.newOrUpdatedSchema(schema);
+            newOrUpdatedSchema(schema);
          }
       }
       else {
          schema.id = null;
          schema.persist();
          em.flush();
-         mediator.newOrUpdatedSchema(schema);
+         newOrUpdatedSchema(schema);
       }
       log.debugf("Added schema %s (%d), URI %s", schema.name, schema.id, schema.uri);
       return schema.id;
+   }
+
+   private void newOrUpdatedSchema(SchemaDAO schema) {
+      log.debugf("Push schema event for async run schemas update: %d (%s)", schema.id, schema.uri);
+      Util.registerTxSynchronization(tm, txStatus -> mediator.queueSchemaSync(schema.id));
    }
 
    private void verifyNewSchema(Schema schemaDTO) {

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -46,6 +46,18 @@ mp.messaging.outgoing.run-recalc-out.address=run-recalc
 mp.messaging.outgoing.run-recalc-out.durable=true
 mp.messaging.outgoing.run-recalc-out.container-id=horreum-broker
 mp.messaging.outgoing.run-recalc-out.link-name=run-recalc
+# schema-sync incoming
+mp.messaging.incoming.schema-sync-in.connector=smallrye-amqp
+mp.messaging.incoming.schema-sync-in.address=schema-sync
+mp.messaging.incoming.schema-sync-in.durable=true
+mp.messaging.incoming.schema-sync-in.container-id=horreum-broker
+mp.messaging.incoming.schema-sync-in.link-name=schema-sync
+# schema-sync outgoing
+mp.messaging.outgoing.schema-sync-out.connector=smallrye-amqp
+mp.messaging.outgoing.schema-sync-out.address=schema-sync
+mp.messaging.outgoing.schema-sync-out.durable=true
+mp.messaging.outgoing.schema-sync-out.container-id=horreum-broker
+mp.messaging.outgoing.schema-sync-out.link-name=schema-sync
 
 ## Datasource updated by Liquibase - the same as app but always with superuser credentials
 
@@ -74,8 +86,9 @@ horreum.test-mode=false
 #quarkus.native.additional-build-args=
 
 # thread pool sizes
-smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
-smallrye.messaging.worker.horreum.run.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=7
+smallrye.messaging.worker.horreum.run.pool.max-concurrency=7
+smallrye.messaging.worker.horreum.schema.pool.max-concurrency=7
 
 
 hibernate.jdbc.time_zone=UTC

--- a/horreum-web/src/Banner.tsx
+++ b/horreum-web/src/Banner.tsx
@@ -3,19 +3,58 @@ import { useEffect, useState } from "react"
 import { Alert } from "@patternfly/react-core"
 import {Banner as BannerData, bannerApi} from "./api"
 
-export default function Banner() {
-    const [banner, setBanner] = useState<BannerData>()
-    const [updateCounter, setUpdateCounter] = useState(0)
-    useEffect(() => {
-        setTimeout(() => setUpdateCounter(updateCounter + 1), 60000)
-        bannerApi.get().then(setBanner)
-    }, [updateCounter])
-    if (!banner) {
-        return null
-    }
+function getAlertBanner(banner: BannerData) {
     return (
         <Alert variant={banner.severity as any} title={banner.title} isInline>
             <div dangerouslySetInnerHTML={{ __html: banner.message || "" }}></div>
         </Alert>
     )
+}
+
+// 30 seconds
+const DEFAULT_TIMEOUT = 30000
+export type TimeoutBannerProps = {
+    bannerData: BannerData
+    timeout?: number
+    onTimeout?: () => void
+}
+
+export function TimeoutBanner({bannerData, timeout, onTimeout}: TimeoutBannerProps) {
+    timeout = timeout ?? DEFAULT_TIMEOUT
+    const [banner, setBanner] = useState<BannerData | undefined>(bannerData)
+
+    useEffect(() => {
+        if (banner) {
+            const timeoutId = setTimeout(() => {
+                setBanner(undefined)
+                if (onTimeout) {
+                    onTimeout()
+                }
+            }, timeout)
+
+            return () => clearTimeout(timeoutId);
+        }
+    }, [])
+
+    if (!banner) {
+        return null
+    }
+
+    return getAlertBanner(banner)
+}
+
+export default function Banner() {
+    const [banner, setBanner] = useState<BannerData>()
+    const [updateCounter, setUpdateCounter] = useState(0)
+    useEffect(() => {
+        const timeoutId = setTimeout(() => setUpdateCounter(updateCounter + 1), 60000)
+        bannerApi.get().then(setBanner)
+
+        return () => clearTimeout(timeoutId)
+    }, [updateCounter])
+    if (!banner) {
+        return null
+    }
+
+    return getAlertBanner(banner)
 }


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1581

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1579

## Changes proposed

Changes:
- [x] create new channel named `schema-sync-{in, out}` and related event `CreateOrUpdateEvent` (TBH I think this could be simplified further as we just need the `schemaId` value, thus we can remove the event and keep an id only)
- [x] move `newOrUpdatedSchema` from `ServiceMediator` to `SchemaServiceImpl` for coherence (especially as we need the TxManager)
- [x] make `runService.onNewOrUpdatedSchema(event.id);` asynchronous

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
