### PR TITLE
[0.14] Create initial account when there are no accounts in the system

### DIFF
--- a/horreum-backend/pom.xml
+++ b/horreum-backend/pom.xml
@@ -152,10 +152,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-elytron-security-properties-file</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elasticsearch-rest-client</artifactId>
         </dependency>
         <dependency>

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityBootstrap.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityBootstrap.java
@@ -1,47 +1,60 @@
 package io.hyperfoil.tools.horreum.server;
 
+import io.hyperfoil.tools.horreum.api.internal.services.UserService;
 import io.hyperfoil.tools.horreum.entity.user.Team;
 import io.hyperfoil.tools.horreum.entity.user.TeamMembership;
 import io.hyperfoil.tools.horreum.entity.user.TeamRole;
 import io.hyperfoil.tools.horreum.entity.user.UserInfo;
 import io.hyperfoil.tools.horreum.entity.user.UserRole;
 import io.hyperfoil.tools.horreum.svc.Roles;
+import io.hyperfoil.tools.horreum.svc.user.UserBackEnd;
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
+import java.security.SecureRandom;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
-@ApplicationScoped
-public class SecurityMigration {
+import static io.quarkus.runtime.configuration.ProfileManager.getLaunchMode;
 
-    private static final Logger LOGGER = Logger.getLogger("SecurityMigration");
+@ApplicationScoped public class SecurityBootstrap {
 
     @ConfigProperty(name = "quarkus.keycloak.admin-client.server-url") Optional<String> keycloakURL;
-    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
 
     @ConfigProperty(name = "horreum.roles.provider", defaultValue = "keycloak") String provider;
 
+    @ConfigProperty(name = "horreum.bootstrap.password") Optional<String> providedBootstrapPassword;
+
     private static final String MIGRATION_PROVIDER = "database";
+    private static final String BOOTSTRAP_ACCOUNT = "horreum.bootstrap";
+
+    private static final char[] RANDOM_PASSWRORD_CHARS = ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789").toCharArray();
+    private static final int RANDOM_PASSWORD_DEFAULT_LENGTH = 16;
 
     @Inject RoleManager roleManager;
 
+    @Inject Instance<UserBackEnd> backend;
+
     void onStart(@Observes StartupEvent event, Keycloak keycloak) {
         if (keycloakURL.isPresent() && performRolesMigration()) {
-            LOGGER.info("Perform roles migration from keycloak...");
+            Log.info("Perform roles migration from keycloak...");
             for (UserRepresentation kcUser : keycloak.realm(realm).users().list(0, Integer.MAX_VALUE)) {
                 performUserMigration(kcUser, keycloak.realm(realm).users().get(kcUser.getId()).roles().getAll().getRealmMappings());
             }
-            LOGGER.info("Migration from keycloak complete");
+            Log.info("Migration from keycloak complete");
         }
+        checkBootstrapAccount();
     }
 
     private boolean performRolesMigration() {
@@ -57,10 +70,10 @@ public class SecurityMigration {
 
     @Transactional
     void performUserMigration(UserRepresentation kcUser, List<RoleRepresentation> kcRoles) {
-        LOGGER.infov("Migration of user {0} {1} with username {2}", kcUser.getFirstName(), kcUser.getLastName(), kcUser.getUsername());
+        Log.infov("Migration of user {0} {1} with username {2}", kcUser.getFirstName(), kcUser.getLastName(), kcUser.getUsername());
         String previousRoles = roleManager.setRoles(kcUser.getUsername());
         try {
-            
+
             Optional<UserInfo> storedUserInfo = UserInfo.findByIdOptional(kcUser.getUsername());
             UserInfo userInfo = storedUserInfo.orElseGet(() -> new UserInfo(kcUser.getUsername()));
             userInfo.email = kcUser.getEmail();
@@ -74,18 +87,18 @@ public class SecurityMigration {
                 } else if (role.endsWith("-tester")) {
                     addTeamMembership(userInfo, role.substring(0, role.length() - 7), TeamRole.TEAM_TESTER);
                 } else if (role.endsWith("-uploader")) {
-                   addTeamMembership(userInfo, role.substring(0, role.length() - 9), TeamRole.TEAM_UPLOADER);
+                    addTeamMembership(userInfo, role.substring(0, role.length() - 9), TeamRole.TEAM_UPLOADER);
                 } else if (role.endsWith("-manager")) {
                     addTeamMembership(userInfo, role.substring(0, role.length() - 8), TeamRole.TEAM_MANAGER);
                 } else if ("admin".equals(role)) {
                     userInfo.roles.add(UserRole.ADMIN);
                 } else {
-                    LOGGER.infov("Dropping role {0} for user {1} {2}", role, kcUser.getFirstName(), kcUser.getLastName());
+                    Log.infov("Dropping role {0} for user {1} {2}", role, kcUser.getFirstName(), kcUser.getLastName());
                 }
             }
             userInfo.persist();
         } catch (Exception e) {
-            LOGGER.warnv("Unable to perform migration for user {0} {1} due to {2}", kcUser.getFirstName(), kcUser.getLastName(), e.getMessage());
+            Log.warnv("Unable to perform migration for user {0} {1} due to {2}", kcUser.getFirstName(), kcUser.getLastName(), e.getMessage());
         } finally {
             roleManager.setRoles(previousRoles);
         }
@@ -95,4 +108,40 @@ public class SecurityMigration {
         Optional<Team> storedTeam = Team.find("teamName", teamName).firstResultOptional();
         userInfo.teams.add(new TeamMembership(userInfo, storedTeam.orElseGet(() -> Team.getEntityManager().merge(new Team(teamName))), role));
     }
+
+    // --- //
+
+    /**
+     * Create an admin account if there are no accounts in the system.
+     * The account should be removed once other accounts are created.
+     */
+    public void checkBootstrapAccount() {
+        // checks the list of administrators. a user cannot remove himself nor create the bootstrap account (restricted namespace)
+        List<String> administrators = backend.get().administrators().stream().map(userData -> userData.username).toList();
+        if (administrators.isEmpty()) {
+            UserService.NewUser user = new UserService.NewUser();
+            user.user = new UserService.UserData("", BOOTSTRAP_ACCOUNT, "Bootstrap", "Acount", "horreum@example.com");
+            user.password = providedBootstrapPassword.orElseGet(() -> getLaunchMode().isDevOrTest() ? "secret" : generateRandomPassword(RANDOM_PASSWORD_DEFAULT_LENGTH));
+
+            // create bootstrap acconut with admin role
+            backend.get().createUser(user);
+            backend.get().setPassword(BOOTSTRAP_ACCOUNT, user.password); // KeycloakUserBackend.createUser() creates a temp password, with this call the password is usable
+            backend.get().updateAdministrators(List.of(BOOTSTRAP_ACCOUNT));
+
+            // create dev-team managed by bootstrap
+            backend.get().addTeam("dev-team");
+            backend.get().updateTeamMembers("dev-team", Map.of(BOOTSTRAP_ACCOUNT, List.of(Roles.MANAGER, Roles.TESTER, Roles.UPLOADER, Roles.VIEWER)));
+
+            Log.infov("\n>>>\n>>> Created temporary account {0} with password {1}\n>>>", BOOTSTRAP_ACCOUNT, user.password);
+        } else if (administrators.size() > 1 && administrators.contains(BOOTSTRAP_ACCOUNT)) {
+            Log.warnv("The temporary account {0} can be removed", BOOTSTRAP_ACCOUNT);
+        }
+    }
+
+    public static String generateRandomPassword(int lenght) {
+        StringBuilder builder = new StringBuilder(lenght);
+        new SecureRandom().ints(lenght, 0, RANDOM_PASSWRORD_CHARS.length).mapToObj(i -> RANDOM_PASSWRORD_CHARS[i]).forEach(builder::append);
+        return builder.toString();
+    }
+
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
@@ -43,7 +43,7 @@ public class KeycloakUserBackend implements UserBackEnd {
 
     private static final String[] ROLE_TYPES = new String[] { "team", Roles.VIEWER, Roles.TESTER, Roles.UPLOADER, Roles.MANAGER };
 
-    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
 
     // please make sure all calls to this object are in a try/catch block to avoid leaking information
     @Inject Keycloak keycloak;

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -104,6 +104,9 @@ quarkus.oidc.credentials.secret=overridden-in-file-dot-env
 # This option lets HorreumAuthorizationFilter transform app keys sent as tokens
 quarkus.http.auth.proactive=false
 
+# JPA authentication with a username and password
+quarkus.http.auth.basic=true
+
 # Keycloak-admin
 quarkus.keycloak.admin-client.server-url=${horreum.keycloak.url}
 quarkus.keycloak.admin-client.client-id=horreum
@@ -223,10 +226,3 @@ quarkus.datasource.devservices.enabled=false
 quarkus.datasource.migration.devservices.enabled=false
 quarkus.keycloak.devservices.enabled=false
 quarkus.elasticsearch.devservices.enabled=false
-
-## Add a dummy administrator in dev mode with name "user" and password "secret" with Basic HTTP authentication
-%dev.quarkus.http.auth.basic=true
-%dev.quarkus.security.users.embedded.enabled=true
-%dev.quarkus.security.users.embedded.plain-text=true
-%dev.quarkus.security.users.embedded.users.user=secret
-%dev.quarkus.security.users.embedded.roles.user=admin

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/KeycloakUserServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/KeycloakUserServiceTest.java
@@ -15,30 +15,4 @@ import org.keycloak.admin.client.resource.RoleScopeResource;
 
 @TestProfile(KeycloakTestProfile.class)
 @QuarkusTest public class KeycloakUserServiceTest extends UserServiceAbstractTest {
-
-    @BeforeAll static void setupClient() {
-        try (Keycloak keycloak = KeycloakBuilder.builder()
-                                                .serverUrl(ConfigProvider.getConfig().getValue("quarkus.keycloak.admin-client.server-url", String.class))
-                                                .realm("master")
-                                                .username("admin")
-                                                .password("admin")
-                                                .clientId("admin-cli")
-                                                .resteasyClient(((ResteasyClientBuilder) ClientBuilder.newBuilder()).disableTrustManager().build())
-                                                .build()) {
-
-            // the client created in KeycloakTestResourceLifecycleManager (the keycloak dev service) lacks the "realm-admin" role on its service account
-            // without it, it has no permission to add / remove users and roles from the realm
-            // (on production instances these permission may be fine-tuned, as "realm-admin" is a composite role)
-
-            RealmResource realmResource = keycloak.realm(KeycloakTestProfile.REALM);
-            String clientId = realmResource.clients().findByClientId(KeycloakTestProfile.CLIENT).get(0).getId();
-            String managementId = realmResource.clients().findByClientId("realm-management").get(0).getId();
-            String serviceAccountId = realmResource.clients().get(clientId).getServiceAccountUser().getId();
-
-            RoleScopeResource managementRolesResource = realmResource.users().get(serviceAccountId).roles().clientLevel(managementId);
-            managementRolesResource.add(managementRolesResource.listAvailable().stream().filter(r -> "realm-admin".equals(r.getName())).toList());
-
-            Log.infov("realm-admin role added to {0} client", KeycloakTestProfile.CLIENT);
-        }
-    }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/UserServiceAbstractTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/UserServiceAbstractTest.java
@@ -2,7 +2,9 @@ package io.hyperfoil.tools.horreum.svc;
 
 import io.hyperfoil.tools.horreum.api.internal.services.UserService;
 import io.hyperfoil.tools.horreum.entity.user.UserInfo;
+import io.hyperfoil.tools.horreum.server.SecurityBootstrap;
 import io.hyperfoil.tools.horreum.server.WithRoles;
+import io.hyperfoil.tools.horreum.svc.user.UserBackEnd;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -10,6 +12,7 @@ import io.quarkus.security.runtime.QuarkusPrincipal;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.security.TestIdentityAssociation;
 import io.quarkus.test.security.TestSecurity;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -44,6 +47,10 @@ public abstract class UserServiceAbstractTest {
 
     @Inject UserServiceImpl userService;
 
+    @Inject Instance<UserBackEnd> backend;
+
+    @Inject SecurityBootstrap securitiyBootstrap;
+
     /**
      * Runs a section of a test under a different user
      */
@@ -72,11 +79,12 @@ public abstract class UserServiceAbstractTest {
         // create the admin user and give it the admin role
         try {
             userService.createUser(adminUser);
-            userService.updateAdministrators(List.of(adminUserName));
             LOG.infov("Created user {0}", adminUserName);
         } catch (ServiceException se) {
             // in the keycloak implementation this admin user already exists, and therefore the exception is expected
             assertEquals(se.getMessage(), "User exists with same username");
+        } finally {
+            userService.updateAdministrators(List.of(adminUserName));
         }
         List<String> adminList = userService.administrators().stream().map(u -> u.username).toList();
         assertTrue(adminList.size() == 1 && adminList.contains(adminUserName));
@@ -504,5 +512,19 @@ public abstract class UserServiceAbstractTest {
             assertEquals(fooBarTestTeamCount, userService.searchUsers("").size());
             assertEquals(1, userService.info(List.of(testManagerUserName)).size());
         });
+    }
+
+    @TestSecurity(user = KEYCLOAK_ADMIN, roles = { Roles.ADMIN })
+    @Test void bootstrapAccount() {
+        // assert bootstrap account exists
+        assertTrue(userService.administrators().stream().map(userData -> userData.username).anyMatch("horreum.bootstrap"::equals), "Bootstrap account missing");
+
+        // reset bootstrap account
+        userService.removeUser("horreum.bootstrap");
+        backend.get().updateAdministrators(List.of()); // call the backend directly to be able to remove *ALL* administrators
+        assertTrue(userService.administrators().isEmpty());
+
+        securitiyBootstrap.checkBootstrapAccount();
+        assertTrue(userService.administrators().stream().map(userData -> userData.username).anyMatch("horreum.bootstrap"::equals), "Bootstrap account missing");
     }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumKeycloakTestResourceLifecycleManager.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumKeycloakTestResourceLifecycleManager.java
@@ -1,0 +1,51 @@
+package io.hyperfoil.tools.horreum.test;
+
+import io.quarkus.logging.Log;
+import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
+import jakarta.ws.rs.client.ClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+
+import java.util.Map;
+
+/**
+ * Extends {@link KeycloakTestResourceLifecycleManager} so that the service client has <pre>realm-admin</pre> role to be able to manage users in the realm
+ */
+public class HorreumKeycloakTestResourceLifecycleManager extends KeycloakTestResourceLifecycleManager {
+
+    private static final String KEYCLOAK_REALM = System.getProperty("keycloak.realm", "quarkus");
+    private static final String KEYCLOAK_SERVICE_CLIENT = System.getProperty("keycloak.service.client", "quarkus-service-app");
+
+    @Override public Map<String, String> start() {
+        Map<String, String> properties = super.start();
+
+        try (Keycloak keycloak = KeycloakBuilder.builder()
+                                                .serverUrl(properties.get("keycloak.url"))
+                                                .realm("master")
+                                                .username("admin")
+                                                .password("admin")
+                                                .clientId("admin-cli")
+                                                .resteasyClient(((ResteasyClientBuilder) ClientBuilder.newBuilder()).disableTrustManager().build())
+                                                .build()) {
+
+            // the client created in KeycloakTestResourceLifecycleManager (the keycloak dev service) lacks the "realm-admin" role on its service account
+            // without it, it has no permission to add / remove users and roles from the realm
+            // (on production instances these permission may be fine-tuned, as "realm-admin" is a composite role)
+
+            RealmResource realmResource = keycloak.realm(KEYCLOAK_REALM);
+            String clientId = realmResource.clients().findByClientId(KEYCLOAK_SERVICE_CLIENT).get(0).getId();
+            String managementId = realmResource.clients().findByClientId("realm-management").get(0).getId();
+            String serviceAccountId = realmResource.clients().get(clientId).getServiceAccountUser().getId();
+
+            RoleScopeResource managementRolesResource = realmResource.users().get(serviceAccountId).roles().clientLevel(managementId);
+            managementRolesResource.add(managementRolesResource.listAvailable().stream().filter(r -> "realm-admin".equals(r.getName())).toList());
+
+            Log.infov("realm-admin role added to {0} client", KEYCLOAK_SERVICE_CLIENT);
+        }
+
+        return properties;
+    }
+}

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
@@ -16,6 +16,8 @@ public class HorreumTestProfile implements QuarkusTestProfile {
             "quarkus.oidc.token.issuer", "https://server.example.com",
             "smallrye.jwt.sign.key.location", "/privateKey.jwk",
             "horreum.url", "http://localhost:8081",
+            "horreum.roles.provider", "database",
+            "horreum.roles.database.override", "false",
             "horreum.test-mode", "true",
             "horreum.privacy", "/path/to/privacy/statement/link");
    }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/KeycloakTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/KeycloakTestProfile.java
@@ -2,7 +2,6 @@ package io.hyperfoil.tools.horreum.test;
 
 import io.hyperfoil.tools.horreum.svc.Roles;
 import io.quarkus.keycloak.admin.client.common.KeycloakAdminClientConfig;
-import io.quarkus.test.keycloak.server.KeycloakTestResourceLifecycleManager;
 
 import java.util.HashMap;
 import java.util.List;
@@ -31,11 +30,11 @@ public class KeycloakTestProfile extends HorreumTestProfile {
         configOverrides.put("keycloak.realm", REALM);
 
         // create the base roles used to compose team roles
-        configOverrides.put("keycloak.token.admin-roles", String.join(",", Roles.ADMIN, Roles.MANAGER, Roles.TESTER, Roles.VIEWER, Roles.UPLOADER, Roles.MACHINE));
+        configOverrides.put("keycloak.token.admin-roles", String.join(",", Roles.MANAGER, Roles.TESTER, Roles.VIEWER, Roles.UPLOADER, Roles.MACHINE));
         return configOverrides;
     }
 
     @Override public List<TestResourceEntry> testResources() {
-        return List.of(new TestResourceEntry(PostgresResource.class), new TestResourceEntry(KeycloakTestResourceLifecycleManager.class));
+        return List.of(new TestResourceEntry(PostgresResource.class), new TestResourceEntry(HorreumKeycloakTestResourceLifecycleManager.class));
     }
 }

--- a/horreum-integration-tests/src/main/resources/application.properties
+++ b/horreum-integration-tests/src/main/resources/application.properties
@@ -3,3 +3,5 @@ quarkus.container-image.build=false
 
 ## disable certificate validation (but still require a SSL connection)
 quarkus.datasource.jdbc.additional-jdbc-properties.sslmode=require
+
+quarkus.http.auth.basic=false

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/ItResource.java
@@ -33,6 +33,7 @@ public class ItResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger log = Logger.getLogger(ItResource.class);
     private static boolean started = false;
 
+    public static String  HORREUM_BOOTSTRAP_PASSWORD = "horreum.secret";
 
     @Override
     public Map<String, String> start() {
@@ -64,7 +65,8 @@ public class ItResource implements QuarkusTestResourceLifecycleManager {
                             Map.entry(HORREUM_DEV_KEYCLOAK_DB_USERNAME, DEFAULT_KC_DB_USERNAME),
                             Map.entry(HORREUM_DEV_KEYCLOAK_DB_PASSWORD, DEFAULT_KC_DB_PASSWORD),
                             Map.entry(HORREUM_DEV_KEYCLOAK_ADMIN_USERNAME, DEFAULT_KC_ADMIN_USERNAME),
-                            Map.entry(HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, DEFAULT_KC_ADMIN_PASSWORD)
+                            Map.entry(HORREUM_DEV_KEYCLOAK_ADMIN_PASSWORD, DEFAULT_KC_ADMIN_PASSWORD),
+                            Map.entry("horreum.bootstrap.password", HORREUM_BOOTSTRAP_PASSWORD) // well known bootstrap password instead of a random one
                     );
                     return startContainers(containerArgs);
                 } catch (Exception e){

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/HorreumResources.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/HorreumResources.java
@@ -2,8 +2,6 @@ package io.hyperfoil.tools.horreum.infra.common;
 
 import io.hyperfoil.tools.horreum.infra.common.resources.KeycloakResource;
 import io.hyperfoil.tools.horreum.infra.common.resources.PostgresResource;
-import io.hyperfoil.tools.horreum.infra.common.utils.RoleBuilder;
-import io.hyperfoil.tools.horreum.infra.common.utils.UserBuilder;
 import jakarta.ws.rs.client.ClientBuilder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -18,8 +16,6 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.RoleRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -36,9 +32,6 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static io.hyperfoil.tools.horreum.infra.common.Const.*;
 
@@ -48,25 +41,6 @@ public class HorreumResources {
     private static Keycloak keycloak;
     private static final String HORREUM_REALM = System.getProperty("horreum.realm", "horreum");
     private static final String KEYCLOAK_REALM = System.getProperty("keycloak.realm", "master");
-
-    static Function<String, ClientRepresentation> findClient = clientName -> keycloak.realm(HORREUM_REALM).clients().findByClientId(clientName).get(0);
-    static Function<String, String> generateClientSecret = clientName -> keycloak.realm(HORREUM_REALM).clients().get(findClient.apply(clientName).getId()).generateNewSecret().getValue();
-    static Function<String, String> getClientSecret = clientName -> keycloak.realm(HORREUM_REALM).clients().get(findClient.apply(clientName).getId()).getSecret().getValue();
-    static Function<String, RoleRepresentation> getRoleID = role -> keycloak.realm(HORREUM_REALM).roles().get(role).toRepresentation();
-    static BiFunction<String, String, RoleRepresentation> getClientRoleID = (clientId, role) -> keycloak.realm(HORREUM_REALM).clients().get(clientId).roles().get(role).toRepresentation();
-
-    static Function<Supplier<RoleRepresentation>, RoleRepresentation> createRole = roleSupplier -> {
-        RoleRepresentation roleRepresentation = roleSupplier.get();
-        keycloak.realm(HORREUM_REALM).roles().create(roleRepresentation);
-        return keycloak.realm(HORREUM_REALM).roles().get(roleRepresentation.getName()).toRepresentation();
-    };
-
-    static Function<Supplier<UserRepresentation>, UserRepresentation> createUser = userSupplier -> {
-        UserRepresentation userRepresentation = userSupplier.get();
-        keycloak.realm(HORREUM_REALM).users().create(userRepresentation);
-        return keycloak.realm(HORREUM_REALM).users().searchByUsername(userRepresentation.getUsername(), true).stream().findFirst().get();
-    };
-
 
     public static Properties configProperties;
 
@@ -172,60 +146,19 @@ public class HorreumResources {
                                       .resteasyClient(((ResteasyClientBuilder) ClientBuilder.newBuilder()).disableTrustManager().build())
                                       .build();
 
-            if (!initArgs.containsKey(HORREUM_DEV_POSTGRES_BACKUP)) {
-                // Not using a backup db, so need to create the dummy roles
-
-                // Obtain client secrets for Horreum
-                envVariables.put("quarkus.oidc.credentials.secret", generateClientSecret.apply("horreum"));
-
-                // Create roles and example user in Keycloak
-                RoleRepresentation machineRole = getRoleID.apply("machine");
-                RoleRepresentation managerRole = getRoleID.apply("manager");
-                RoleRepresentation uploaderRole = getRoleID.apply("uploader");
-                RoleRepresentation testerRole = getRoleID.apply("tester");
-                RoleRepresentation viewerRole = getRoleID.apply("viewer");
-                RoleRepresentation adminRole = getRoleID.apply("admin");
-
-                RoleRepresentation devTeamRole = createRole.apply(() -> RoleBuilder.create().name("dev-team").build());
-                RoleRepresentation teamViewerRole = createRole.apply(() -> RoleBuilder.create().name("dev-viewer").composite().realmComposite(devTeamRole).realmComposite(viewerRole).build());
-                RoleRepresentation teamUploaderRole = createRole.apply(() -> RoleBuilder.create().name("dev-uploader").composite().realmComposite(devTeamRole).realmComposite(uploaderRole).build());
-                RoleRepresentation teamTesterRole = createRole.apply(() -> RoleBuilder.create().name("dev-tester").composite().realmComposite(devTeamRole).realmComposite(testerRole).build());
-                RoleRepresentation teamMachineRole = createRole.apply(() -> RoleBuilder.create().name("dev-machine").composite().realmComposite(devTeamRole).realmComposite(machineRole).build());
-                RoleRepresentation teamManagerRole = createRole.apply(() -> RoleBuilder.create().name("dev-manager").composite().realmComposite(devTeamRole).realmComposite(managerRole).build());
-
-                UserRepresentation dummyUser = createUser.apply(() ->
-                        UserBuilder.create()
-                                   .username("user")
-                                   .firstName("Dummy")
-                                   .lastName("User")
-                                   .password("secret")
-                                   .email("user@example.com")
-                                   .enabled(true)
-                                   .build()
-                );
-
-                keycloak.realm(HORREUM_REALM).users().get(dummyUser.getId()).roles().realmLevel().add(Arrays.asList(teamUploaderRole, teamTesterRole, teamViewerRole, teamManagerRole, teamMachineRole, adminRole));
-
-                ClientRepresentation accountClient = findClient.apply("account");
-
-                RoleRepresentation viewProfileRole = getClientRoleID.apply(accountClient.getId(), "view-profile");
-
-                keycloak.realm(HORREUM_REALM).users().get(dummyUser.getId()).roles().clientLevel(accountClient.getId()).add(Collections.singletonList(viewProfileRole));
-            }
-
             //update running keycloak realm with dev services configuration
             try {
                 Config config = ConfigProvider.getConfig();
                 String httpPort = config.getOptionalValue("quarkus.http.port", String.class).orElse("8080");
                 String httpHost = config.getOptionalValue("quarkus.http.host", String.class).orElse("localhost");
 
-                ClientRepresentation clientRepresentation = keycloak.realm(HORREUM_REALM).clients().findByClientId("horreum-ui").get(0);
-                clientRepresentation.getWebOrigins().add("http://".concat(httpHost).concat(":").concat(httpPort));
-                clientRepresentation.getRedirectUris().add("http://".concat(httpHost).concat(":").concat(httpPort).concat("/*"));
+                ClientRepresentation uiClient = keycloak.realm(HORREUM_REALM).clients().findByClientId("horreum-ui").get(0);
+                uiClient.getWebOrigins().add("http://".concat(httpHost).concat(":").concat(httpPort));
+                uiClient.getRedirectUris().add("http://".concat(httpHost).concat(":").concat(httpPort).concat("/*"));
+                keycloak.realm(HORREUM_REALM).clients().get(uiClient.getId()).update(uiClient);
 
-                envVariables.put("quarkus.oidc.credentials.secret", getClientSecret.apply("horreum"));
-
-                keycloak.realm(HORREUM_REALM).clients().get(clientRepresentation.getId()).update(clientRepresentation);
+                ClientRepresentation mainClient = keycloak.realm(HORREUM_REALM).clients().findByClientId("horreum").get(0);
+                envVariables.put("quarkus.oidc.credentials.secret", keycloak.realm(HORREUM_REALM).clients().get(mainClient.getId()).getSecret().getValue());
             } catch (Exception e) {
                 log.error("Unable to re-configure keycloak instance: ".concat(e.getLocalizedMessage()));
             }


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1708

This PR adds a mechanism that generates an account that can be used to bootstrap Horreum. That account should be removed once there are other accounts in the system.

Its another step towards removing dependency on keycloak and also custom dev-services. 

fixes https://github.com/Hyperfoil/Horreum/issues/1719