### PR TITLE
UI datasets ordering starting from 0

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/notification/EmailPlugin.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/notification/EmailPlugin.java
@@ -122,7 +122,7 @@ public class EmailPlugin implements NotificationPlugin {
         @Override
         public void notifyMissingValues(String testName, String fingerprint, MissingValuesEvent event) {
             String subject = String.format("%s Missing change detection values in test %s, dataset %d#%d",
-                    subjectPrefix, testName, event.dataset.runId, event.dataset.ordinal + 1);
+                    subjectPrefix, testName, event.dataset.runId, event.dataset.ordinal);
             missingValuesNotificationEmail
                     .data("username", username)
                     .data("testName", testName)

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ReportServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ReportServiceImpl.java
@@ -454,7 +454,7 @@ public class ReportServiceImpl implements ReportService {
                     } catch (PolyglotException e) {
                         log(report, PersistentLogDAO.ERROR,
                                 "Failed to run report %s(%d) category function on dataset %d/%d (%d). Offending code: <br><pre>%s</pre>",
-                                config.title, config.id, data.runId, data.ordinal + 1, data.datasetId, jsCode);
+                                config.title, config.id, data.runId, data.ordinal, data.datasetId, jsCode);
                         log.debug("Caused by exception", e);
                         continue;
                     }
@@ -480,7 +480,7 @@ public class ReportServiceImpl implements ReportService {
                     } catch (PolyglotException e) {
                         log(report, PersistentLogDAO.ERROR,
                                 "Failed to run report %s(%d) series function on run %d/%d (%d). Offending code: <br><pre>%s</pre>",
-                                config.title, config.id, runId, ordinal + 1, datasetId, jsCode);
+                                config.title, config.id, runId, ordinal, datasetId, jsCode);
                         log.debug("Caused by exception", e);
                     }
                 }
@@ -504,7 +504,7 @@ public class ReportServiceImpl implements ReportService {
                     } catch (PolyglotException e) {
                         log(report, PersistentLogDAO.ERROR,
                                 "Failed to run report %s(%d) label function on dataset %d/%d (%d). Offending code: <br><pre>%s</pre>",
-                                config.title, config.id, runId, ordinal + 1, datasetId, jsCode);
+                                config.title, config.id, runId, ordinal, datasetId, jsCode);
                         log.debug("Caused by exception", e);
                     }
                 }
@@ -639,7 +639,7 @@ public class ReportServiceImpl implements ReportService {
                 if (debugList.length() != 0) {
                     debugList.append(", ");
                 }
-                debugList.append(runId).append('/').append(ordinal + 1);
+                debugList.append(runId).append('/').append(ordinal);
                 if (row[3] != null && ((JsonNode) row[3]).asBoolean(false)) {
                     datasetIds.add(datasetId);
                 } else {
@@ -658,7 +658,7 @@ public class ReportServiceImpl implements ReportService {
                     if (debugList.length() != 0) {
                         debugList.append(", ");
                     }
-                    debugList.append(runId).append('/').append(ordinal + 1);
+                    debugList.append(runId).append('/').append(ordinal);
                     try {
                         org.graalvm.polyglot.Value value = context.eval("js", jsCode);
                         if (value.isBoolean()) {
@@ -673,13 +673,13 @@ public class ReportServiceImpl implements ReportService {
                             debugList.append("(filtered: not boolean)");
                             log(report, PersistentLogDAO.ERROR,
                                     "Report %s(%d) filter result for dataset %d/%d (%d) is not a boolean: %s. Offending code: <br><pre>%s</pre>",
-                                    config.title, config.id, runId, ordinal + 1, datasetId, value, jsCode);
+                                    config.title, config.id, runId, ordinal, datasetId, value, jsCode);
                         }
                     } catch (PolyglotException e) {
                         debugList.append("(filtered: JS error)");
                         log(report, PersistentLogDAO.ERROR,
                                 "Failed to run report %s(%d) filter function on dataset %d/%d (%d). Offending code: <br><pre>%s</pre>",
-                                config.title, config.id, runId, ordinal + 1, datasetId, jsCode);
+                                config.title, config.id, runId, ordinal, datasetId, jsCode);
                         log.debug("Caused by exception", e);
                     }
                 }

--- a/horreum-backend/src/main/resources/templates/tags/dataset_link.md
+++ b/horreum-backend/src/main/resources/templates/tags/dataset_link.md
@@ -1,1 +1,1 @@
-[{it.runId}#{it.ordinal + 1}]({publicUrl}/run/{it.runId}#dataset{it.ordinal})
+[{it.runId}/{it.ordinal}]({publicUrl}/run/{it.runId}#dataset{it.ordinal})

--- a/horreum-web/src/domain/alerting/ChangeTable.tsx
+++ b/horreum-web/src/domain/alerting/ChangeTable.tsx
@@ -194,7 +194,7 @@ export const ChangeTable = ({ varId, fingerprint, testOwner, selectedChangeId }:
                 if (!dataset) return <></>
                 return (
                     <NavLink to={`/run/${dataset.runId}#dataset${dataset.ordinal}`}>
-                        {dataset.runId}/{dataset.ordinal + 1}
+                        {dataset.runId}/{dataset.ordinal}
                     </NavLink>
                 )
             },

--- a/horreum-web/src/domain/alerting/RecalculateModal.tsx
+++ b/horreum-web/src/domain/alerting/RecalculateModal.tsx
@@ -41,7 +41,7 @@ function datasetsToLinks(datasets: DatasetInfo[] | undefined | null) {
                     <>
                         {i !== 0 && ", "}
                         <NavLink to={`/run/${ds.runId}#dataset${ds.ordinal}`}>
-                            {ds.runId}/{ds.ordinal + 1}
+                            {ds.runId}/{ds.ordinal}
                         </NavLink>
                     </>
                 ))}

--- a/horreum-web/src/domain/reports/TableReportView.tsx
+++ b/horreum-web/src/domain/reports/TableReportView.tsx
@@ -60,7 +60,7 @@ function DataView(props: DataViewProps) {
                 <>
                     Dataset{" "}
                     <NavLink to={`/run/${data.runId}#dataset${data.ordinal}`}>
-                        {data.runId}/{data.ordinal + 1}
+                        {data.runId}/{data.ordinal}
                     </NavLink>
                 </>
             }

--- a/horreum-web/src/domain/runs/DatasetComparison.tsx
+++ b/horreum-web/src/domain/runs/DatasetComparison.tsx
@@ -77,7 +77,7 @@ export default function DatasetComparison() {
             ...datasets.map(item => ({
                 title: (
                     <NavLink to={`/run/${item.runId}#dataset${item.ordinal}`}>
-                        {item.runId}/{item.ordinal + 1}
+                        {item.runId}/{item.ordinal}
                     </NavLink>
                 ),
             })),
@@ -166,7 +166,7 @@ function LabelsComparison({headers, datasets, alerting}: LabelsComparisonProps) 
                                         title: (
                                             <BarValuesChart
                                                 values={row.slice(1)}
-                                                legend={labels.map(item => `${item.runId}/${item.ordinal + 1}`)}
+                                                legend={labels.map(item => `${item.runId}/${item.ordinal}`)}
                                             />
                                         ),
                                         props: {
@@ -261,7 +261,7 @@ function ViewComparison({headers, view, datasets, alerting}: ViewComparisonProps
                                         title: (
                                             <BarValuesChart
                                                 values={rd.slice(1)}
-                                                legend={summaries.map(summary => `${summary.runId}/${summary.ordinal + 1}`)}
+                                                legend={summaries.map(summary => `${summary.runId}/${summary.ordinal}`)}
                                             />
                                         ) ,
                                         props: {

--- a/horreum-web/src/domain/runs/ExperimentModal.tsx
+++ b/horreum-web/src/domain/runs/ExperimentModal.tsx
@@ -150,7 +150,7 @@ export default function ExperimentModal(props: ExperimentModalProps) {
                                     interleave(
                                         result.baseline.map((ds, i) => (
                                             <NavLink key={2 * i} to={`/run/${ds.runId}#dataset${ds.ordinal}`}>
-                                                {ds.runId}/{ds.ordinal + 1}
+                                                {ds.runId}/{ds.ordinal}
                                             </NavLink>
                                         )),
                                         i => <React.Fragment key={2 * i + 1}>, </React.Fragment>

--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -68,7 +68,7 @@ const staticColumns: DatasetColumn[] = [
                 <>
                     <NavLink to={`/run/${value}#dataset${arg.row.original.ordinal}`}>
                         <ArrowRightIcon />
-                        {`\u00A0${value} #${arg.row.original.ordinal + 1}`}
+                        {`\u00A0${value}/${arg.row.original.ordinal}`}
                     </NavLink>
                 </>
             )

--- a/horreum-web/src/domain/schemas/TestLabelModal.tsx
+++ b/horreum-web/src/domain/schemas/TestLabelModal.tsx
@@ -92,7 +92,7 @@ export default function TestLabelModal(props: TestLabelModalProps) {
                                 {
                                     title: (
                                         <NavLink to={`/run/${d.runId}#dataset${d.ordinal}`}>
-                                            {d.runId}/{d.ordinal + 1}
+                                            {d.runId}/{d.ordinal}
                                         </NavLink>
                                     ),
                                 },

--- a/horreum-web/src/domain/schemas/TryJsonPathModal.tsx
+++ b/horreum-web/src/domain/schemas/TryJsonPathModal.tsx
@@ -219,7 +219,7 @@ export default function TryJsonPathModal(props: TryJsonPathModalProps) {
                                                         props.jsonpath || ""
                                                     )}#dataset${d.ordinal}`}
                                                 >
-                                                    {d.runId}/{d.ordinal + 1}
+                                                    {d.runId}/{d.ordinal}
                                                 </NavLink>
                                             ),
                                         },
@@ -284,7 +284,7 @@ export default function TryJsonPathModal(props: TryJsonPathModalProps) {
                                 props.jsonpath || ""
                             )}#dataset${(target as DatasetSummary).ordinal}`}
                         >
-                            Go to dataset {(target as DatasetSummary).runId} #{(target as DatasetSummary).ordinal + 1}
+                            Go to dataset {(target as DatasetSummary).runId} #{(target as DatasetSummary).ordinal}
                         </NavLink>
                     )}
                 </div>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Currently in the UI the datasets ordering is starting from 1, whereas the ordering in the backend start from 0.
This could create some confusion, when both conventions are reported in the UI, e.g., https://github.com/Hyperfoil/Horreum/issues/2093. 

Moreover, all the urls that contain some datasets identifiers use the backend convention (starting from 0).

My proposal is to unify the convention and make use of the 0ed one, this would also simplify its management in the UI.

## Changes proposed

- [x] Keep the same datasets ordering between backend and UI

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
