### PR TITLE
Add before/after labelValues filtering test

### DIFF
--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -268,7 +268,11 @@ public class BaseServiceTest {
 
     protected String uploadRun(Object runJson, String test, String schemaUri, Integer statusCode) {
         long timestamp = System.currentTimeMillis();
-        String runId = uploadRun(Long.toString(timestamp), Long.toString(timestamp), test, UPLOADER_ROLES[0], Access.PUBLIC,
+        return uploadRun(timestamp, timestamp, runJson, test, schemaUri, statusCode);
+    }
+
+    protected String uploadRun(long start, long stop, Object runJson, String test, String schemaUri, Integer statusCode) {
+        String runId = uploadRun(Long.toString(start), Long.toString(stop), test, UPLOADER_ROLES[0], Access.PUBLIC,
                 null, schemaUri, null, statusCode, runJson);
         assertNotEquals("-1", runId);
         return runId;

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/UtilTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/UtilTest.java
@@ -155,7 +155,7 @@ public class UtilTest {
     }
 
     @Test
-    public void toInstant_valid() throws IOException {
+    public void toInstant_valid() {
         //already an instant
         assertNotNull(Util.toInstant(Instant.now()), "failed to handle instant input");
         //number
@@ -167,6 +167,7 @@ public class UtilTest {
         assertNotNull(Util.toInstant("2020-01-01T01:01:01Z"), "failed to parse YYYY-MM-DDThh:mm:ssZ");
         assertNotNull(Util.toInstant("2020-01-01T01:01:01+00:00"), "failed to parse YYYY-MM-DDThh:mm:ss[+-]zz:zz");
         assertNotNull(Util.toInstant("2024-03-11T22:16:24.302655-04:00"), "failed to parse ISO with microseconds and zzzz");
+        assertNotNull(Util.toInstant("2024-10-07T20:20:32.183Z"), "failed to parse YYYY-MM-DDTHH:mm:ss.zzz");
         //json
         assertNotNull(Util.toInstant(new TextNode("2020-01-01")), "failed to parse json text YYYY-MM-DD");
         assertNotNull(Util.toInstant(new LongNode(System.currentTimeMillis())), "failed to parse current millis as json node");


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

This was initially meant to address https://github.com/Hyperfoil/Horreum/issues/2078 but it looks like the before/after filtering is actually working as expected.

Therefore, at the moment, I am proposing to simply add some more testing that will improve the labelValues coverage.

## Changes proposed

- [x] Add some more testing on before/after labelValues filtering

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
