### PR TITLE
Fix native typecast in queries

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/SchemaDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/SchemaDAO.java
@@ -28,8 +28,8 @@ import static org.hibernate.id.enhanced.SequenceStyleGenerator.SEQUENCE_PARAM;
    @NamedNativeQuery(
       name = SchemaDAO.QUERY_1ST_LEVEL_BY_RUNID_TRANSFORMERID_SCHEMA_ID,
       query = "SELECT te.name, (" +
-            "CASE WHEN te.isarray THEN jsonb_path_query_array(r.data, te.jsonpath::::jsonpath) " +
-            "ELSE jsonb_path_query_first(r.data,te.jsonpath::::jsonpath) END) AS value " +
+            "CASE WHEN te.isarray THEN jsonb_path_query_array(r.data, te.jsonpath::jsonpath) " +
+            "ELSE jsonb_path_query_first(r.data,te.jsonpath::jsonpath) END) AS value " +
             "FROM run r, transformer t " +
             "JOIN transformer_extractors te ON te.transformer_id = t.id " +
             "WHERE r.id = ?1 AND t.id = ?2"
@@ -37,8 +37,8 @@ import static org.hibernate.id.enhanced.SequenceStyleGenerator.SEQUENCE_PARAM;
    @NamedNativeQuery(
       name = SchemaDAO.QUERY_2ND_LEVEL_BY_RUNID_TRANSFORMERID_SCHEMA_ID,
       query = "SELECT te.name, (" +
-            "CASE WHEN te.isarray THEN jsonb_path_query_array((CASE WHEN ?4 = 0 THEN r.data ELSE r.metadata END)->?3, te.jsonpath::::jsonpath) " +
-            "ELSE jsonb_path_query_first((CASE WHEN ?4 = 0 THEN r.data ELSE r.metadata END)->?3, te.jsonpath::::jsonpath) END) AS value " +
+            "CASE WHEN te.isarray THEN jsonb_path_query_array((CASE WHEN ?4 = 0 THEN r.data ELSE r.metadata END)->?3, te.jsonpath::jsonpath) " +
+            "ELSE jsonb_path_query_first((CASE WHEN ?4 = 0 THEN r.data ELSE r.metadata END)->?3, te.jsonpath::jsonpath) END) AS value " +
             "FROM run r, transformer t " +
             "JOIN transformer_extractors te ON te.transformer_id = t.id " +
             "WHERE r.id = ?1 AND t.id = ?2"

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -91,7 +91,7 @@ public class AlertingServiceImpl implements AlertingService {
             SELECT timeline_function,
                (CASE
                   WHEN jsonb_array_length(timeline_labels) = 1 THEN jsonb_agg(lv.value)->0
-                  ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::::jsonb)
+                  ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::jsonb)
                END) as value
             FROM test
             JOIN label ON json_contains(timeline_labels, label.name)
@@ -113,7 +113,7 @@ public class AlertingServiceImpl implements AlertingService {
                jsonb_array_length(var.labels) AS numLabels,
                (CASE
                   WHEN jsonb_array_length(var.labels) = 1 THEN jsonb_agg(lv.value)->0
-                  ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::::jsonb)
+                  ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::jsonb)
                   END) AS value
             FROM variable var
             LEFT JOIN label ON json_contains(var.labels, label.name)
@@ -131,7 +131,7 @@ public class AlertingServiceImpl implements AlertingService {
             (CASE
                WHEN mdr.labels IS NULL OR jsonb_array_length(mdr.labels) = 0 THEN NULL
                WHEN jsonb_array_length(mdr.labels) = 1 THEN jsonb_agg(lv.value)->0
-               ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::::jsonb)
+               ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::jsonb)
             END) as value
          FROM missingdata_rule mdr
          LEFT JOIN label ON json_contains(mdr.labels, label.name)
@@ -146,7 +146,7 @@ public class AlertingServiceImpl implements AlertingService {
              (CASE
                WHEN mdr.labels IS NULL OR jsonb_array_length(mdr.labels) = 0 THEN NULL
                WHEN jsonb_array_length(mdr.labels) = 1 THEN jsonb_agg(lv.value)->0
-               ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::::jsonb)
+               ELSE COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::jsonb)
              END) as value
          FROM missingdata_rule mdr
          LEFT JOIN label ON json_contains(mdr.labels, label.name)
@@ -178,7 +178,7 @@ public class AlertingServiceImpl implements AlertingService {
          FROM datapoint dp
          LEFT JOIN fingerprint fp ON fp.dataset_id = dp.dataset_id
          WHERE
-            ((fp.fingerprint IS NULL AND (?1)::::jsonb IS NULL) OR json_equals(fp.fingerprint, (?1)::::jsonb))
+            ((fp.fingerprint IS NULL AND (?1)::jsonb IS NULL) OR json_equals(fp.fingerprint, (?1)::jsonb))
             AND variable_id = ANY(?2)
          ORDER BY variable_id, timestamp DESC
          """;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ChangesServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ChangesServiceImpl.java
@@ -105,7 +105,7 @@ public class ChangesServiceImpl implements ChangesService {
          }
          sql.append(") SELECT dp.* FROM dp ");
          if (fingerprint != null) {
-            sql.append("LEFT JOIN fingerprint fp ON fp.dataset_id = dp.dataset_id WHERE json_equals(fp.fingerprint, (?4)::::jsonb) ");
+            sql.append("LEFT JOIN fingerprint fp ON fp.dataset_id = dp.dataset_id WHERE json_equals(fp.fingerprint, (?4)::jsonb) ");
          }
          sql.append("ORDER BY timestamp ASC");
          NativeQuery<DataPointDAO> nativeQuery = em.unwrap(Session.class).createNativeQuery(sql.toString(), DataPointDAO.class)
@@ -174,7 +174,7 @@ public class ChangesServiceImpl implements ChangesService {
       }
       sql.append(" WHERE variable_id = ?1 AND timestamp BETWEEN ?2 AND ?3 ");
       if (fingerprint != null) {
-         sql.append("AND json_equals(fp.fingerprint, (?4)::::jsonb)");
+         sql.append("AND json_equals(fp.fingerprint, (?4)::jsonb)");
       }
       NativeQuery<ChangeDAO> nativeQuery = em.unwrap(Session.class).createNativeQuery(sql.toString(), ChangeDAO.class)
             .setParameter(1, variableId)

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ExperimentServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ExperimentServiceImpl.java
@@ -169,7 +169,7 @@ public class ExperimentServiceImpl implements ExperimentService {
                CASE
                   WHEN count > 1 THEN jsonb_object_agg(COALESCE(name, ''), lvalues.value)
                   WHEN count = 1 THEN jsonb_agg(lvalues.value) -> 0
-                  ELSE '{}'::::jsonb END
+                  ELSE '{}'::jsonb END
             ) AS value
             FROM lvalues
             GROUP BY profile_id, selector_filter, count
@@ -213,7 +213,7 @@ public class ExperimentServiceImpl implements ExperimentService {
                (CASE
                   WHEN count > 1 THEN jsonb_object_agg(COALESCE(name, ''), lvalues.value)
                   WHEN count = 1 THEN jsonb_agg(lvalues.value) -> 0
-                  ELSE '{}'::::jsonb END
+                  ELSE '{}'::jsonb END
                ) AS value,
                dataset_id
             FROM lvalues
@@ -283,7 +283,7 @@ public class ExperimentServiceImpl implements ExperimentService {
          List<Dataset.Info> baseline = datasetQuery.setParameter(1, entry.getValue()).getResultList();
 
          JsonNode extraLabels = (JsonNode) em.createNativeQuery("""
-               SELECT COALESCE(jsonb_object_agg(COALESCE(label.name, ''), lv.value), '{}'::::jsonb) AS value
+               SELECT COALESCE(jsonb_object_agg(COALESCE(label.name, ''), lv.value), '{}'::jsonb) AS value
                FROM experiment_profile ep
                JOIN label ON json_contains(ep.extra_labels, label.name)
                LEFT JOIN label_values lv ON label.id = lv.label_id

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ReportServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ReportServiceImpl.java
@@ -545,7 +545,7 @@ public class ReportServiceImpl implements ReportService {
       sql.append("SELECT id, runid, ordinal, ");
       if (labels.size() != 1) {
          // jsonb_object_agg fails when values.name is null
-         sql.append("COALESCE(jsonb_object_agg(values.name, values.value) FILTER (WHERE values.name IS NOT NULL), '{}'::::jsonb)");
+         sql.append("COALESCE(jsonb_object_agg(values.name, values.value) FILTER (WHERE values.name IS NOT NULL), '{}'::jsonb)");
       } else {
          sql.append("values.value");
       }
@@ -566,7 +566,7 @@ public class ReportServiceImpl implements ReportService {
    private List<Object[]> selectByDatasets(ArrayNode labels, List<Integer> datasets) {
       StringBuilder sql = new StringBuilder("SELECT dataset.id AS id, dataset.runid AS runid, dataset.ordinal AS ordinal, ");
       if (labels.size() != 1) {
-         sql.append("COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::::jsonb)");
+         sql.append("COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL), '{}'::jsonb)");
       } else {
          sql.append("lv.value");
       }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SqlServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SqlServiceImpl.java
@@ -62,11 +62,11 @@ public class SqlServiceImpl implements SqlService {
       try {
          if (schemaUri != null && !schemaUri.isEmpty()) {
             String sqlQuery = "SELECT " + func + "((CASE " +
-                    "WHEN rs.type = 0 THEN run.data WHEN rs.type = 1 THEN run.data->rs.key ELSE run.data->(rs.key::::integer) END)" +
-                    ", (?1)::::jsonpath)#>>'{}' FROM run JOIN run_schemas rs ON rs.runid = run.id WHERE id = ?2 AND rs.uri = ?3";
+                    "WHEN rs.type = 0 THEN run.data WHEN rs.type = 1 THEN run.data->rs.key ELSE run.data->(rs.key::integer) END)" +
+                    ", (?1)::jsonpath)#>>'{}' FROM run JOIN run_schemas rs ON rs.runid = run.id WHERE id = ?2 AND rs.uri = ?3";
             result.value = String.valueOf(Util.runQuery(em, sqlQuery, jsonpath, id, schemaUri));
          } else {
-            String sqlQuery = "SELECT " + func + "(data, (?1)::::jsonpath)#>>'{}' FROM run WHERE id = ?2";
+            String sqlQuery = "SELECT " + func + "(data, (?1)::jsonpath)#>>'{}' FROM run WHERE id = ?2";
             result.value = String.valueOf(Util.runQuery(em, sqlQuery, jsonpath, id));
          }
          result.valid = true;
@@ -86,16 +86,16 @@ public class SqlServiceImpl implements SqlService {
       try {
          if (schemaUri == null) {
             String func = array ? "jsonb_path_query_array" : "jsonb_path_query_first";
-            String sqlQuery = "SELECT " + func + "(data, ?::::jsonpath)#>>'{}' FROM dataset WHERE id = ?";
+            String sqlQuery = "SELECT " + func + "(data, ?::jsonpath)#>>'{}' FROM dataset WHERE id = ?";
             result.value = String.valueOf(Util.runQuery(em, sqlQuery, jsonpath, datasetId));
          } else {
             // This schema-aware query already assumes that Dataset.data is an array of objects with defined schema
-            String schemaQuery = "jsonb_path_query(data, '$[*] ? (@.\"$schema\" == $schema)', ('{\"schema\":\"' || ? || '\"}')::::jsonb)";
+            String schemaQuery = "jsonb_path_query(data, '$[*] ? (@.\"$schema\" == $schema)', ('{\"schema\":\"' || ? || '\"}')::jsonb)";
             String sqlQuery;
             if (!array) {
-               sqlQuery = "SELECT jsonb_path_query_first(" + schemaQuery + ", ?::::jsonpath)#>>'{}' FROM dataset WHERE id = ? LIMIT 1";
+               sqlQuery = "SELECT jsonb_path_query_first(" + schemaQuery + ", ?::jsonpath)#>>'{}' FROM dataset WHERE id = ? LIMIT 1";
             } else {
-               sqlQuery = "SELECT jsonb_agg(v)#>>'{}' FROM (SELECT jsonb_path_query(" + schemaQuery + ", ?::::jsonpath) AS v FROM dataset WHERE id = ?) AS values";
+               sqlQuery = "SELECT jsonb_agg(v)#>>'{}' FROM (SELECT jsonb_path_query(" + schemaQuery + ", ?::jsonpath) AS v FROM dataset WHERE id = ?) AS values";
             }
             result.value = String.valueOf(Util.runQuery(em, sqlQuery, schemaUri, jsonpath, datasetId));
          }
@@ -129,7 +129,7 @@ public class SqlServiceImpl implements SqlService {
          result.reason = "Jsonpath should start with '$'";
          return result;
       }
-      Query query = em.createNativeQuery("SELECT jsonb_path_query_first('{}', ?::::jsonpath)::::text");
+      Query query = em.createNativeQuery("SELECT jsonb_path_query_first('{}', ?::jsonpath)::text");
       query.setParameter(1, jsonpath);
       try {
          query.getSingleResult();

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -94,7 +94,7 @@ public class TestServiceImpl implements TestService {
    protected static final String LABEL_VALUES_QUERY = """
          WITH
          combined as (
-         SELECT DISTINCT COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL INCLUDE_EXCLUDE_PLACEHOLDER), '{}'::::jsonb) AS values, runId, dataset.id AS datasetId, dataset.start AS start, dataset.stop AS stop
+         SELECT DISTINCT COALESCE(jsonb_object_agg(label.name, lv.value) FILTER (WHERE label.name IS NOT NULL INCLUDE_EXCLUDE_PLACEHOLDER), '{}'::jsonb) AS values, runId, dataset.id AS datasetId, dataset.start AS start, dataset.stop AS stop
                   FROM dataset
                   LEFT JOIN label_values lv ON dataset.id = lv.dataset_id
                   LEFT JOIN label ON label.id = lv.label_id
@@ -353,7 +353,7 @@ public class TestServiceImpl implements TestService {
       if (anyFolder) {
          Roles.addRolesSql(identity, "test", testSql, roles, 1, " WHERE");
       } else {
-         testSql.append(" WHERE COALESCE(folder, '') = COALESCE((?1)::::text, '')");
+         testSql.append(" WHERE COALESCE(folder, '') = COALESCE((?1)::text, '')");
          Roles.addRolesSql(identity, "test", testSql, roles, 2, " AND");
       }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasetServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasetServiceTest.java
@@ -336,7 +336,7 @@ public class DatasetServiceTest extends BaseServiceTest {
             assertEquals(24, vc2.get("a").asInt());
             assertEquals(42, vc2.get("b").asInt());
 
-            String labelIds = (String) em.createNativeQuery("SELECT to_json(label_ids)::::text FROM dataset_view WHERE dataset_id = ?1")
+            String labelIds = (String) em.createNativeQuery("SELECT to_json(label_ids)::text FROM dataset_view WHERE dataset_id = ?1")
                   .setParameter(1, ds.id).getSingleResult();
             Set<Integer> ids = new HashSet<>();
             StreamSupport.stream(Util.toJsonNode(labelIds).spliterator(), false).mapToInt(JsonNode::asInt).forEach(ids::add);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
@@ -299,8 +299,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertNotNull(datasetValidation2);
       assertEquals(4, datasetValidation2.errors.size());
 
-      assertEquals(4, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(4, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(4, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(4, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
    }
 
    @org.junit.jupiter.api.Test
@@ -594,8 +594,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertTrue(runId > 0);
 
       // no validation errors
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
 
       List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
       assertEquals(0, runSchemasBefore.size());
@@ -628,8 +628,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertTrue(runId > 0);
 
       // no validation errors
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
 
       List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
       assertEquals(0, runSchemasBefore.size());
@@ -661,8 +661,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertTrue(runId > 0);
 
       // no validation errors
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
 
       List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
       assertEquals(0, runSchemasBefore.size());
@@ -698,8 +698,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertTrue(runId > 0);
 
       // no validation errors
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
 
       List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
       assertEquals(2, runSchemasBefore.size());
@@ -730,8 +730,8 @@ class SchemaServiceTest extends BaseServiceTest {
       assertTrue(runId > 0);
 
       // no validation errors
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM run_validationerrors").getSingleResult());
-      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::::int FROM dataset_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM run_validationerrors").getSingleResult());
+      assertEquals(0, em.createNativeQuery("SELECT COUNT(*)::int FROM dataset_validationerrors").getSingleResult());
 
       List<?> runSchemasBefore = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId).getResultList();
       assertEquals(2, runSchemasBefore.size());


### PR DESCRIPTION
fixes #1766 

it's no longer necessary to escape `::` (native typecast operator) and it's not desirable

reference [HHH-17759](https://hibernate.atlassian.net/browse/HHH-17759) and [https://github.com/hibernate/hibernate-orm/pull/8007](https://github.com/hibernate/hibernate-orm/pull/8007)