### PR TITLE
MPL-75: Establish schemas team selector

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -675,6 +675,7 @@ paths:
         description: query string to filter runs
         schema:
           type: string
+        example: $.*
       - name: matchAll
         in: query
         description: match all Runs?
@@ -1296,6 +1297,12 @@ paths:
         schema:
           $ref: '#/components/schemas/SortDirection'
         example: Ascending
+      - name: roles
+        in: query
+        description: "__my, __all or a comma delimited  list of roles"
+        schema:
+          type: string
+        example: __my
       responses:
         "200":
           description: OK

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -90,9 +90,11 @@ public interface SchemaService {
            @Parameter(name = "limit", description = "limit the number of results", example = "20"),
            @Parameter(name = "page", description = "filter by page number of a paginated list of Schemas", example = "2"),
            @Parameter(name = "sort", description = "Field name to sort results", example = "name"),
-           @Parameter(name = "direction", description = "Sort direction", example ="Ascending")
+           @Parameter(name = "direction", description = "Sort direction", example ="Ascending"),
+           @Parameter(name = "roles", description = "__my, __all or a comma delimited  list of roles", example = "__my"),
    })
-   SchemaQueryResult list(@QueryParam("limit") Integer limit,
+   SchemaQueryResult list(@QueryParam("roles") String roles,
+                          @QueryParam("limit") Integer limit,
                           @QueryParam("page") Integer page,
                           @QueryParam("sort") String sort,
                           @QueryParam("direction") SortDirection direction);

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/TestService.java
@@ -380,6 +380,9 @@ public interface TestService {
       @JsonProperty(required = true)
       public long count;
 
+      // required for automatic parsing in testing
+      public TestQueryResult() {}
+
       public TestQueryResult(List<Test> tests, long count) {
          this.tests = tests;
          this.count = count;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Roles.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Roles.java
@@ -20,8 +20,8 @@ public final class Roles {
    public static final String HORREUM_SYSTEM = "horreum.system";
    public static final String HORREUM_MESSAGEBUS = "horreum.messagebus";
 
-   private static final String MY_ROLES = "__my";
-   private static final String ALL_ROLES = "__all";
+   public static final String MY_ROLES = "__my";
+   public static final String ALL_ROLES = "__all";
 
    private Roles() {}
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -1,20 +1,31 @@
 package io.hyperfoil.tools.horreum.svc;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.hyperfoil.tools.horreum.api.SortDirection;
-import io.hyperfoil.tools.horreum.api.data.*;
-import io.hyperfoil.tools.horreum.api.data.datastore.DatastoreType;
 import io.hyperfoil.tools.horreum.api.data.Access;
+import io.hyperfoil.tools.horreum.api.data.ExportedLabelValues;
+import io.hyperfoil.tools.horreum.api.data.Fingerprints;
+import io.hyperfoil.tools.horreum.api.data.Test;
+import io.hyperfoil.tools.horreum.api.data.TestExport;
+import io.hyperfoil.tools.horreum.api.data.TestToken;
+import io.hyperfoil.tools.horreum.api.data.datastore.DatastoreType;
+import io.hyperfoil.tools.horreum.api.services.TestService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
 import io.hyperfoil.tools.horreum.entity.alerting.WatchDAO;
 import io.hyperfoil.tools.horreum.entity.backend.DatastoreConfigDAO;
-import io.hyperfoil.tools.horreum.entity.data.*;
+import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
+import io.hyperfoil.tools.horreum.entity.data.RunDAO;
+import io.hyperfoil.tools.horreum.entity.data.TestDAO;
+import io.hyperfoil.tools.horreum.entity.data.TestTokenDAO;
+import io.hyperfoil.tools.horreum.entity.data.TransformerDAO;
+import io.hyperfoil.tools.horreum.entity.data.ViewDAO;
 import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
 import io.hyperfoil.tools.horreum.mapper.DatasourceMapper;
 import io.hyperfoil.tools.horreum.mapper.TestMapper;
 import io.hyperfoil.tools.horreum.mapper.TestTokenMapper;
-import io.hyperfoil.tools.horreum.api.services.TestService;
 import io.hyperfoil.tools.horreum.server.EncryptionManager;
 import io.hyperfoil.tools.horreum.server.WithRoles;
 import io.hyperfoil.tools.horreum.server.WithToken;
@@ -23,23 +34,18 @@ import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
-
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
-import jakarta.persistence.*;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Query;
+import jakarta.persistence.Tuple;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-
-import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 import org.hibernate.Hibernate;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
@@ -48,8 +54,11 @@ import org.hibernate.query.NativeQuery;
 import org.hibernate.type.StandardBasicTypes;
 import org.jboss.logging.Logger;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class TestServiceImpl implements TestService {
    private static final Logger log = Logger.getLogger(TestServiceImpl.class);
@@ -278,7 +287,7 @@ public class TestServiceImpl implements TestService {
       PanacheQuery<TestDAO> query;
       Set<String> actualRoles = null;
       if (Roles.hasRolesParam(roles)) {
-         if (roles.equals("__my")) {
+         if (roles.equals(Roles.MY_ROLES)) {
             if (!identity.isAnonymous()) {
                actualRoles = identity.getRoles();
             }
@@ -297,7 +306,7 @@ public class TestServiceImpl implements TestService {
       if (limit != null && page != null) {
          query.page(Page.of(page, limit));
       }
-      return new TestQueryResult( query.list().stream().map(TestMapper::from).collect(Collectors.toList()), TestDAO.count() ) ;
+      return new TestQueryResult(query.list().stream().map(TestMapper::from).toList(), TestDAO.count());
    }
 
    @Override

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -212,7 +212,7 @@ public class BaseServiceTest {
       return createExampleTest(testName, null);
    }
 
-      public static Test createExampleTest(String testName, Integer datastoreID) {
+   public static Test createExampleTest(String testName, Integer datastoreID) {
       Test test = new Test();
       test.name = testName;
       test.description = "Bar";


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1589

## Changes proposed

- [x] Re-establish the schemas filter by team from the UI (that was hidden as part of https://github.com/Hyperfoil/Horreum/pull/1290 because not properly implemented)
- [x] Implemented schemas filtering by roles (i.e., team selection), the same way it is implemented on tests side 
- [x] Improve some test cases for both tests and schemas (focusing on this team filtering)

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
