### PR TITLE
[0.14] Dynamically resolve custom views in Compare Datasets: Fixes #1879

### DIFF
--- a/horreum-web/src/domain/runs/DatasetComparison.tsx
+++ b/horreum-web/src/domain/runs/DatasetComparison.tsx
@@ -85,7 +85,18 @@ export default function DatasetComparison() {
         [datasets]
     )
 
-    const defaultView = views?.find(v => (v.name = "Default"))
+    const fragmentTags = views.map(view => {
+        return (
+            <FragmentTab title={view.name} fragment={`view_${view.id}`} key={`view_${view.id}`}>
+                <ViewComparison headers={headers} view={view} datasets={datasets} alerting={alerting} />
+            </FragmentTab>
+        )
+    })
+    fragmentTags.unshift(
+        <FragmentTab title="Labels" fragment="labels" key="view_0">
+            <LabelsComparison headers={headers} datasets={datasets} alerting={alerting} />
+        </FragmentTab>
+    )
 
     return (
         <PageSection>
@@ -95,22 +106,14 @@ export default function DatasetComparison() {
                         <EmptyState>
                             <EmptyStateBody>No datasets have been loaded</EmptyStateBody>
                         </EmptyState>
-                    ) : (
-                        <FragmentTabs>
-                            <FragmentTab title="Labels" fragment="labels">
-                                <LabelsComparison headers={headers} datasets={datasets} alerting={alerting} />
-                            </FragmentTab>
-                            <FragmentTab title="Default view" fragment="view_default" isHidden={!test}>
-                                {defaultView ? (
-                                    <ViewComparison headers={headers} view={defaultView} datasets={datasets} alerting={alerting} />
-                                ) : (
-                                    <Bullseye>
-                                        <Spinner size="xl" />
-                                    </Bullseye>
-                                )}
-                            </FragmentTab>
-                        </FragmentTabs>
-                    )}
+                        ) :
+                        (
+                            <FragmentTabs>
+                                {fragmentTags}
+                            </FragmentTabs>
+                        )
+
+                    }
                 </CardBody>
             </Card>
         </PageSection>


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1880

## Fixes Issue

Fixes #1879

Dynamically resolve the custom views for Compare Datasets

![Screenshot from 2024-07-09 16-54-02](https://github.com/Hyperfoil/Horreum/assets/959822/82c3d6e5-fa55-447c-98c2-fdfc7e474fea)

![Screenshot from 2024-07-09 16-54-33](https://github.com/Hyperfoil/Horreum/assets/959822/3ae19a88-db5a-4a43-9dae-63d5d54ee3a8)


![Screenshot from 2024-07-09 16-54-38](https://github.com/Hyperfoil/Horreum/assets/959822/becad555-904c-41f8-988c-866ffa304fca)
