### PR TITLE
Avoid loading entity into 2nd level cache so that it isn't considered…

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/TestDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/TestDAO.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 
@@ -35,9 +36,16 @@ import static jakarta.persistence.GenerationType.SEQUENCE;
 import static org.hibernate.id.OptimizableGenerator.INCREMENT_PARAM;
 import static org.hibernate.id.enhanced.SequenceStyleGenerator.SEQUENCE_PARAM;
 
+@NamedQuery(
+    name = TestDAO.QUERY_TEST_NAME,
+    query = "SELECT name FROM test WHERE id = ?1"
+)
 @Entity(name="test")
 @JsonIgnoreType
 public class TestDAO extends PanacheEntityBase {
+
+   public static final String QUERY_TEST_NAME = "TestDAO.getNameById";
+
    @Id
    @GenericGenerator(
          name = "testIdGenerator",

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/NotificationServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/NotificationServiceImpl.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
@@ -178,8 +179,9 @@ public class NotificationServiceImpl implements NotificationService {
    }
 
    public void notifyMissingDataset(int testId, String ruleName, long maxStaleness, Instant lastTimestamp) {
-      TestDAO test = TestDAO.findById(testId);
-      String testName = test != null ? test.name : "<unknown test>";
+      String name = em.createNamedQuery(TestDAO.QUERY_TEST_NAME, String.class)
+         .setParameter(1, testId).getSingleResult();
+      String testName = name != null ? name : "<unknown test>";
       notifyAll(testId, n -> n.notifyMissingDataset(testName, testId, ruleName, maxStaleness, lastTimestamp));
    }
 


### PR DESCRIPTION
… stale by Hibernate which causes OptimisticLockException.

## Fixes Issue

fixes #1616 

## Changes proposed

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
