### PR TITLE
Do not use recalc lock for run-recalc

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -64,6 +65,7 @@ import io.hyperfoil.tools.horreum.api.data.Run;
 import io.hyperfoil.tools.horreum.api.data.ValidationError;
 import io.hyperfoil.tools.horreum.api.services.RunService;
 import io.hyperfoil.tools.horreum.api.services.SchemaService;
+import io.hyperfoil.tools.horreum.api.services.TestService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
 import io.hyperfoil.tools.horreum.datastore.BackendResolver;
 import io.hyperfoil.tools.horreum.datastore.Datastore;
@@ -151,6 +153,8 @@ public class RunServiceImpl implements RunService {
 
     @Inject
     Session session;
+
+    private final ConcurrentHashMap<Integer, TestService.RecalculationStatus> transformations = new ConcurrentHashMap<>();
 
     @Transactional
     @WithRoles(extras = Roles.HORREUM_SYSTEM)
@@ -1118,6 +1122,15 @@ public class RunServiceImpl implements RunService {
         }
     }
 
+    /**
+     * Transforms the data for a given run by applying applicable schemas and transformers.
+     * It ensures any existing datasets for the run are removed before creating new ones,
+     * handles timeouts for ongoing transformations, and creates datasets with the transformed data.
+     *
+     * @param runId the ID of the run to transform
+     * @param isRecalculation flag indicating if this is a recalculation
+     * @return the number of datasets created, or 0 if the run is invalid or not found or already ongoing
+     */
     @WithRoles(extras = Roles.HORREUM_SYSTEM)
     @Transactional
     int transform(int runId, boolean isRecalculation) {
@@ -1125,7 +1138,22 @@ public class RunServiceImpl implements RunService {
             log.errorf("Transformation parameters error: run %s", runId);
             return 0;
         }
+
         log.debugf("Transforming run ID %d, recalculation? %s", runId, Boolean.toString(isRecalculation));
+        int numDatasets = 0;
+
+        // check whether there is an ongoing transformation on the same runId
+        TestService.RecalculationStatus status = new TestService.RecalculationStatus(1);
+        TestService.RecalculationStatus prev = transformations.putIfAbsent(runId, status);
+        // ensure the transformation is removed, with this approach we should be sure
+        // it gets removed even if transaction-level exception occurs, e.g., timeout
+        Util.registerTxSynchronization(tm, txStatus -> transformations.remove(runId, status));
+        if (prev != null) {
+            // there is an ongoing transformation that has recently been initiated
+            log.warnf("Transformation for run %d already in progress", runId);
+            return numDatasets;
+        }
+
         // We need to make sure all old datasets are gone before creating new; otherwise we could
         // break the runid,ordinal uniqueness constraint
         for (DatasetDAO old : DatasetDAO.<DatasetDAO> list("run.id", runId)) {
@@ -1138,9 +1166,8 @@ public class RunServiceImpl implements RunService {
         RunDAO run = RunDAO.findById(runId);
         if (run == null) {
             log.errorf("Cannot load run ID %d for transformation", runId);
-            return 0;
+            return numDatasets; // this is 0
         }
-        int ordinal = 0;
         Map<Integer, JsonNode> transformerResults = new TreeMap<>();
         // naked nodes (those produced by implicit identity transformers) are all added to each dataset
         List<JsonNode> nakedNodes = new ArrayList<>();
@@ -1247,7 +1274,8 @@ public class RunServiceImpl implements RunService {
                     }
                 } else if (!result.isContainerNode() || (result.isObject() && !result.has("$schema")) ||
                         (result.isArray()
-                                && StreamSupport.stream(result.spliterator(), false).anyMatch(item -> !item.has("$schema")))) {
+                                && StreamSupport.stream(result.spliterator(), false)
+                                        .anyMatch(item -> !item.has("$schema")))) {
                     logMessage(run, PersistentLogDAO.WARN, "Dataset will contain element without a schema.");
                 }
                 JsonNode existing = transformerResults.get(transformerId);
@@ -1285,12 +1313,14 @@ public class RunServiceImpl implements RunService {
                 }
                 nakedNodes.add(node);
                 logMessage(run, PersistentLogDAO.DEBUG,
-                        "This test (%d) does not use any transformer for schema %s (key %s), passing as-is.", run.testid, uri,
+                        "This test (%d) does not use any transformer for schema %s (key %s), passing as-is.", run.testid,
+                        uri,
                         key);
             }
         }
         if (schemasAndTransformers > 0) {
-            int max = transformerResults.values().stream().filter(JsonNode::isArray).mapToInt(JsonNode::size).max().orElse(1);
+            int max = transformerResults.values().stream().filter(JsonNode::isArray).mapToInt(JsonNode::size).max()
+                    .orElse(1);
 
             for (int position = 0; position < max; position += 1) {
                 ArrayNode all = instance.arrayNode(max + nakedNodes.size());
@@ -1305,7 +1335,7 @@ public class RunServiceImpl implements RunService {
                             String message = String.format(
                                     "Transformer %d produced an array of %d elements but other transformer " +
                                             "produced %d elements; dataset %d/%d might be missing some data.",
-                                    entry.getKey(), node.size(), max, run.id, ordinal);
+                                    entry.getKey(), node.size(), max, run.id, numDatasets);
                             logMessage(run, PersistentLogDAO.WARN, "%s", message);
                             log.warnf(message);
                         }
@@ -1316,18 +1346,18 @@ public class RunServiceImpl implements RunService {
                     }
                 }
                 nakedNodes.forEach(all::add);
-                createDataset(new DatasetDAO(run, ordinal++, run.description, all), isRecalculation);
+                createDataset(new DatasetDAO(run, numDatasets++, run.description, all), isRecalculation);
             }
             mediator.validateRun(run.id);
-            return ordinal;
         } else {
+            numDatasets = 1;
             logMessage(run, PersistentLogDAO.INFO, "No applicable schema, dataset will be empty.");
             createDataset(new DatasetDAO(
                     run, 0, "Empty Dataset for run data without any schema.",
                     instance.arrayNode()), isRecalculation);
             mediator.validateRun(run.id);
-            return 1;
         }
+        return numDatasets;
     }
 
     private String limitLength(String str) {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -720,7 +720,7 @@ public class TestServiceImpl implements TestService {
             // transform will add proper roles anyway
             //         messageBus.executeForTest(testId, () -> datasetService.withRecalculationLock(() -> {
             //         mediator.executeBlocking(() -> mediator.transform(runId, true));
-            mediator.executeBlocking(() -> mediator.withRecalculationLock(() -> {
+            mediator.executeBlocking(() -> mediator.withSharedLock(() -> {
                 int newDatasets = 0;
                 try {
                     newDatasets = mediator.transform(runId, true);

--- a/horreum-web/src/api.tsx
+++ b/horreum-web/src/api.tsx
@@ -342,14 +342,6 @@ export function updateChangeDetection(
 
 }
 
-export function updateRunsAndDatasetsAction(
-    testId: number,
-    runs: number,
-    datasets: number
-): any {
-    return {type: "Tests/UPDATE_RUNS_AND_DATASETS", testId, runs, datasets}
-}
-
 ///Runs
 export function fetchRunSummary(id: number, token: string | undefined, alerting: AlertContextType): Promise<RunSummary> {
     return apiCall(runApi.getRunSummary(id, token), alerting, "FETCH_RUN_SUMMARY", "Failed to fetch data for run " + id + ", try uploading a Run and use new Run id instead.");

--- a/horreum-web/src/domain/tests/RecalculateDatasetsModal.tsx
+++ b/horreum-web/src/domain/tests/RecalculateDatasetsModal.tsx
@@ -1,6 +1,6 @@
-import {useCallback, useEffect, useState, useRef, useContext} from "react"
+import { useCallback, useEffect, useState, useRef, useContext } from "react"
 import { Bullseye, Button, Modal, Progress, Spinner } from "@patternfly/react-core"
-import {fetchTest, RecalculationStatus, testApi, TestStorage, updateRunsAndDatasetsAction} from "../../api"
+import { fetchTest, RecalculationStatus, testApi, TestStorage } from "../../api"
 import {AppContext} from "../../context/appContext";
 import {AppContextType} from "../../context/@types/appContextTypes";
 
@@ -13,7 +13,7 @@ type RecalculateDatasetsModalProps = {
 
 export default function RecalculateDatasetsModal(props: RecalculateDatasetsModalProps) {
     const { alerting } = useContext(AppContext) as AppContextType;
-    const [test, setTest] = useState<TestStorage | undefined>( undefined)
+    const [test, setTest] = useState<TestStorage | undefined>(undefined)
     const [progress, setProgress] = useState(-1)
     const [status, setStatus] = useState<RecalculationStatus>()
     const timerId = useRef<number>()
@@ -32,19 +32,16 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
         if (!props.isOpen) {
             return
         }
-        fetchTest(props.testId, alerting).then(setTest)
-    }, [props.testId]);
 
-    useEffect(() => {
-        if (!props.isOpen) {
-            return
-        }
+        // fetch the current test
+        fetchTest(props.testId, alerting).then(setTest)
+
+        // fetch the latest recalculation status
         if (test?.runs === undefined) {
-            testApi.getRecalculationStatus(props.testId).then(status => {
-                updateRunsAndDatasetsAction(props.testId, status.totalRuns, status.datasets)
-            })
+            testApi.getRecalculationStatus(props.testId).then(setStatus)
         }
-    }, [test, props.isOpen])
+    }, [props.isOpen]);
+
     return (
         <Modal
             title={`Re-transform datasets for test ${test?.name || "<unknown test>"}`}
@@ -66,11 +63,6 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
                                                   .then(status => {
                                                       setStatus(status)
                                                       setProgress(status.finished)
-                                                      updateRunsAndDatasetsAction(
-                                                          props.testId,
-                                                          status.totalRuns,
-                                                          status.datasets
-                                                      )
                                                       if (status.finished === status.totalRuns) {
                                                           onClose()
                                                       }
@@ -112,7 +104,7 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
             )}
             {progress < 0 && (
                 <div style={{ marginBottom: "16px" }}>
-                    This test has {test?.runs || "<unknown number>"} of runs; do you want to recalculate all datasets?
+                    This test has {status?.totalRuns || "<unknown number>"} of runs; do you want to recalculate all datasets?
                 </div>
             )}
             {progress >= 0 && (


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1975

## Changes proposed

- [x] Do not use shared lock during labelValues computation 
- [x] Move shared lock usage into ServiceMediator if really required 
- [x] Manage concurrent runs transformation similarly to what we are doing for test datasets recalculation
- [x] Fix the test datasets recalculation modal (show correct data)
   
![image](https://github.com/user-attachments/assets/2b3f27f1-d95c-4d9b-892c-bf8a02ea893c)


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
