### PR TITLE
[0.15] fix delete labels from the ui

### DIFF
--- a/horreum-web/src/domain/schemas/Labels.tsx
+++ b/horreum-web/src/domain/schemas/Labels.tsx
@@ -75,7 +75,7 @@ export default function Labels({ schemaId, schemaUri, funcsRef }: LabelsProps) {
                         })
                     ),
                 ...deleted.map(l =>
-                    schemaApi.deleteLabel(l.id, l.schemaId).catch(e => {
+                    schemaApi.deleteLabel(l.schemaId, l.id).catch(e => {
                         setLabels([...labels, l])
                         throw e
                     })


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2128

the definition of `deleteLabel` is 
``` javascript
deleteLabel(schemaId: number, labelId: number)
```
