### PR TITLE
Add support for jsonpath filter expression ...

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -431,9 +431,9 @@ public class Util {
         try {
             JsonPath path = JsonPath.compile(jsonPath);
             Object obj = ctx.read(path);
-            if (obj instanceof ArrayNode) {
-                if (((ArrayNode) obj).size() == 1) {
-                    obj = ((ArrayNode) obj).get(0);
+            if (obj instanceof ArrayNode arr) {
+                if (arr.size() == 1) {
+                    obj = arr.get(0);
                 }
             }
             if (obj instanceof ValueNode) {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -431,6 +431,11 @@ public class Util {
         try {
             JsonPath path = JsonPath.compile(jsonPath);
             Object obj = ctx.read(path);
+            if (obj instanceof ArrayNode) {
+                if (((ArrayNode) obj).size() == 1) {
+                    obj = ((ArrayNode) obj).get(0);
+                }
+            }
             if (obj instanceof ValueNode) {
                 ValueNode node = (ValueNode) obj;
                 switch (node.getNodeType()) {


### PR DESCRIPTION
... which may return an ArrayNode that we need to process more

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

When `findJsonPath` is invoked with a jsonpath filter expression, the ArrayNode is not transformed correctly.

## Changes proposed

If the result of the jsonPath is an ArrayNode of size exactly one, then process that one-and-only entry as a value.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
