### PR TITLE
[0.15] Set AMQP strategy to modified-failed

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -39,49 +39,50 @@ public class ServiceMediator {
     private static final Logger log = Logger.getLogger(ServiceMediator.class);
 
     @Inject
-    private TestServiceImpl testService;
+    TestServiceImpl testService;
 
     @Inject
-    private AlertingServiceImpl alertingService;
+    AlertingServiceImpl alertingService;
 
     @Inject
-    private RunServiceImpl runService;
+    RunServiceImpl runService;
 
     @Inject
-    private ReportServiceImpl reportService;
+    ReportServiceImpl reportService;
 
     @Inject
-    private ExperimentServiceImpl experimentService;
+    ExperimentServiceImpl experimentService;
 
     @Inject
-    private LogServiceImpl logService;
+    LogServiceImpl logService;
 
     @Inject
-    private SubscriptionServiceImpl subscriptionService;
+    SubscriptionServiceImpl subscriptionService;
 
     @Inject
-    private ActionServiceImpl actionService;
+    ActionServiceImpl actionService;
 
     @Inject
-    private NotificationServiceImpl notificationService;
+    NotificationServiceImpl notificationService;
 
     @Inject
-    private DatasetServiceImpl datasetService;
+    DatasetServiceImpl datasetService;
 
     @Inject
-    private EventAggregator aggregator;
+    EventAggregator aggregator;
 
     @Inject
     Vertx vertx;
+
     @Inject
-    private SchemaServiceImpl schemaService;
+    SchemaServiceImpl schemaService;
 
     @Inject
     SecurityIdentity identity;
 
     @Inject
     @ConfigProperty(name = "horreum.test-mode", defaultValue = "false")
-    private Boolean testMode;
+    Boolean testMode;
 
     @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 10000)
     @Channel("dataset-event-out")
@@ -306,7 +307,7 @@ public class ServiceMediator {
         }
     }
 
-    static class RunUpload {
+    public static class RunUpload {
         public String start;
         public String stop;
         public String test;

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -31,48 +31,56 @@ mp.messaging.incoming.dataset-event-in.address=dataset-event
 mp.messaging.incoming.dataset-event-in.durable=true
 mp.messaging.incoming.dataset-event-in.container-id=horreum-broker
 mp.messaging.incoming.dataset-event-in.link-name=dataset-event
+mp.messaging.incoming.dataset-event-in.failure-strategy=modified-failed
 # dataset-event outgoing
 mp.messaging.outgoing.dataset-event-out.connector=smallrye-amqp
 mp.messaging.outgoing.dataset-event-out.address=dataset-event
 mp.messaging.outgoing.dataset-event-out.durable=true
 mp.messaging.outgoing.dataset-event-out.container-id=horreum-broker
 mp.messaging.outgoing.dataset-event-out.link-name=dataset-event
+mp.messaging.outgoing.dataset-event-out.failure-strategy=modified-failed
 # re-calc incoming
 mp.messaging.incoming.run-recalc-in.connector=smallrye-amqp
 mp.messaging.incoming.run-recalc-in.address=run-recalc
 mp.messaging.incoming.run-recalc-in.durable=true
 mp.messaging.incoming.run-recalc-in.container-id=horreum-broker
 mp.messaging.incoming.run-recalc-in.link-name=run-recalc
+mp.messaging.incoming.run-recalc-in.failure-strategy=modified-failed
 # re-calc outgoing
 mp.messaging.outgoing.run-recalc-out.connector=smallrye-amqp
 mp.messaging.outgoing.run-recalc-out.address=run-recalc
 mp.messaging.outgoing.run-recalc-out.durable=true
 mp.messaging.outgoing.run-recalc-out.container-id=horreum-broker
 mp.messaging.outgoing.run-recalc-out.link-name=run-recalc
+mp.messaging.outgoing.run-recalc-out.failure-strategy=modified-failed
 # schema-sync incoming
 mp.messaging.incoming.schema-sync-in.connector=smallrye-amqp
 mp.messaging.incoming.schema-sync-in.address=schema-sync
 mp.messaging.incoming.schema-sync-in.durable=true
 mp.messaging.incoming.schema-sync-in.container-id=horreum-broker
 mp.messaging.incoming.schema-sync-in.link-name=schema-sync
+mp.messaging.incoming.schema-sync-in.failure-strategy=modified-failed
 # schema-sync outgoing
 mp.messaging.outgoing.schema-sync-out.connector=smallrye-amqp
 mp.messaging.outgoing.schema-sync-out.address=schema-sync
 mp.messaging.outgoing.schema-sync-out.durable=true
 mp.messaging.outgoing.schema-sync-out.container-id=horreum-broker
 mp.messaging.outgoing.schema-sync-out.link-name=schema-sync
+mp.messaging.outgoing.schema-sync-out.failure-strategy=modified-failed
 # run-upload incoming
 mp.messaging.incoming.run-upload-in.connector=smallrye-amqp
 mp.messaging.incoming.run-upload-in.address=run-upload
 mp.messaging.incoming.run-upload-in.durable=true
 mp.messaging.incoming.run-upload-in.container-id=horreum-broker
 mp.messaging.incoming.run-upload-in.link-name=run-upload
+mp.messaging.incoming.run-upload-in.failure-strategy=modified-failed
 # run-upload outgoing
 mp.messaging.outgoing.run-upload-out.connector=smallrye-amqp
 mp.messaging.outgoing.run-upload-out.address=run-upload
 mp.messaging.outgoing.run-upload-out.durable=true
 mp.messaging.outgoing.run-upload-out.container-id=horreum-broker
 mp.messaging.outgoing.run-upload-out.link-name=run-upload
+mp.messaging.outgoing.run-upload-out.failure-strategy=modified-failed
 
 ## Datasource updated by Liquibase - the same as app but always with superuser credentials
 
@@ -234,6 +242,7 @@ quarkus.test.enable-callbacks-for-integration-tests=true
 horreum.dev-services.enabled=true
 #horreum.dev-services.postgres.ssl-enabled=true
 #horreum.dev-services.keycloak.https-enabled=true
+quarkus.amqp.devservices.enabled=true
 
 ## We don't want quarkus to start a database/keycloak for us in dev mode, we are doing that
 quarkus.datasource.devservices.enabled=false


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2113

This strategy keeps accepting new messages even if one failed, therefore without closing the connections at first failure.

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2103

## Changes proposed

The default messaging fail strategy is `fail` which stops the application from receiving messages at first failure, as stated here https://quarkus.io/guides/amqp-reference#failure-management

- [x] Change the strategy to `modified-failed` which put the failed message in DLQ but keeps processing all the others without disconnecting the connections 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
