### PR TITLE
Datasets listing should treat {} as empty filter

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
@@ -190,7 +190,7 @@ public class DatasetServiceImpl implements DatasetService {
                 .append(SCHEMAS_SELECT).append(" WHERE testid = :testId GROUP BY dataset_id")
                 .append("), ").append(VALIDATION_SELECT);
         JsonNode jsonFilter = null;
-        if (filter != null && !filter.isBlank()) {
+        if (filter != null && !filter.isBlank() && !filter.equals("{}")) {
             sql.append(", all_labels AS (").append(ALL_LABELS_SELECT).append(" WHERE testid = :testId GROUP BY dataset.id)");
             sql.append(DATASET_SUMMARY_SELECT);
             addViewIdCondition(sql, viewId);


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Early improvement that would consider `{}` as empty filter, this way the query is a LOT easier and faster.

This does not solve the performance issue we currently have when the filter is set, as it would require a refactoring that might be not necessarily as we are trying to get rid of the datasets entirely.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
