### PR TITLE
[0.15] Pin python version 3.9 into the horreum-base

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       # required to install Hunter
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.9'
       - name: Install Hunter
         run: |
           pip --version

--- a/horreum-backend/src/main/docker/Dockerfile.jvm.base
+++ b/horreum-backend/src/main/docker/Dockerfile.jvm.base
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/openjdk-17
 USER root
 #Install python packages to run Hunter
-RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip python3-pip nss_wrapper \
+RUN INSTALL_PKGS="python3-3.9.* python3-devel python3-setuptools python3-pip nss_wrapper \
         httpd httpd-devel mod_ssl mod_auth_gssapi mod_ldap \
         mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl \
         enchant krb5-devel git" && \


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2085

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Followup of https://github.com/Hyperfoil/Horreum/pull/2080.

Pin the python version that we embed in the Horreum container, this comes with some good improvements:
- Reproducibility of the build
- Clearly state the python version being used
- Ensure CI uses and test the same version we use in the container

## Changes proposed

- [x] Pin the python version that is bundled in the Horreum container
- [x] Choose version `3.9` as this is the one installed in `registry.access.redhat.com/ubi9/openjdk-17` by default
- [x] Align CI to use the same version, i.e., `3.9`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
