### PR TITLE
[0.15] Do not use recalc lock for run-recalc

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.locks.ReentrantLock;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
@@ -102,6 +103,8 @@ public class ServiceMediator {
 
     private Map<AsyncEventChannels, Map<Integer, BlockingQueue<Object>>> events = new ConcurrentHashMap<>();
 
+    private final ReentrantLock lock = new ReentrantLock();
+
     public ServiceMediator() {
     }
 
@@ -151,7 +154,6 @@ public class ServiceMediator {
     }
 
     void newDataset(Dataset.EventNew eventNew) {
-        //Note: should we call onNewDataset which will enable a lock?
         datasetService.onNewDataset(eventNew);
     }
 
@@ -166,7 +168,7 @@ public class ServiceMediator {
     @ActivateRequestContext
     @WithRoles(extras = Roles.HORREUM_SYSTEM)
     public void processDatasetEvents(Dataset.EventNew newEvent) {
-        datasetService.onNewDatasetNoLock(newEvent);
+        newDataset(newEvent);
         validateDataset(newEvent.datasetId);
     }
 
@@ -232,8 +234,13 @@ public class ServiceMediator {
         return runService.transform(runId, isRecalculation);
     }
 
-    void withRecalculationLock(Runnable run) {
-        datasetService.withRecalculationLock(run);
+    void withSharedLock(Runnable runnable) {
+        lock.lock();
+        try {
+            runnable.run();
+        } finally {
+            lock.unlock();
+        }
     }
 
     void newExperimentResult(ExperimentService.ExperimentResult result) {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -720,7 +720,7 @@ public class TestServiceImpl implements TestService {
             // transform will add proper roles anyway
             //         messageBus.executeForTest(testId, () -> datasetService.withRecalculationLock(() -> {
             //         mediator.executeBlocking(() -> mediator.transform(runId, true));
-            mediator.executeBlocking(() -> mediator.withRecalculationLock(() -> {
+            mediator.executeBlocking(() -> mediator.withSharedLock(() -> {
                 int newDatasets = 0;
                 try {
                     newDatasets = mediator.transform(runId, true);

--- a/horreum-web/src/api.tsx
+++ b/horreum-web/src/api.tsx
@@ -342,14 +342,6 @@ export function updateChangeDetection(
 
 }
 
-export function updateRunsAndDatasetsAction(
-    testId: number,
-    runs: number,
-    datasets: number
-): any {
-    return {type: "Tests/UPDATE_RUNS_AND_DATASETS", testId, runs, datasets}
-}
-
 ///Runs
 export function fetchRunSummary(id: number, token: string | undefined, alerting: AlertContextType): Promise<RunSummary> {
     return apiCall(runApi.getRunSummary(id, token), alerting, "FETCH_RUN_SUMMARY", "Failed to fetch data for run " + id + ", try uploading a Run and use new Run id instead.");

--- a/horreum-web/src/domain/tests/RecalculateDatasetsModal.tsx
+++ b/horreum-web/src/domain/tests/RecalculateDatasetsModal.tsx
@@ -1,6 +1,6 @@
-import {useCallback, useEffect, useState, useRef, useContext} from "react"
+import { useCallback, useEffect, useState, useRef, useContext } from "react"
 import { Bullseye, Button, Modal, Progress, Spinner } from "@patternfly/react-core"
-import {fetchTest, RecalculationStatus, testApi, TestStorage, updateRunsAndDatasetsAction} from "../../api"
+import { fetchTest, RecalculationStatus, testApi, TestStorage } from "../../api"
 import {AppContext} from "../../context/appContext";
 import {AppContextType} from "../../context/@types/appContextTypes";
 
@@ -13,7 +13,7 @@ type RecalculateDatasetsModalProps = {
 
 export default function RecalculateDatasetsModal(props: RecalculateDatasetsModalProps) {
     const { alerting } = useContext(AppContext) as AppContextType;
-    const [test, setTest] = useState<TestStorage | undefined>( undefined)
+    const [test, setTest] = useState<TestStorage | undefined>(undefined)
     const [progress, setProgress] = useState(-1)
     const [status, setStatus] = useState<RecalculationStatus>()
     const timerId = useRef<number>()
@@ -32,19 +32,16 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
         if (!props.isOpen) {
             return
         }
-        fetchTest(props.testId, alerting).then(setTest)
-    }, [props.testId]);
 
-    useEffect(() => {
-        if (!props.isOpen) {
-            return
-        }
+        // fetch the current test
+        fetchTest(props.testId, alerting).then(setTest)
+
+        // fetch the latest recalculation status
         if (test?.runs === undefined) {
-            testApi.getRecalculationStatus(props.testId).then(status => {
-                updateRunsAndDatasetsAction(props.testId, status.totalRuns, status.datasets)
-            })
+            testApi.getRecalculationStatus(props.testId).then(setStatus)
         }
-    }, [test, props.isOpen])
+    }, [props.isOpen]);
+
     return (
         <Modal
             title={`Re-transform datasets for test ${test?.name || "<unknown test>"}`}
@@ -66,11 +63,6 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
                                                   .then(status => {
                                                       setStatus(status)
                                                       setProgress(status.finished)
-                                                      updateRunsAndDatasetsAction(
-                                                          props.testId,
-                                                          status.totalRuns,
-                                                          status.datasets
-                                                      )
                                                       if (status.finished === status.totalRuns) {
                                                           onClose()
                                                       }
@@ -112,7 +104,7 @@ export default function RecalculateDatasetsModal(props: RecalculateDatasetsModal
             )}
             {progress < 0 && (
                 <div style={{ marginBottom: "16px" }}>
-                    This test has {test?.runs || "<unknown number>"} of runs; do you want to recalculate all datasets?
+                    This test has {status?.totalRuns || "<unknown number>"} of runs; do you want to recalculate all datasets?
                 </div>
             )}
             {progress >= 0 && (


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2084

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1975

## Changes proposed

- [x] Do not use shared lock during labelValues computation 
- [x] Move shared lock usage into ServiceMediator if really required 
- [x] Manage concurrent runs transformation similarly to what we are doing for test datasets recalculation
- [x] Fix the test datasets recalculation modal (show correct data)
   
![image](https://github.com/user-attachments/assets/2b3f27f1-d95c-4d9b-892c-bf8a02ea893c)


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
