### PR TITLE
[0.15] Fix RunService in java client

### DIFF
--- a/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
+++ b/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
@@ -74,9 +74,9 @@ public interface RunService {
             @QueryParam("access") Access access);
 
     @POST
-    @Path("test/{test}")
+    @Path("test")
     @Consumes(MediaType.APPLICATION_JSON)
-    Response add(@PathParam("test") String testNameOrId,
+    Response add(@QueryParam("test") String testNameOrId,
             @QueryParam("owner") String owner,
             @QueryParam("access") Access access,
             @QueryParam("token") String token,


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2117

[This change](https://github.com/Hyperfoil/Horreum/pull/641/files#diff-c3cbefab12e12b2c5bfaa7dde40f95e053e03ca209c6cca20ab56357942000b5) was not carried over to the `RunService` representation on the java client, causing a mismatch between client and server.

Calls to the `add()` method will always result in a `404 Not Found` response.