### PR TITLE
CI: check for uncommitted changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Build on ${{ matrix.os.name }}
     strategy:
       matrix:
         os:
@@ -41,6 +42,17 @@ jobs:
       run: mvn --version
     - name: Build and Test
       run: mvn clean install -B --file pom.xml ${{ matrix.os.build-options }}
+    - name: Check uncommitted changes
+      if: matrix.os.name == 'ubuntu-latest'
+      run: |
+        clean=$(git status --porcelain)
+        if [[ -z "$clean" ]]; then
+          echo "Empty git status --porcelain: $clean"
+        else
+          echo "Uncommitted file changes detected: $clean"
+          git diff
+          exit 1
+        fi
     - name: Upload artifact for failed workflow
       if: failure()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Proposing to add a check for uncommitted changes during PR checks, this is going to ensure that all those autogenerated files are properly committed (doing this especially for the openapi spec)

## Changes proposed

- [x] Checks for uncommitted changes during pull request checks

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
