### PR TITLE
Remove hardcoded test recalc timeout

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -102,8 +101,6 @@ public class ServiceMediator {
     Emitter<RunUpload> runUploadEmitter;
 
     private Map<AsyncEventChannels, Map<Integer, BlockingQueue<Object>>> events = new ConcurrentHashMap<>();
-
-    private final ReentrantLock lock = new ReentrantLock();
 
     public ServiceMediator() {
     }
@@ -232,15 +229,6 @@ public class ServiceMediator {
 
     int transform(int runId, boolean isRecalculation) {
         return runService.transform(runId, isRecalculation);
-    }
-
-    void withSharedLock(Runnable runnable) {
-        lock.lock();
-        try {
-            runnable.run();
-        } finally {
-            lock.unlock();
-        }
     }
 
     void newExperimentResult(ExperimentService.ExperimentResult result) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Follows the same change that have been done for run recal 👉🏻  https://github.com/Hyperfoil/Horreum/pull/2084

## Changes proposed

- [x] Remove the test datasets recalc timeout use case

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
