### PR TITLE
Remove go to changes button

### DIFF
--- a/horreum-web/src/domain/alerting/Changes.tsx
+++ b/horreum-web/src/domain/alerting/Changes.tsx
@@ -259,7 +259,7 @@ export default function Changes(props: ChangesProps) {
         if (lineType !== "linear") {
             query += "&line=" + lineType
         }
-        return "?" + query.replace(/^&/, '');
+        return query.replace(/^&/, '');
     }
     useEffect(() => {
         if (!selectedTest) {
@@ -267,7 +267,10 @@ export default function Changes(props: ChangesProps) {
             return
         }
         document.title = `${selectedTest.id} | Horreum`
-        navigate(location.pathname + createQuery(false))
+        const query = createQuery(false)
+        if (query !== "") {
+            navigate(location.pathname + "?" + query)
+        }
     }, [selectedTest, selectedFingerprint, endTime, timespan, lineType, firstNow, history])
     useEffect(() => {
         setPanels([])

--- a/horreum-web/src/domain/tests/ChangeDetectionForm.tsx
+++ b/horreum-web/src/domain/tests/ChangeDetectionForm.tsx
@@ -209,9 +209,6 @@ type ActionsProps = {
 const Actions = (props: ActionsProps) => {
     return (
         <div>
-            <NavLink className="pf-v5-c-button pf-m-primary" to={"/changes?test=" + props.testName}>
-                Go to changes
-            </NavLink>
             {props.isTester && (
                 <>
                     <Button variant="secondary" onClick={props.onCopy}>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1639

## Changes proposed

Proposing to remove the "Go to changes" redirection from "Change detection" tab as it is no more needed given that with the latest UI refactoring both "Changes" and "Change detection" are under the `Test` page.

- [x] Remove the "Go to changes" redirection from "Change detection" tab
- [x] Fix URL query generation in "Changes" tab 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
