### PR TITLE
Fix SecurityMigration realm

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityMigration.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityMigration.java
@@ -26,7 +26,7 @@ public class SecurityMigration {
     private static final Logger LOGGER = Logger.getLogger("SecurityMigration");
 
     @ConfigProperty(name = "quarkus.keycloak.admin-client.server-url") Optional<String> keycloakURL;
-    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
 
     @ConfigProperty(name = "horreum.roles.provider", defaultValue = "keycloak") String provider;
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
@@ -43,7 +43,7 @@ public class KeycloakUserBackend implements UserBackEnd {
 
     private static final String[] ROLE_TYPES = new String[] { "team", Roles.VIEWER, Roles.TESTER, Roles.UPLOADER, Roles.MANAGER };
 
-    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
 
     // please make sure all calls to this object are in a try/catch block to avoid leaking information
     @Inject Keycloak keycloak;

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/KeycloakUserServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/KeycloakUserServiceTest.java
@@ -1,9 +1,44 @@
 package io.hyperfoil.tools.horreum.svc;
 
 import io.hyperfoil.tools.horreum.test.KeycloakTestProfile;
+import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.ws.rs.client.ClientBuilder;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
 
 @TestProfile(KeycloakTestProfile.class)
 @QuarkusTest public class KeycloakUserServiceTest extends UserServiceAbstractTest {
+
+    @BeforeAll static void setupClient() {
+        try (Keycloak keycloak = KeycloakBuilder.builder()
+                                                .serverUrl(ConfigProvider.getConfig().getValue("quarkus.keycloak.admin-client.server-url", String.class))
+                                                .realm("master")
+                                                .username("admin")
+                                                .password("admin")
+                                                .clientId("admin-cli")
+                                                .resteasyClient(((ResteasyClientBuilder) ClientBuilder.newBuilder()).disableTrustManager().build())
+                                                .build()) {
+
+            // the client created in KeycloakTestResourceLifecycleManager (the keycloak dev service) lacks the "realm-admin" role on its service account
+            // without it, it has no permission to add / remove users and roles from the realm
+            // (on production instances these permission may be fine-tuned, as "realm-admin" is a composite role)
+
+            RealmResource realmResource = keycloak.realm(KeycloakTestProfile.REALM);
+            String clientId = realmResource.clients().findByClientId(KeycloakTestProfile.CLIENT).get(0).getId();
+            String managementId = realmResource.clients().findByClientId("realm-management").get(0).getId();
+            String serviceAccountId = realmResource.clients().get(clientId).getServiceAccountUser().getId();
+
+            RoleScopeResource managementRolesResource = realmResource.users().get(serviceAccountId).roles().clientLevel(managementId);
+            managementRolesResource.add(managementRolesResource.listAvailable().stream().filter(r -> "realm-admin".equals(r.getName())).toList());
+
+            Log.infov("realm-admin role added to {0} client", KeycloakTestProfile.CLIENT);
+        }
+    }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/KeycloakTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/KeycloakTestProfile.java
@@ -12,19 +12,23 @@ import static java.lang.System.getProperty;
 
 public class KeycloakTestProfile extends HorreumTestProfile {
 
+    public static final String CLIENT = "horreum-client", REALM = "horreum";
+
     @Override public Map<String, String> getConfigOverrides() {
         Map<String, String> configOverrides = new HashMap<>(super.getConfigOverrides());
         configOverrides.put("horreum.roles.provider", "keycloak");
 
-        configOverrides.put("quarkus.oidc.auth-server-url", "${keycloak.url}/realms/horreum/");
+        configOverrides.put("quarkus.oidc.auth-server-url", "${keycloak.url}/realms/" + REALM);
         configOverrides.put("quarkus.keycloak.admin-client.server-url", "${keycloak.url}");
-        configOverrides.put("quarkus.keycloak.admin-client.client-id", "admin-cli");
-        configOverrides.put("quarkus.keycloak.admin-client.realm", "master");
-        configOverrides.put("quarkus.keycloak.admin-client.grant-type", KeycloakAdminClientConfig.GrantType.PASSWORD.asString());
+        configOverrides.put("quarkus.keycloak.admin-client.client-id", CLIENT);
+        configOverrides.put("quarkus.keycloak.admin-client.realm", REALM);
+        configOverrides.put("quarkus.keycloak.admin-client.client-secret", "secret");
+        configOverrides.put("quarkus.keycloak.admin-client.grant-type", KeycloakAdminClientConfig.GrantType.CLIENT_CREDENTIALS.asString());
 
         configOverrides.put("keycloak.docker.image", getProperty("horreum.dev-services.keycloak.image"));
         configOverrides.put("keycloak.use.https", "false");
-        configOverrides.put("keycloak.realm", "horreum");
+        configOverrides.put("keycloak.service.client", CLIENT);
+        configOverrides.put("keycloak.realm", REALM);
 
         // create the base roles used to compose team roles
         configOverrides.put("keycloak.token.admin-roles", String.join(",", Roles.ADMIN, Roles.MANAGER, Roles.TESTER, Roles.VIEWER, Roles.UPLOADER));


### PR DESCRIPTION
the user management should rely only on the configuration of the `keycloak-admin` extension. that is independent of the OICD configuration. 