### PR TITLE
[0.15] Fix sequential handling of multi upload type with less than 10 items

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -585,7 +585,7 @@ public class RunServiceImpl implements RunService {
             } else { //process synchronously
                 response.payload.forEach(jsonNode -> {
                     runIds.add(getPersistRun(start, stop, test, owner, access, token, schemaUri, description, metadata,
-                            response.payload, testEntity));
+                            jsonNode, testEntity));
                 });
             }
         } else {


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2036

## Fixes Issue

Fixes the sequential handling of multi-upload datastore types. 

Fixup of https://github.com/Hyperfoil/Horreum/pull/1859

## Changes proposed

- [x] Instead of passing the full payload a single node should be passed at a time.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
