### PR TITLE
Change backporting strategy

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
       - labeled
 
 env:
-  GITHUB_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NO_SQUASH_OPTION: true
 
 jobs:
@@ -39,9 +39,12 @@ jobs:
         run: |
           echo "NO_SQUASH_OPTION=false" >> $GITHUB_ENV
       - name: Backporting
-        uses: kiegroup/git-backporting@v4.7.1
+        uses: kiegroup/git-backporting@v4
         with:
           target-branch: 0.12.x
           pull-request: ${{ github.event.pull_request.url }}
-          auth: ${{ secrets.BACKPORT_TOKEN }}
+          auth: ${{ secrets.GITHUB_TOKEN }}
           no-squash: ${{ env.NO_SQUASH_OPTION }}
+          strategy: ort
+          strategy-option: ours
+          enable-err-notification: true


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

As per [discussion](https://github.com/Hyperfoil/Horreum/discussions/1601), this is my proposal for the backporting cherry-pick strategy in order to be more confident on the backported changes.

## Changes proposed

- [x] Change the cherry-pick/merge strategy to [ort](https://git-scm.com/docs/merge-strategies#Documentation/merge-strategies.txt-ort) with option [find-renames](https://git-scm.com/docs/merge-strategies#Documentation/merge-strategies.txt-find-renamesltngt).
  - [x] [edit] After discussion, set conflict resolution to [ours](https://git-scm.com/docs/merge-strategies#Documentation/merge-strategies.txt-ours) instead of `find-renames`. 
- [x] Enabled error notification on the original pull request, such that we don't have to monitor the jobs but we will get notified if the job failed on the original pr.
- [x] Use `GITHUB_TOKEN` that will have proper privileges

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
