### PR TITLE
Return empty list if machine role is not present

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/user/KeycloakUserBackend.java
@@ -417,6 +417,9 @@ public class KeycloakUserBackend implements UserBackEnd {
             String prefix = getTeamPrefix(team);
             return keycloak.realm(realm).roles().get(prefix + Roles.MACHINE).getUserMembers(0, Integer.MAX_VALUE).stream()
                     .map(KeycloakUserBackend::toUserInfo).toList();
+        } catch (NotFoundException ex) {
+            LOG.debugv("Unable to list machine accounts for team {0}", team);
+            return List.of();
         } catch (Throwable t) {
             LOG.warnv(t, "Unable to list machine accounts for team {0}", team);
             throw ServiceException


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

At the moment, everytime a user open the administrator tab a warning saying that it is not able to list machine accounts for a specific team (the one selected by default, i.e., the first one) alongside the exception which says that the role is NOT FOUND is printed in the logs.

```bash
2024-09-09 10:50:46,107 e4b3085409dd quarkus-run.jar[7] WARN  [io.hyp.too.hor.svc.use.KeycloakUserBackend] (executor-thread-23917) Unable to list machine accounts for team <MY_TEAM>: jakarta.ws.rs.NotFoundException: HTTP 404 Not Found
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.handleErrorStatus(ClientInvocation.java:242)
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.extractResult(ClientInvocation.java:216)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.BodyEntityExtractor.extractEntity(BodyEntityExtractor.java:59)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invokeSync(ClientInvoker.java:136)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invoke(ClientInvoker.java:103)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy.invoke(ClientProxy.java:102)
	at jdk.proxy2/jdk.proxy2.$Proxy121.getUserMembers(Unknown Source)
	at io.hyperfoil.tools.horreum.svc.user.KeycloakUserBackend.machineAccounts(KeycloakUserBackend.java:368)
	at io.hyperfoil.tools.horreum.svc.user.KeycloakUserBackend_ClientProxy.machineAccounts(Unknown Source)
	at io.hyperfoil.tools.horreum.svc.UserServiceImpl.safeMachineAccounts(UserServiceImpl.java:215)
	at io.hyperfoil.tools.horreum.svc.UserServiceImpl.teamMembers(UserServiceImpl.java:100)
```

Given that the situation when the machine role is not present is an expected condition I don't see real value in logging the exception alongside the warning, this is going to pollute the log files with unnecessary and useless information.

Therefore I'd propose to catch the `NotFoundException` and either log it at `DEBUG` level or keep it as `WARNING` but without the stacktrace.

## Changes proposed

Instead of logging the exception when the `machine` role is not found, simply log the warning and return empty list.
This will cleanup the logs a little bit by removing useless information from them.

With the change the log will be something like:
```bash
2024-09-09 14:50:08,047 WARN  [io.hyp.too.hor.svc.use.KeycloakUserBackend] (executor-thread-1) Unable to list machine accounts for team <MY_TEAM>
```

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
