### PR TITLE
Replace Test.get calls when not really required

### DIFF
--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
@@ -32,9 +32,11 @@ import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.DEFAULT_USER;
 import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.FOO_TEAM;
 import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.FOO_TESTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(PostgresResource.class)
@@ -158,6 +160,21 @@ class TestServiceNoRestTest extends BaseServiceNoRestTest {
       ServiceException thrown = assertThrows(ServiceException.class, () -> testService.add(t));
       assertEquals("Could not persist test due to another test.", thrown.getMessage());
       assertEquals(Response.Status.CONFLICT.getStatusCode(), thrown.getResponse().getStatus());
+   }
+
+   @org.junit.jupiter.api.Test
+   void testCheckTestExists() {
+      Test t1 = createSampleTest("test", null, null, null);
+      Test t2 = createSampleTest("1234", null, null, null);
+
+      Test created1 = testService.add(t1);
+      assertNotNull(created1.id);
+      Test created2 = testService.add(t2);
+      assertNotNull(created2.id);
+
+      assertTrue(((TestServiceImpl) testService).checkTestExists(created1.id));
+      assertTrue(((TestServiceImpl) testService).checkTestExists(created2.id));
+      assertFalse(((TestServiceImpl) testService).checkTestExists(9999));
    }
 
    @org.junit.jupiter.api.Test


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

- [x] Create ad-hoc method to simply check test existence and access right by triggering db level RLS
- [x] Replace `TestServiceImpl.get` call with the new one when not really required

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
