### PR TITLE
[0.15]  Specify the 202 Accepted response in RunService API

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -659,6 +659,10 @@ paths:
                 format: int32
                 type: integer
               example: 101
+        "202":
+          description: The run data will be processed asynchronously
+          content:
+            text/plain: {}
         "400":
           description: Some fields are missing or invalid
           content:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -221,6 +221,7 @@ public interface RunService {
             "]"))
     @APIResponses(value = {
             @APIResponse(responseCode = "200", description = "id of the newly generated run", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.INTEGER, implementation = Integer.class), example = "101")),
+            @APIResponse(responseCode = "202", description = "The run data will be processed asynchronously", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
             @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
     })
     @Operation(description = "Upload a new Run")

--- a/horreum-web/src/domain/runs/RunImportModal.tsx
+++ b/horreum-web/src/domain/runs/RunImportModal.tsx
@@ -62,6 +62,7 @@ export const RunImportModal = (props: RunImportModalProps) => {
              )
              , alerting, "UPLOAD_ERROR", "Failed to upload run data")
              .then(noop)
+             .catch(noop)
              .then(() => props.onClose())
 
     }


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2124

attempt to fix #2098. I don't have a test for this right now.

this change causes the generated `horreum-web/src/generated/apis/RunApi.ts` file to change from:
```javascript
return await response.value();
```
to 
``` javascript
switch (response.raw.status) {
  case 200:
    return await response.value();
  case 202:
    return null;
  default:
    return await response.value();
}
```
this should prevent the `Uncaught (in promise) SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data` error, reported in the issue, that prevents the dialog from closing.

also added a `catch` call to be double safe.