### PR TITLE
Add openapi discriminator on Datastore types.

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -3227,10 +3227,14 @@ components:
           type: boolean
           example: false
         config:
+          required:
+          - builtIn
           type: object
-          oneOf:
-          - $ref: "#/components/schemas/ElasticsearchDatastoreConfig"
-          - $ref: "#/components/schemas/PostgresDatastoreConfig"
+          properties:
+            builtIn:
+              description: Built In
+              type: boolean
+          example: ElasticsearchDatastoreConfig
         type:
           description: Type of backend datastore
           enum:
@@ -3239,6 +3243,8 @@ components:
           - COLLECTORAPI
           type: string
           example: ELASTICSEARCH
+          discriminator:
+            propertyName: type
     DatastoreTestResponse:
       type: object
       properties:
@@ -3254,6 +3260,8 @@ components:
       - COLLECTORAPI
       type: string
       example: ELASTICSEARCH
+      discriminator:
+        propertyName: type
     EDivisiveDetectionConfig:
       required:
       - builtIn

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/BaseDatastoreConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/BaseDatastoreConfig.java
@@ -8,11 +8,15 @@ public abstract class BaseDatastoreConfig {
     @Schema(type = SchemaType.BOOLEAN, required = true, description = "Built In")
     public Boolean builtIn = true;
 
+    //    @Schema(type = SchemaType.STRING, required = true, description = "type information")
+    //    public String type = "";
+
     public BaseDatastoreConfig() {
     }
 
-    public BaseDatastoreConfig(Boolean builtIn) {
+    public BaseDatastoreConfig(Boolean builtIn/* , String type */) {
         this.builtIn = builtIn;
+        //        this.type = type;
     }
 
     public abstract String validateConfig();

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/Datastore.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/Datastore.java
@@ -3,6 +3,7 @@ package io.hyperfoil.tools.horreum.api.data.datastore;
 import jakarta.validation.constraints.NotNull;
 
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.DiscriminatorMapping;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.hyperfoil.tools.horreum.api.data.ProtectedType;
 
 @Schema(type = SchemaType.OBJECT, required = true, description = "Type of backend datastore")
+
 public class Datastore extends ProtectedType {
     @JsonProperty(required = true)
     @Schema(description = "Unique Datastore id", example = "101")
@@ -28,15 +30,16 @@ public class Datastore extends ProtectedType {
 
     @NotNull
     @JsonProperty(required = true)
-    @Schema(type = SchemaType.OBJECT, oneOf = {
-            ElasticsearchDatastoreConfig.class,
-            PostgresDatastoreConfig.class
-    })
+    @Schema(type = SchemaType.OBJECT, implementation = BaseDatastoreConfig.class, example = "ElasticsearchDatastoreConfig")
     public ObjectNode config;
 
     @NotNull
     @JsonProperty(required = true)
-    @Schema(type = SchemaType.STRING, implementation = DatastoreType.class, example = "ELASTICSEARCH")
+    @Schema(type = SchemaType.STRING, implementation = DatastoreType.class, example = "ELASTICSEARCH", discriminatorProperty = "type", discriminatorMapping = {
+            @DiscriminatorMapping(value = "ELASTICSEARCH", schema = String.class),
+            @DiscriminatorMapping(value = "POSTGRES", schema = String.class),
+            @DiscriminatorMapping(value = "COLLECTORAPI", schema = String.class)
+    })
     public DatastoreType type;
 
     public void pruneSecrets() {

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/PostgresDatastoreConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/datastore/PostgresDatastoreConfig.java
@@ -6,6 +6,10 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(type = SchemaType.OBJECT, required = true, description = "Built in backend datastore")
 public class PostgresDatastoreConfig extends BaseDatastoreConfig {
 
+    public PostgresDatastoreConfig() {
+        super(false);
+    }
+
     @Override
     public String validateConfig() {
         return null;

--- a/horreum-web/src/domain/admin/Datastores.tsx
+++ b/horreum-web/src/domain/admin/Datastores.tsx
@@ -25,8 +25,8 @@ import {
     CollectorApiDatastoreConfig,
     configApi,
     Datastore,
-    DatastoreTypeEnum,
-    ElasticsearchDatastoreConfig
+    DatastoreType,
+    ElasticsearchDatastoreConfig, PostgresDatastoreConfig
 } from "../../api";
 import {AppContext} from "../../context/appContext";
 import {AppContextType} from "../../context/@types/appContextTypes";
@@ -66,9 +66,8 @@ const DatastoresTable = ( props: dataStoreTableProps) => {
         },
 
     ];
-    const newBackendConfig: ElasticsearchDatastoreConfig | CollectorApiDatastoreConfig = {
-        url: "",
-        apiKey: "",
+    const newBackendConfig: ({ type: "ELASTICSEARCH";} & ElasticsearchDatastoreConfig) | ({ type: "COLLECTORAPI"; } & CollectorApiDatastoreConfig ) | ({ type: "POSTGRES"; } & PostgresDatastoreConfig)= {
+        type: DatastoreType.Postgres,
         builtIn: false
     }
 
@@ -79,7 +78,7 @@ const DatastoresTable = ( props: dataStoreTableProps) => {
         builtIn: false,
         access: Access.Private,
         config: newBackendConfig,
-        type: DatastoreTypeEnum.Postgres
+        type: DatastoreType.Postgres
     }
 
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);

--- a/horreum-web/src/domain/admin/datastore/ModifyDatastoreModal.tsx
+++ b/horreum-web/src/domain/admin/datastore/ModifyDatastoreModal.tsx
@@ -9,25 +9,25 @@ import {
     Modal, TextInput
 } from "@patternfly/react-core"
 import {
-    Datastore,
-    DatastoreTypeEnum, ElasticsearchDatastoreConfig,
+    Datastore, DatastoreConfig,
+    DatastoreType, ElasticsearchDatastoreConfig
 } from "../../../api";
 import {AppContext} from "../../../context/appContext";
 import {AppContextType} from "../../../context/@types/appContextTypes";
 
 type ConfirmDeleteModalProps = {
     isOpen: boolean
-    dataStore: Datastore
+    dataStore: ({type: 'ELASTICSEARCH', config: DatastoreConfig} & Datastore) | ({type: 'POSTGRES', config: DatastoreConfig} & Datastore) | ({type: 'COLLECTORAPI', config: DatastoreConfig} & Datastore),
     onClose(): void
     onDelete(): Promise<any>
-    updateDatastore(datastore: Datastore): void
+    updateDatastore(datastore: ({type: 'ELASTICSEARCH', config: DatastoreConfig} & Datastore) | ({type: 'POSTGRES', config: DatastoreConfig} & Datastore) | ({type: 'COLLECTORAPI', config: DatastoreConfig} & Datastore) ): void
     persistDatastore: (datastore: Datastore) => Promise<void>
     description: string
     extra?: string
 }
 
 interface datastoreOption {
-    value: DatastoreTypeEnum,
+    value: DatastoreType,
     label: string,
     disabled: boolean,
     urlDisabled: boolean,
@@ -79,9 +79,9 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
     }
 
     const options : datastoreOption[] = [
-        { value:  DatastoreTypeEnum.Postgres, label: 'Please select...', disabled: true, urlDisabled: true, usernameDisable: true, tokenDisbaled: true },
-        { value:  DatastoreTypeEnum.Elasticsearch, label: 'Elasticsearch', disabled: false, urlDisabled: false, usernameDisable: false, tokenDisbaled: false },
-        { value:  DatastoreTypeEnum.Collectorapi, label: 'Collector API', disabled: false, urlDisabled: false, usernameDisable: true, tokenDisbaled: false },
+        { value:  DatastoreType.Postgres, label: 'Please select...', disabled: true, urlDisabled: true, usernameDisable: true, tokenDisbaled: true },
+        { value:  DatastoreType.Elasticsearch, label: 'Elasticsearch', disabled: false, urlDisabled: false, usernameDisable: false, tokenDisbaled: false },
+        { value:  DatastoreType.Collectorapi, label: 'Collector API', disabled: false, urlDisabled: false, usernameDisable: true, tokenDisbaled: false },
     ];
 
     const actionButtons = [
@@ -132,12 +132,12 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
                     fieldId="horizontal-form-name"
                 >
                     <TextInput
-                        value={"url" in dataStore.config ? dataStore.config.url : ""}
+                        value={"url" in dataStore.config  && typeof dataStore.config.url === 'string' ? dataStore.config.url : ""}
                         onChange={(_, value) => {
                             const config :ElasticsearchDatastoreConfig = dataStore.config as ElasticsearchDatastoreConfig;
                             config.url = value
                             updateDatastore({...dataStore, config: config})
-                            }}
+                        }}
                         isDisabled={enabledURL}
                         type="text"
                         id="horizontal-form-url"
@@ -155,7 +155,7 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
                     fieldId="horizontal-form-token"
                 >
                     <TextInput
-                        value={"apiKey" in dataStore.config ? dataStore.config.apiKey : ""}
+                        value={"apiKey" in dataStore.config && typeof dataStore.config.apiKey === 'string' ? dataStore.config.apiKey : ""}
                         onChange={(_, value) => {
                             const config :ElasticsearchDatastoreConfig = dataStore.config as ElasticsearchDatastoreConfig;
                             config.apiKey = value
@@ -178,7 +178,7 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
                     fieldId="horizontal-form-token"
                 >
                     <TextInput
-                        value={"username" in dataStore.config ? dataStore.config.username : ""}
+                        value={"username" in dataStore.config && typeof dataStore.config.username === 'string' ? dataStore.config.username : ""}
                         onChange={(_, value) => {
                             const config :ElasticsearchDatastoreConfig = dataStore.config as ElasticsearchDatastoreConfig;
                             config.username = value
@@ -200,7 +200,7 @@ export default function ModifyDatastoreModal({isOpen, onClose, persistDatastore,
                     fieldId="horizontal-form-token"
                 >
                     <TextInput
-                        value={"password" in dataStore.config ? dataStore.config.password : ""}
+                        value={"password" in dataStore.config && typeof dataStore.config.password === 'string' ? dataStore.config.password : ""}
                         onChange={(_, value) => {
                             const config :ElasticsearchDatastoreConfig = dataStore.config as ElasticsearchDatastoreConfig;
                             config.password = value


### PR DESCRIPTION

## Fixes Issue

#1395 

## Changes proposed

 Add openapi annotations to enhance Datastore type information for clients. 

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
