### PR TITLE
[0.14] Fix horreum realm for oidc deployments

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityBootstrap.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/SecurityBootstrap.java
@@ -30,7 +30,7 @@ import static io.quarkus.runtime.configuration.ProfileManager.getLaunchMode;
 @ApplicationScoped public class SecurityBootstrap {
 
     @ConfigProperty(name = "quarkus.keycloak.admin-client.server-url") Optional<String> keycloakURL;
-    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
 
     @ConfigProperty(name = "horreum.roles.provider", defaultValue = "keycloak") String provider;
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
@@ -43,7 +43,7 @@ public class KeycloakUserBackend implements UserBackEnd {
 
     private static final String[] ROLE_TYPES = new String[] { "team", Roles.VIEWER, Roles.TESTER, Roles.UPLOADER, Roles.MANAGER };
 
-    @ConfigProperty(name = "horreum.keycloak.realm", defaultValue = "horreum") String realm;
+    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm", defaultValue = "horreum") String realm;
 
     // please make sure all calls to this object are in a try/catch block to avoid leaking information
     @Inject Keycloak keycloak;


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/1900

In situations where the OIDC server is not manged by Horreum (an external SSO provider is used) make the distinction between `horreum.keycloak.realm` (the realm that is sent to the front end and used for authentication) and `quarkus.keycloak.admin-client.realm` (a managed realm used for migration in those scenarios).

This change aligns the realm definition with the usages of `@Inject Keycloak`.