### PR TITLE
Refactor the Run upload process

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -648,18 +648,25 @@ paths:
               jobDisplayName: upstream-perf-bre-datastructures
               buildDisplayName: "#125"
       responses:
-        "200":
-          description: id of the newly generated run
+        "202":
+          description: "The request has been accepted for processing. Returns a list\
+            \ of created run IDs if available, or an empty list if processing is still\
+            \ ongoing. Label values and change detection processing is performed asynchronously."
           content:
             application/json:
               schema:
-                format: int32
-                type: integer
-              example: 101
-        "202":
-          description: The run data will be processed asynchronously
-          content:
-            text/plain: {}
+                type: array
+                items:
+                  format: int32
+                  type: integer
+                example:
+                - 101
+                - 102
+                - 103
+              example:
+              - 101
+              - 102
+              - 103
         "204":
           description: Data is valid but no run was created
           content:
@@ -841,8 +848,29 @@ paths:
               $ref: "#/components/schemas/Run"
         required: true
       responses:
-        "200":
-          description: OK
+        "202":
+          description: "The request has been accepted for processing. Returns a list\
+            \ of created run IDs if available, or an empty list if processing is still\
+            \ ongoing. Label values and change detection processing is performed asynchronously."
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  format: int32
+                  type: integer
+                example:
+                - 101
+                - 102
+                - 103
+              example:
+              - 101
+              - 102
+              - 103
+        "400":
+          description: Some fields are missing or invalid
+          content:
+            application/json: {}
   /api/run/{id}:
     get:
       tags:

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -653,20 +653,11 @@ paths:
             \ of created run IDs if available, or an empty list if processing is still\
             \ ongoing. Label values and change detection processing is performed asynchronously."
           content:
-            application/json:
+            text/plain:
               schema:
-                type: array
-                items:
-                  format: int32
-                  type: integer
-                example:
-                - 101
-                - 102
-                - 103
-              example:
-              - 101
-              - 102
-              - 103
+                type: string
+                example: "101,102,103"
+              example: "101,102,103"
         "204":
           description: Data is valid but no run was created
           content:
@@ -674,7 +665,7 @@ paths:
         "400":
           description: Some fields are missing or invalid
           content:
-            application/json: {}
+            text/plain: {}
   /api/run/list:
     get:
       tags:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/Version.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/Version.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import io.quarkus.logging.Log;
 
 public class Version {
-    public static final String getVersion() {
+    public static String getVersion() {
         final Properties properties = new Properties();
         try {
             properties.load(Version.class.getClassLoader().getResourceAsStream("build.properties"));

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -225,9 +225,9 @@ public interface RunService {
     @APIResponses(value = {
             @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
                     + "or an empty list if processing is still ongoing. Label values and change detection processing " +
-                    "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
+                    "is performed asynchronously.", content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING, example = "101,102,103"), example = "101,102,103")),
             @APIResponse(responseCode = "204", description = "Data is valid but no run was created", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
-            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
+            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.TEXT_PLAIN))
     })
     Response addRunFromData(@QueryParam("start") String start,
             @QueryParam("stop") String stop,
@@ -245,9 +245,9 @@ public interface RunService {
     @APIResponses(value = {
             @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
                     + "or an empty list if processing is still ongoing. Label values and change detection processing " +
-                    "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
+                    "is performed asynchronously.", content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING, example = "101,102,103"), example = "101,102,103")),
             @APIResponse(responseCode = "204", description = "Data is valid but no run was created", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
-            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
+            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.TEXT_PLAIN))
     })
     Response addRunFromData(@Parameter(required = true) @QueryParam("start") String start,
             @Parameter(required = true) @QueryParam("stop") String stop,

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -166,6 +166,12 @@ public interface RunService {
             @Parameter(name = "access", description = "New Access level", example = "0"),
     })
     @RequestBody(name = "runBody", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Run.class)), required = true)
+    @APIResponses(value = {
+            @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
+                    + "or an empty list if processing is still ongoing. Label values and change detection processing " +
+                    "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
+            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
+    })
     Response add(@QueryParam("test") String testNameOrId,
             @QueryParam("owner") String owner,
             @QueryParam("access") Access access,
@@ -199,12 +205,6 @@ public interface RunService {
             "    \"buildDisplayName\": \"#125\"\n" +
             "  }\n" +
             "]"))
-    @APIResponses(value = {
-            @APIResponse(responseCode = "200", description = "id of the newly generated run", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.INTEGER, implementation = Integer.class), example = "101")),
-            @APIResponse(responseCode = "202", description = "The run data will be processed asynchronously", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
-            @APIResponse(responseCode = "204", description = "Data is valid but no run was created", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
-            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
-    })
     @Operation(description = "Upload a new Run")
     @Parameters(value = {
             @Parameter(name = "start", required = true, description = "start timestamp of run, or json path expression", examples = {
@@ -222,6 +222,13 @@ public interface RunService {
             @Parameter(name = "description", description = "Run description", example = "AWS runs"),
 
     })
+    @APIResponses(value = {
+            @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
+                    + "or an empty list if processing is still ongoing. Label values and change detection processing " +
+                    "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
+            @APIResponse(responseCode = "204", description = "Data is valid but no run was created", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
+            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
+    })
     Response addRunFromData(@QueryParam("start") String start,
             @QueryParam("stop") String stop,
             @QueryParam("test") String test,
@@ -234,11 +241,14 @@ public interface RunService {
     @POST
     @Path("data")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Produces(MediaType.TEXT_PLAIN) // run ID as string
     @Operation(description = "Upload a new Run with metadata", hidden = true)
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", content = {
-                    @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)) }) })
+            @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
+                    + "or an empty list if processing is still ongoing. Label values and change detection processing " +
+                    "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
+            @APIResponse(responseCode = "204", description = "Data is valid but no run was created", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
+            @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
+    })
     Response addRunFromData(@Parameter(required = true) @QueryParam("start") String start,
             @Parameter(required = true) @QueryParam("stop") String stop,
             @Parameter(required = true) @QueryParam("test") String test,

--- a/horreum-backend/pom.xml
+++ b/horreum-backend/pom.xml
@@ -210,6 +210,11 @@
             <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -534,7 +534,7 @@ public class RunServiceImpl implements RunService {
         // if the request is accepted return 202 with all generated run ids
         // if no run ids, means all run upload have been queued up (datastore scenario)
         return Response.status(Response.Status.ACCEPTED)
-                .entity(runs.stream().map(val -> val.runId).toList())
+                .entity(runs.stream().map(val -> Integer.toString(val.runId)).collect(Collectors.joining(",")))
                 .build();
     }
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -198,7 +198,6 @@ public class ServiceMediator {
     public void processRunUpload(RunUpload runUpload) {
         log.debugf("Run Upload: %d", runUpload.testId);
         runService.persistRun(runUpload);
-
     }
 
     @Transactional(Transactional.TxType.NOT_SUPPORTED)

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -666,7 +666,6 @@ public class TestServiceImpl implements TestService {
                     int newDatasets = 0;
                     try {
                         newDatasets = mediator.transform(runId, true);
-                        //               mediator.queueRunRecalculation(runId);
                     } finally {
                         synchronized (status) {
                             status.finished++;

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -1139,6 +1139,14 @@ public class BaseServiceTest {
                 .as(TestService.TestListing.class);
     }
 
+    protected void updateView(View view) {
+        View newView = jsonRequest().body(view).post("/api/ui/view")
+                .then().statusCode(200).extract().body().as(View.class);
+        if (view.id != null) {
+            assertEquals(view.id, newView.id);
+        }
+    }
+
     protected DataPoint assertValue(BlockingQueue<DataPoint.Event> datapointQueue, double value) throws InterruptedException {
         DataPoint.Event dpe = datapointQueue.poll(10, TimeUnit.SECONDS);
         assertNotNull(dpe);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ConfigServiceTest.java
@@ -130,7 +130,7 @@ public class ConfigServiceTest extends BaseServiceTest {
 
         assertNotNull(datastore);
         assertNotNull(config);
-        assertTrue(config instanceof PostgresDatastoreConfig);
+        assertInstanceOf(PostgresDatastoreConfig.class, config);
 
     }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasourceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasourceTest.java
@@ -1,7 +1,8 @@
 package io.hyperfoil.tools.horreum.svc;
 
-import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -16,7 +17,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -69,10 +69,11 @@ public class DatasourceTest extends BaseServiceTest {
                  }
                 """.replace("{docID}", "f4a0c0ea-a3cc-4c2e-bb28-00d1a25b0135");
 
-        String runID = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
+        List<Integer> runIDs = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
 
-        assertNotNull(runID);
-        Assert.assertTrue(Integer.parseInt(runID) > 0);
+        assertNotNull(runIDs);
+        assertEquals(1, runIDs.size());
+        assertTrue(runIDs.get(0) > 0);
 
         Dataset.EventNew event = dataSetQueue.poll(10, TimeUnit.SECONDS);
         Assertions.assertNotNull(event);
@@ -105,10 +106,10 @@ public class DatasourceTest extends BaseServiceTest {
                  }
                 """;
 
-        String runID = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
+        List<Integer> runIDs = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
 
-        assertNotNull(runID);
-        Assert.assertEquals(4, runID.split(",").length);
+        assertNotNull(runIDs);
+        assertEquals(4, runIDs.size());
 
     }
 
@@ -124,10 +125,10 @@ public class DatasourceTest extends BaseServiceTest {
                  }
                 """;
 
-        String runID = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
+        List<Integer> runIDs = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
 
-        assertNotNull(runID);
-        Assert.assertEquals(4, runID.split(",").length);
+        assertNotNull(runIDs);
+        assertEquals(4, runIDs.size());
     }
 
     @org.junit.jupiter.api.Test
@@ -146,11 +147,12 @@ public class DatasourceTest extends BaseServiceTest {
                  }
                 """;
 
-        String runResponse = uploadRun(payload, testConfig.test.name, testConfig.schema.uri,
+        List<Integer> runResponse = uploadRun(payload, testConfig.test.name, testConfig.schema.uri,
                 jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode());
 
         assertNotNull(runResponse);
-        Assert.assertEquals("More than 10 runs uploaded, processing asynchronously", runResponse);
+        // More than 10 runs uploaded, processing asynchronously
+        assertEquals(0, runResponse.size());
 
     }
 
@@ -184,10 +186,10 @@ public class DatasourceTest extends BaseServiceTest {
                     }
                 }
                 """;
-        String runID = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
+        List<Integer> runIDs = uploadRun(payload, testConfig.test.name, testConfig.schema.uri);
 
-        assertNotNull(runID);
-        Assert.assertEquals(2, runID.split(",").length);
+        assertNotNull(runIDs);
+        assertEquals(2, runIDs.size());
 
     }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
@@ -109,7 +109,7 @@ class RunServiceNoRestTest extends BaseServiceNoRestTest {
         Run run = createSampleRun(testId, runData, owner);
 
         try (Response resp = runService.add(String.valueOf(testId), owner, Access.PUBLIC, run)) {
-            assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
             return Integer.parseInt(resp.getEntity().toString());
         }
     }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
@@ -61,7 +61,7 @@ import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
 import io.hyperfoil.tools.horreum.entity.data.RunDAO;
 import io.hyperfoil.tools.horreum.mapper.DatasetMapper;
 import io.hyperfoil.tools.horreum.server.CloseMe;
-import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
+import io.hyperfoil.tools.horreum.test.InMemoryAMQTestProfile;
 import io.hyperfoil.tools.horreum.test.PostgresResource;
 import io.hyperfoil.tools.horreum.test.TestUtil;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -75,7 +75,7 @@ import io.restassured.specification.RequestSpecification;
 @QuarkusTest
 @QuarkusTestResource(PostgresResource.class)
 @QuarkusTestResource(OidcWiremockTestResource.class)
-@TestProfile(HorreumTestProfile.class)
+@TestProfile(InMemoryAMQTestProfile.class)
 public class RunServiceTest extends BaseServiceTest {
     private static final int POLL_DURATION_SECONDS = 10;
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
@@ -517,7 +517,7 @@ class TestServiceNoRestTest extends BaseServiceNoRestTest {
         Run run1 = createSampleRun(created1.id, JsonNodeFactory.instance.objectNode(), FOO_TEAM);
         int runId;
         try (Response resp = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1)) {
-            assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
             runId = Integer.parseInt(resp.getEntity().toString());
         }
         assertEquals(1, RunDAO.count());
@@ -546,7 +546,7 @@ class TestServiceNoRestTest extends BaseServiceNoRestTest {
         Run run1 = createSampleRun(created1.id, JsonNodeFactory.instance.objectNode(), FOO_TEAM);
         int runId;
         try (Response resp = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1)) {
-            assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
             runId = Integer.parseInt(resp.getEntity().toString());
         }
         assertEquals(1, RunDAO.count());

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
@@ -2,7 +2,6 @@ package io.hyperfoil.tools.horreum.svc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -10,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,8 +19,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.groovy.util.Maps;
-import org.hibernate.query.NativeQuery;
 import org.junit.jupiter.api.TestInfo;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,8 +26,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.action.ExperimentResultToMarkdown;
 import io.hyperfoil.tools.horreum.api.SortDirection;
@@ -41,7 +35,6 @@ import io.hyperfoil.tools.horreum.api.data.Action;
 import io.hyperfoil.tools.horreum.api.data.ActionLog;
 import io.hyperfoil.tools.horreum.api.data.Dataset;
 import io.hyperfoil.tools.horreum.api.data.ExperimentProfile;
-import io.hyperfoil.tools.horreum.api.data.ExportedLabelValues;
 import io.hyperfoil.tools.horreum.api.data.Extractor;
 import io.hyperfoil.tools.horreum.api.data.FingerprintValue;
 import io.hyperfoil.tools.horreum.api.data.Fingerprints;
@@ -64,10 +57,9 @@ import io.hyperfoil.tools.horreum.entity.data.ActionDAO;
 import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
 import io.hyperfoil.tools.horreum.entity.data.RunDAO;
 import io.hyperfoil.tools.horreum.entity.data.TestDAO;
-import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
 import io.hyperfoil.tools.horreum.mapper.VariableMapper;
 import io.hyperfoil.tools.horreum.server.CloseMe;
-import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
+import io.hyperfoil.tools.horreum.test.InMemoryAMQTestProfile;
 import io.hyperfoil.tools.horreum.test.PostgresResource;
 import io.hyperfoil.tools.horreum.test.TestUtil;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -80,7 +72,7 @@ import io.restassured.response.Response;
 @QuarkusTest
 @QuarkusTestResource(PostgresResource.class)
 @QuarkusTestResource(OidcWiremockTestResource.class)
-@TestProfile(HorreumTestProfile.class)
+@TestProfile(InMemoryAMQTestProfile.class)
 class TestServiceTest extends BaseServiceTest {
 
     @org.junit.jupiter.api.Test
@@ -205,123 +197,6 @@ class TestServiceTest extends BaseServiceTest {
         jsonRequest().body(action).post("/api/action/update").then().statusCode(204);
 
         deleteTest(test);
-    }
-
-    @org.junit.jupiter.api.Test
-    public void testUpdateView(TestInfo info) throws InterruptedException {
-        Test test = createTest(createExampleTest(getTestName(info)));
-        Schema schema = createExampleSchema(info);
-
-        BlockingQueue<Dataset.EventNew> newDatasetQueue = serviceMediator.getEventQueue(AsyncEventChannels.DATASET_NEW,
-                test.id);
-        uploadRun(runWithValue(42, schema), test.name);
-        Dataset.EventNew event = newDatasetQueue.poll(10, TimeUnit.SECONDS);
-        assertNotNull(event);
-
-        ViewComponent vc = new ViewComponent();
-        vc.headerName = "Foobar";
-        vc.labels = JsonNodeFactory.instance.arrayNode().add("value");
-        List<View> views = getViews(test.id);
-        View defaultView = views.stream().filter(v -> "Default".equals(v.name)).findFirst().orElseThrow();
-        defaultView.components.add(vc);
-        defaultView.testId = test.id;
-        updateView(defaultView);
-
-        TestUtil.eventually(() -> {
-            em.clear();
-            @SuppressWarnings("unchecked")
-            List<JsonNode> list = em.createNativeQuery(
-                    "SELECT value FROM dataset_view WHERE dataset_id = ?1 AND view_id = ?2")
-                    .setParameter(1, event.datasetId).setParameter(2, defaultView.id)
-                    .unwrap(NativeQuery.class).addScalar("value", JsonBinaryType.INSTANCE)
-                    .getResultList();
-            return !list.isEmpty() && !list.get(0).isEmpty();
-        });
-    }
-
-    private void updateView(View view) {
-        View newView = jsonRequest().body(view).post("/api/ui/view")
-                .then().statusCode(200).extract().body().as(View.class);
-        if (view.id != null) {
-            assertEquals(view.id, newView.id);
-        }
-    }
-
-    @org.junit.jupiter.api.Test
-    public void testLabelValues(TestInfo info) throws InterruptedException {
-        Test test = createTest(createExampleTest(getTestName(info)));
-        Schema schema = createExampleSchema(info);
-
-        BlockingQueue<Dataset.LabelsUpdatedEvent> newDatasetQueue = serviceMediator
-                .getEventQueue(AsyncEventChannels.DATASET_UPDATED_LABELS, test.id);
-        uploadRun(runWithValue(42, schema), test.name);
-        uploadRun(JsonNodeFactory.instance.objectNode(), test.name);
-        assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
-        assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
-
-        List<ExportedLabelValues> values = jsonRequest().get("/api/test/" + test.id + "/labelValues").then().statusCode(200)
-                .extract().body().as(new TypeRef<>() {
-                });
-        assertNotNull(values);
-        assertFalse(values.isEmpty());
-        assertEquals(2, values.size());
-        assertTrue(values.get(1).values.containsKey("value"));
-    }
-
-    @org.junit.jupiter.api.Test
-    public void testFilterLabelValues(TestInfo info) throws InterruptedException {
-        Test test = createTest(createExampleTest(getTestName(info)));
-
-        String name = info.getTestClass().map(Class::getName).orElse("<unknown>") + "." + info.getDisplayName();
-        Schema schema = createSchema(name, uriForTest(info, "1.0"));
-
-        addLabel(schema, "filter-1", null, true, false, new Extractor("filter", "$.filter1", false));
-        addLabel(schema, "filter-2", null, true, false, new Extractor("filter", "$.filter2", false));
-
-        BlockingQueue<Dataset.LabelsUpdatedEvent> newDatasetQueue = serviceMediator
-                .getEventQueue(AsyncEventChannels.DATASET_UPDATED_LABELS, test.id);
-        ObjectNode run;
-
-        run = runWithValue(42, schema);
-        run.put("filter1", "foo");
-        run.put("filter2", "bar");
-        uploadRun(run, test.name);
-
-        run = runWithValue(43, schema);
-        run.put("filter1", "foo");
-        run.put("filter2", "bar");
-        uploadRun(run, test.name);
-
-        run = runWithValue(44, schema);
-        run.put("filter1", "biz");
-        run.put("filter2", "bar");
-        uploadRun(run, test.name);
-
-        run = runWithValue(45, schema);
-        run.put("filter1", "foo");
-        run.put("filter2", "baz");
-        uploadRun(run, test.name);
-
-        for (int i = 0; i < 4; i++) {
-            assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
-        }
-
-        List<ObjectNode> values = jsonRequest().get("/api/test/" + test.id + "/filteringLabelValues").then().statusCode(200)
-                .extract().body().as(new TypeRef<>() {
-                });
-        assertNotNull(values);
-        assertFalse(values.isEmpty());
-        assertEquals(3, values.size());
-        assertNotNull(values.stream()
-                .filter(node -> node.get("filter-1").asText().equals("foo") && node.get("filter-2").asText().equals("bar"))
-                .findAny().orElse(null));
-        assertNotNull(values.stream()
-                .filter(node -> node.get("filter-1").asText().equals("biz") && node.get("filter-2").asText().equals("bar"))
-                .findAny().orElse(null));
-        assertNotNull(values.stream()
-                .filter(node -> node.get("filter-1").asText().equals("foo") && node.get("filter-2").asText().equals("baz"))
-                .findAny().orElse(null));
-
     }
 
     @org.junit.jupiter.api.Test
@@ -484,443 +359,6 @@ class TestServiceTest extends BaseServiceTest {
         assertEquals(200d, ((FingerprintValue<Double>) values.get(1).values.get(1).children.get(1)).value);
         assertEquals("rulesProviderId", ((FingerprintValue<String>) values.get(1).values.get(1).children.get(2)).name);
         assertEquals("RulesWithJoinsProvides", ((FingerprintValue<String>) values.get(1).values.get(1).children.get(2)).value);
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesIncludeExcluded() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, true);
-
-        JsonNode response = jsonRequest()
-                .get("/api/test/" + t.id + "/labelValues?include=labelFoo&exclude=labelFoo")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size());
-        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
-        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
-        assertFalse(objectNode.has("labelFoo"), objectNode.toString());
-        assertTrue(objectNode.has("labelBar"), objectNode.toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesWithTimestampAfterFilter() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        long stop = System.currentTimeMillis();
-        long start = System.currentTimeMillis();
-        long delta = 5000; // 5 seconds
-        Integer runId = uploadRun(start, stop, "{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo",
-                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun(start + delta, stop, "{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo",
-                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun(start + delta, stop, "{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo",
-                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                // keep only those runs that started after (start+delta-1)
-                .queryParam("after", Long.toString(start + delta - 1))
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(2, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        JsonNode second = arrayResponse.get(1);
-        assertTrue(first.has("values"), second.toString());
-        JsonNode secondValues = second.get("values");
-        assertTrue(secondValues.has("labelBar"), secondValues.toString());
-        assertEquals(JsonNodeType.STRING, secondValues.get("labelBar").getNodeType());
-
-        List<String> labelBarValues = List.of(values.get("labelBar").asText(), secondValues.get("labelBar").asText());
-        assertTrue(labelBarValues.contains("dos"), labelBarValues.toString());
-        assertTrue(labelBarValues.contains("tres"), labelBarValues.toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesWithISOAfterFilter() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        long stop = System.currentTimeMillis();
-        Integer runId = uploadRun(Util.toInstant("2024-10-06T20:20:32.183Z").toEpochMilli(), stop,
-                "{ \"foo\": 1, \"bar\": \"uno\"}", t.name,
-                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun(Util.toInstant("2024-10-06T20:20:32.183Z").toEpochMilli(), stop, "{ \"foo\": 2, \"bar\": \"dos\"}",
-                t.name,
-                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun(Util.toInstant("2024-10-09T20:20:32.183Z").toEpochMilli(), stop, "{ \"foo\": 3, \"bar\": \"tres\"}",
-                t.name,
-                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
-        recalculateDatasetForRun(runId);
-
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                // keep only those runs that started after (start+delta-1)
-                .queryParam("after", "2024-10-07T20:20:32.183Z")
-                .queryParam("filter", Maps.of("labelBar", Arrays.asList("none", "tres")))
-                .queryParam("multiFilter", true)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        assertEquals("tres", values.get("labelBar").asText());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterWithJsonpath() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", "$.labelFoo ? (@ < 2)")
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        assertEquals("uno", values.get("labelBar").asText());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterWithInvalidJsonpath() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
-        jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", "$..name")
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(400);
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterWithObject() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", Maps.of("labelBar", "uno", "labelFoo", 1))
-                .queryParam("multiFilter", false)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        assertEquals("uno", values.get("labelBar").asText());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterWithObjectNoMatch() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                // no runs match both conditions
-                .queryParam("filter", Maps.of("labelBar", "uno", "labelFoo", "3"))
-                .queryParam("multiFilter", false)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(0, arrayResponse.size(), "unexpected number of responses " + response);
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterMultiSelectMultipleValues() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        Integer runId = uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo").get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo").get(0);
-        recalculateDatasetForRun(runId);
-        runId = uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo").get(0);
-        recalculateDatasetForRun(runId);
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", Maps.of("labelBar", Arrays.asList("uno", "tres")))
-                .queryParam("multiFilter", true)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(2, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        JsonNode second = arrayResponse.get(1);
-        assertTrue(first.has("values"), second.toString());
-        JsonNode secondValues = second.get("values");
-        assertTrue(secondValues.has("labelBar"), secondValues.toString());
-        assertEquals(JsonNodeType.STRING, secondValues.get("labelBar").getNodeType());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterMultiSelectStrings() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", Maps.of("labelBar", Arrays.asList("uno", 30)))
-                .queryParam("multiFilter", true)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
-        assertEquals("uno", values.get("labelBar").asText());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterMultiSelectNumber() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": 10}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": 20}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", Maps.of("labelBar", Arrays.asList(10, 30)))
-                .queryParam("multiFilter", true)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.NUMBER, values.get("labelBar").getNodeType());
-        assertEquals("10", values.get("labelBar").toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesFilterMultiSelectBoolean() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, false);
-        uploadRun("{ \"foo\": 1, \"bar\": true}", t.name, "urn:foo");
-        uploadRun("{ \"foo\": 2, \"bar\": 20}", t.name, "urn:foo");
-        JsonNode response = jsonRequest()
-                .urlEncodingEnabled(true)
-                .queryParam("filter", Maps.of("labelBar", Arrays.asList(true, 30)))
-                .queryParam("multiFilter", true)
-                .get("/api/test/" + t.id + "/labelValues")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
-        JsonNode first = arrayResponse.get(0);
-        assertTrue(first.has("values"), first.toString());
-        JsonNode values = first.get("values");
-        assertTrue(values.has("labelBar"), values.toString());
-        assertEquals(JsonNodeType.BOOLEAN, values.get("labelBar").getNodeType());
-        assertEquals("true", values.get("labelBar").toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesIncludeTwoParams() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, true);
-
-        JsonNode response = jsonRequest()
-                .get("/api/test/" + t.id + "/labelValues?include=labelFoo&include=labelBar")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size());
-        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
-        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
-        assertTrue(objectNode.has("labelFoo"), objectNode.toString());
-        assertTrue(objectNode.has("labelBar"), objectNode.toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesIncludeTwoSeparated() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, true);
-
-        JsonNode response = jsonRequest()
-                .get("/api/test/" + t.id + "/labelValues?include=labelFoo,labelBar")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size());
-        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
-        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
-        assertTrue(objectNode.has("labelFoo"), objectNode.toString());
-        assertTrue(objectNode.has("labelBar"), objectNode.toString());
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesInclude() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, true);
-
-        JsonNode response = jsonRequest()
-                .get("/api/test/" + t.id + "/labelValues?include=labelFoo")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size());
-        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
-        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
-        assertTrue(objectNode.has("labelFoo"));
-        assertFalse(objectNode.has("labelBar"));
-    }
-
-    @org.junit.jupiter.api.Test
-    public void labelValuesExclude() {
-        Test t = createTest(createExampleTest("my-test"));
-        labelValuesSetup(t, true);
-
-        JsonNode response = jsonRequest()
-                .get("/api/test/" + t.id + "/labelValues?exclude=labelFoo")
-                .then()
-                .statusCode(200)
-                .extract()
-                .body()
-                .as(JsonNode.class);
-        assertInstanceOf(ArrayNode.class, response);
-        ArrayNode arrayResponse = (ArrayNode) response;
-        assertEquals(1, arrayResponse.size());
-        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
-        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
-        assertFalse(objectNode.has("labelFoo"), objectNode.toPrettyString());
-        assertTrue(objectNode.has("labelBar"), objectNode.toPrettyString());
-
-    }
-
-    @org.junit.jupiter.api.Test
-    public void testLabelValues() throws JsonProcessingException {
-        List<Object[]> toParse = new ArrayList<>();
-        toParse.add(
-                new Object[] { "job", mapper.readTree("\"quarkus-release-startup\""), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Max RSS", mapper.readTree("[]"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "build-id", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 1 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 2 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 4 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 8 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 32 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Quarkus - Kafka_tags", mapper.readTree("\"quarkus-release-startup\""), 10, 10,
-                Instant.now(), Instant.now() });
-        List<ExportedLabelValues> values = LabelValuesService.parse(toParse);
-        assertEquals(1, values.size());
-        assertEquals(9, values.get(0).values.size());
-        assertEquals("quarkus-release-startup", values.get(0).values.get("job").asText());
-        assertEquals("null", values.get(0).values.get("Throughput 32 CPU").asText());
-
-        toParse.add(
-                new Object[] { "job", mapper.readTree("\"quarkus-release-startup\""), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Max RSS", mapper.readTree("[]"), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "build-id", mapper.readTree("null"), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 1 CPU", mapper.readTree("17570.30"), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 2 CPU", mapper.readTree("43105.62"), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 4 CPU", mapper.readTree("84895.13"), 10, 11, Instant.now(), Instant.now() });
-        toParse.add(new Object[] { "Throughput 8 CPU", mapper.readTree("141086.29"), 10, 11, Instant.now(), Instant.now() });
-        values = LabelValuesService.parse(toParse);
-        assertEquals(2, values.size());
-        assertEquals(9, values.get(0).values.size());
-        assertEquals(7, values.get(1).values.size());
-        assertEquals(84895.13d, values.get(1).values.get("Throughput 4 CPU").asDouble());
     }
 
     @org.junit.jupiter.api.Test

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceWithAsyncProcessingTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceWithAsyncProcessingTest.java
@@ -1,0 +1,596 @@
+package io.hyperfoil.tools.horreum.svc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.groovy.util.Maps;
+import org.hibernate.query.NativeQuery;
+import org.junit.jupiter.api.TestInfo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.hyperfoil.tools.horreum.api.data.Dataset;
+import io.hyperfoil.tools.horreum.api.data.ExportedLabelValues;
+import io.hyperfoil.tools.horreum.api.data.Extractor;
+import io.hyperfoil.tools.horreum.api.data.Schema;
+import io.hyperfoil.tools.horreum.api.data.Test;
+import io.hyperfoil.tools.horreum.api.data.View;
+import io.hyperfoil.tools.horreum.api.data.ViewComponent;
+import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
+import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
+import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
+import io.hyperfoil.tools.horreum.test.PostgresResource;
+import io.hyperfoil.tools.horreum.test.TestUtil;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+import io.restassured.common.mapper.TypeRef;
+
+@QuarkusTest
+@QuarkusTestResource(PostgresResource.class)
+@QuarkusTestResource(OidcWiremockTestResource.class)
+@TestProfile(HorreumTestProfile.class)
+class TestServiceWithAsyncProcessingTest extends BaseServiceTest {
+
+    @org.junit.jupiter.api.Test
+    public void testUpdateView(TestInfo info) throws InterruptedException {
+        Test test = createTest(createExampleTest(getTestName(info)));
+        Schema schema = createExampleSchema(info);
+
+        BlockingQueue<Dataset.EventNew> newDatasetQueue = serviceMediator.getEventQueue(AsyncEventChannels.DATASET_NEW,
+                test.id);
+        uploadRun(runWithValue(42, schema), test.name);
+        Dataset.EventNew event = newDatasetQueue.poll(10, TimeUnit.SECONDS);
+        assertNotNull(event);
+
+        ViewComponent vc = new ViewComponent();
+        vc.headerName = "Foobar";
+        vc.labels = JsonNodeFactory.instance.arrayNode().add("value");
+        List<View> views = getViews(test.id);
+        View defaultView = views.stream().filter(v -> "Default".equals(v.name)).findFirst().orElseThrow();
+        defaultView.components.add(vc);
+        defaultView.testId = test.id;
+        updateView(defaultView);
+
+        TestUtil.eventually(() -> {
+            em.clear();
+            @SuppressWarnings("unchecked")
+            List<JsonNode> list = em.createNativeQuery(
+                    "SELECT value FROM dataset_view WHERE dataset_id = ?1 AND view_id = ?2")
+                    .setParameter(1, event.datasetId).setParameter(2, defaultView.id)
+                    .unwrap(NativeQuery.class).addScalar("value", JsonBinaryType.INSTANCE)
+                    .getResultList();
+            return !list.isEmpty() && !list.get(0).isEmpty();
+        });
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testLabelValues(TestInfo info) throws InterruptedException {
+        Test test = createTest(createExampleTest(getTestName(info)));
+        Schema schema = createExampleSchema(info);
+
+        BlockingQueue<Dataset.LabelsUpdatedEvent> newDatasetQueue = serviceMediator
+                .getEventQueue(AsyncEventChannels.DATASET_UPDATED_LABELS, test.id);
+        uploadRun(runWithValue(42, schema), test.name);
+        uploadRun(JsonNodeFactory.instance.objectNode(), test.name);
+        assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
+        assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
+
+        List<ExportedLabelValues> values = jsonRequest().get("/api/test/" + test.id + "/labelValues").then().statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
+        assertNotNull(values);
+        assertFalse(values.isEmpty());
+        assertEquals(2, values.size());
+        assertTrue(values.get(1).values.containsKey("value"));
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testFilterLabelValues(TestInfo info) throws InterruptedException {
+        Test test = createTest(createExampleTest(getTestName(info)));
+
+        String name = info.getTestClass().map(Class::getName).orElse("<unknown>") + "." + info.getDisplayName();
+        Schema schema = createSchema(name, uriForTest(info, "1.0"));
+
+        addLabel(schema, "filter-1", null, true, false, new Extractor("filter", "$.filter1", false));
+        addLabel(schema, "filter-2", null, true, false, new Extractor("filter", "$.filter2", false));
+
+        BlockingQueue<Dataset.LabelsUpdatedEvent> newDatasetQueue = serviceMediator
+                .getEventQueue(AsyncEventChannels.DATASET_UPDATED_LABELS, test.id);
+        ObjectNode run;
+
+        run = runWithValue(42, schema);
+        run.put("filter1", "foo");
+        run.put("filter2", "bar");
+        uploadRun(run, test.name);
+
+        run = runWithValue(43, schema);
+        run.put("filter1", "foo");
+        run.put("filter2", "bar");
+        uploadRun(run, test.name);
+
+        run = runWithValue(44, schema);
+        run.put("filter1", "biz");
+        run.put("filter2", "bar");
+        uploadRun(run, test.name);
+
+        run = runWithValue(45, schema);
+        run.put("filter1", "foo");
+        run.put("filter2", "baz");
+        uploadRun(run, test.name);
+
+        for (int i = 0; i < 4; i++) {
+            assertNotNull(newDatasetQueue.poll(10, TimeUnit.SECONDS));
+        }
+
+        List<ObjectNode> values = jsonRequest().get("/api/test/" + test.id + "/filteringLabelValues").then().statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
+        assertNotNull(values);
+        assertFalse(values.isEmpty());
+        assertEquals(3, values.size());
+        assertNotNull(values.stream()
+                .filter(node -> node.get("filter-1").asText().equals("foo") && node.get("filter-2").asText().equals("bar"))
+                .findAny().orElse(null));
+        assertNotNull(values.stream()
+                .filter(node -> node.get("filter-1").asText().equals("biz") && node.get("filter-2").asText().equals("bar"))
+                .findAny().orElse(null));
+        assertNotNull(values.stream()
+                .filter(node -> node.get("filter-1").asText().equals("foo") && node.get("filter-2").asText().equals("baz"))
+                .findAny().orElse(null));
+
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesIncludeExcluded() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, true);
+
+        JsonNode response = jsonRequest()
+                .get("/api/test/" + t.id + "/labelValues?include=labelFoo&exclude=labelFoo")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size());
+        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
+        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
+        assertFalse(objectNode.has("labelFoo"), objectNode.toString());
+        assertTrue(objectNode.has("labelBar"), objectNode.toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesWithTimestampAfterFilter() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        long stop = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
+        long delta = 5000; // 5 seconds
+        Integer runId = uploadRun(start, stop, "{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo",
+                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun(start + delta, stop, "{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo",
+                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun(start + delta, stop, "{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo",
+                jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                // keep only those runs that started after (start+delta-1)
+                .queryParam("after", Long.toString(start + delta - 1))
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(2, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        JsonNode second = arrayResponse.get(1);
+        assertTrue(first.has("values"), second.toString());
+        JsonNode secondValues = second.get("values");
+        assertTrue(secondValues.has("labelBar"), secondValues.toString());
+        assertEquals(JsonNodeType.STRING, secondValues.get("labelBar").getNodeType());
+
+        List<String> labelBarValues = List.of(values.get("labelBar").asText(), secondValues.get("labelBar").asText());
+        assertTrue(labelBarValues.contains("dos"), labelBarValues.toString());
+        assertTrue(labelBarValues.contains("tres"), labelBarValues.toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesWithISOAfterFilter() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        long stop = System.currentTimeMillis();
+        Integer runId = uploadRun(Util.toInstant("2024-10-06T20:20:32.183Z").toEpochMilli(), stop,
+                "{ \"foo\": 1, \"bar\": \"uno\"}", t.name,
+                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun(Util.toInstant("2024-10-06T20:20:32.183Z").toEpochMilli(), stop, "{ \"foo\": 2, \"bar\": \"dos\"}",
+                t.name,
+                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun(Util.toInstant("2024-10-09T20:20:32.183Z").toEpochMilli(), stop, "{ \"foo\": 3, \"bar\": \"tres\"}",
+                t.name,
+                "urn:foo", jakarta.ws.rs.core.Response.Status.ACCEPTED.getStatusCode()).get(0);
+        recalculateDatasetForRun(runId);
+
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                // keep only those runs that started after (start+delta-1)
+                .queryParam("after", "2024-10-07T20:20:32.183Z")
+                .queryParam("filter", Maps.of("labelBar", Arrays.asList("none", "tres")))
+                .queryParam("multiFilter", true)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        assertEquals("tres", values.get("labelBar").asText());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterWithJsonpath() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", "$.labelFoo ? (@ < 2)")
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        assertEquals("uno", values.get("labelBar").asText());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterWithInvalidJsonpath() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
+        jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", "$..name")
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(400);
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterWithObject() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", Maps.of("labelBar", "uno", "labelFoo", 1))
+                .queryParam("multiFilter", false)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        assertEquals("uno", values.get("labelBar").asText());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterWithObjectNoMatch() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                // no runs match both conditions
+                .queryParam("filter", Maps.of("labelBar", "uno", "labelFoo", "3"))
+                .queryParam("multiFilter", false)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(0, arrayResponse.size(), "unexpected number of responses " + response);
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterMultiSelectMultipleValues() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        Integer runId = uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo").get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo").get(0);
+        recalculateDatasetForRun(runId);
+        runId = uploadRun("{ \"foo\": 3, \"bar\": \"tres\"}", t.name, "urn:foo").get(0);
+        recalculateDatasetForRun(runId);
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", Maps.of("labelBar", Arrays.asList("uno", "tres")))
+                .queryParam("multiFilter", true)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(2, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        JsonNode second = arrayResponse.get(1);
+        assertTrue(first.has("values"), second.toString());
+        JsonNode secondValues = second.get("values");
+        assertTrue(secondValues.has("labelBar"), secondValues.toString());
+        assertEquals(JsonNodeType.STRING, secondValues.get("labelBar").getNodeType());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterMultiSelectStrings() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": \"uno\"}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": \"dos\"}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", Maps.of("labelBar", Arrays.asList("uno", 30)))
+                .queryParam("multiFilter", true)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.STRING, values.get("labelBar").getNodeType());
+        assertEquals("uno", values.get("labelBar").asText());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterMultiSelectNumber() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": 10}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": 20}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", Maps.of("labelBar", Arrays.asList(10, 30)))
+                .queryParam("multiFilter", true)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.NUMBER, values.get("labelBar").getNodeType());
+        assertEquals("10", values.get("labelBar").toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesFilterMultiSelectBoolean() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, false);
+        uploadRun("{ \"foo\": 1, \"bar\": true}", t.name, "urn:foo");
+        uploadRun("{ \"foo\": 2, \"bar\": 20}", t.name, "urn:foo");
+        JsonNode response = jsonRequest()
+                .urlEncodingEnabled(true)
+                .queryParam("filter", Maps.of("labelBar", Arrays.asList(true, 30)))
+                .queryParam("multiFilter", true)
+                .get("/api/test/" + t.id + "/labelValues")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size(), "unexpected number of responses " + response);
+        JsonNode first = arrayResponse.get(0);
+        assertTrue(first.has("values"), first.toString());
+        JsonNode values = first.get("values");
+        assertTrue(values.has("labelBar"), values.toString());
+        assertEquals(JsonNodeType.BOOLEAN, values.get("labelBar").getNodeType());
+        assertEquals("true", values.get("labelBar").toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesIncludeTwoParams() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, true);
+
+        JsonNode response = jsonRequest()
+                .get("/api/test/" + t.id + "/labelValues?include=labelFoo&include=labelBar")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size());
+        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
+        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
+        assertTrue(objectNode.has("labelFoo"), objectNode.toString());
+        assertTrue(objectNode.has("labelBar"), objectNode.toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesIncludeTwoSeparated() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, true);
+
+        JsonNode response = jsonRequest()
+                .get("/api/test/" + t.id + "/labelValues?include=labelFoo,labelBar")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size());
+        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
+        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
+        assertTrue(objectNode.has("labelFoo"), objectNode.toString());
+        assertTrue(objectNode.has("labelBar"), objectNode.toString());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesInclude() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, true);
+
+        JsonNode response = jsonRequest()
+                .get("/api/test/" + t.id + "/labelValues?include=labelFoo")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size());
+        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
+        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
+        assertTrue(objectNode.has("labelFoo"));
+        assertFalse(objectNode.has("labelBar"));
+    }
+
+    @org.junit.jupiter.api.Test
+    public void labelValuesExclude() {
+        Test t = createTest(createExampleTest("my-test"));
+        labelValuesSetup(t, true);
+
+        JsonNode response = jsonRequest()
+                .get("/api/test/" + t.id + "/labelValues?exclude=labelFoo")
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonNode.class);
+        assertInstanceOf(ArrayNode.class, response);
+        ArrayNode arrayResponse = (ArrayNode) response;
+        assertEquals(1, arrayResponse.size());
+        assertInstanceOf(ObjectNode.class, arrayResponse.get(0));
+        ObjectNode objectNode = (ObjectNode) arrayResponse.get(0).get("values");
+        assertFalse(objectNode.has("labelFoo"), objectNode.toPrettyString());
+        assertTrue(objectNode.has("labelBar"), objectNode.toPrettyString());
+
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testLabelValues() throws JsonProcessingException {
+        List<Object[]> toParse = new ArrayList<>();
+        toParse.add(
+                new Object[] { "job", mapper.readTree("\"quarkus-release-startup\""), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Max RSS", mapper.readTree("[]"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "build-id", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 1 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 2 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 4 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 8 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 32 CPU", mapper.readTree("null"), 10, 10, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Quarkus - Kafka_tags", mapper.readTree("\"quarkus-release-startup\""), 10, 10,
+                Instant.now(), Instant.now() });
+        List<ExportedLabelValues> values = LabelValuesService.parse(toParse);
+        assertEquals(1, values.size());
+        assertEquals(9, values.get(0).values.size());
+        assertEquals("quarkus-release-startup", values.get(0).values.get("job").asText());
+        assertEquals("null", values.get(0).values.get("Throughput 32 CPU").asText());
+
+        toParse.add(
+                new Object[] { "job", mapper.readTree("\"quarkus-release-startup\""), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Max RSS", mapper.readTree("[]"), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "build-id", mapper.readTree("null"), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 1 CPU", mapper.readTree("17570.30"), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 2 CPU", mapper.readTree("43105.62"), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 4 CPU", mapper.readTree("84895.13"), 10, 11, Instant.now(), Instant.now() });
+        toParse.add(new Object[] { "Throughput 8 CPU", mapper.readTree("141086.29"), 10, 11, Instant.now(), Instant.now() });
+        values = LabelValuesService.parse(toParse);
+        assertEquals(2, values.size());
+        assertEquals(9, values.get(0).values.size());
+        assertEquals(7, values.get(1).values.size());
+        assertEquals(84895.13d, values.get(1).values.get("Throughput 4 CPU").asDouble());
+    }
+}

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/AMQPInMemoryResource.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/AMQPInMemoryResource.java
@@ -1,0 +1,36 @@
+package io.hyperfoil.tools.horreum.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+
+public class AMQPInMemoryResource implements QuarkusTestResourceLifecycleManager {
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> env = new HashMap<>();
+        Map<String, String> props1 = InMemoryConnector.switchIncomingChannelsToInMemory("run-upload-in");
+        Map<String, String> props2 = InMemoryConnector.switchOutgoingChannelsToInMemory("run-upload-out");
+        Map<String, String> props3 = InMemoryConnector.switchIncomingChannelsToInMemory("dataset-event-in");
+        Map<String, String> props4 = InMemoryConnector.switchOutgoingChannelsToInMemory("dataset-event-out");
+        Map<String, String> props5 = InMemoryConnector.switchIncomingChannelsToInMemory("run-recalc-in");
+        Map<String, String> props6 = InMemoryConnector.switchOutgoingChannelsToInMemory("run-recalc-out");
+        Map<String, String> props7 = InMemoryConnector.switchIncomingChannelsToInMemory("schema-sync-in");
+        Map<String, String> props8 = InMemoryConnector.switchOutgoingChannelsToInMemory("schema-sync-out");
+        env.putAll(props1);
+        env.putAll(props2);
+        env.putAll(props3);
+        env.putAll(props4);
+        env.putAll(props5);
+        env.putAll(props6);
+        env.putAll(props7);
+        env.putAll(props8);
+        return env;
+    }
+
+    @Override
+    public void stop() {
+        InMemoryConnector.clear();
+    }
+}

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/ElasticsearchTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/ElasticsearchTestProfile.java
@@ -3,7 +3,7 @@ package io.hyperfoil.tools.horreum.test;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ElasticsearchTestProfile extends HorreumTestProfile {
+public class ElasticsearchTestProfile extends InMemoryAMQTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/HorreumTestProfile.java
@@ -31,6 +31,7 @@ public class HorreumTestProfile implements QuarkusTestProfile {
     @Override
     public List<TestResourceEntry> testResources() {
         return Arrays.asList(
-                new TestResourceEntry(PostgresResource.class), new TestResourceEntry(OidcWiremockTestResource.class));
+                new TestResourceEntry(PostgresResource.class),
+                new TestResourceEntry(OidcWiremockTestResource.class));
     }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/InMemoryAMQTestProfile.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/test/InMemoryAMQTestProfile.java
@@ -1,0 +1,17 @@
+package io.hyperfoil.tools.horreum.test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.quarkus.test.oidc.server.OidcWiremockTestResource;
+
+public class InMemoryAMQTestProfile extends HorreumTestProfile {
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Arrays.asList(
+                new TestResourceEntry(PostgresResource.class),
+                new TestResourceEntry(OidcWiremockTestResource.class),
+                new TestResourceEntry(AMQPInMemoryResource.class));
+    }
+}

--- a/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
+++ b/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
@@ -74,7 +74,7 @@ public interface RunService {
 
     @POST
     @Path("data")
-    @Produces(MediaType.TEXT_PLAIN) // run ID as string
+    @Produces(MediaType.TEXT_PLAIN) // array of generated Run IDs
     Response addRunFromData(@QueryParam("start") String start,
             @QueryParam("stop") String stop,
             @QueryParam("test") String test,

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -121,7 +121,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             run.data = new ObjectMapper().readTree(resourceToString("data/config-quickstart.jvm.json"));
             run.description = "Test description";
             try (Response response = apiClient.runService.add(dummyTest.name, dummyTest.owner, Access.PRIVATE, run)) {
-                assertEquals(200, response.getStatus());
+                assertEquals(202, response.getStatus());
             }
         } finally {
             horreumClient.testService.updateAccess(dummyTest.id, dummyTest.owner, Access.PUBLIC);
@@ -367,6 +367,10 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             uploadData.accept(mapper.readTree(resourceToString("data/experiment-ds2.json")));
             uploadData.accept(mapper.readTree(resourceToString("data/experiment-ds3.json")));
 
+            // let process finish async, labelValues calculation is getting processed async
+            // TODO: is there a better way to wait for this?
+            Thread.sleep(6000);
+
             //6. run experiments
             RunService.RunsSummary runsSummary = horreumClient.runService.listTestRuns(dummyTest.id, false, null, null, "name",
                     SortDirection.Ascending);
@@ -384,7 +388,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
                     .runExperiments(maxDataset);
 
             assertNotNull(experimentResults);
-            assertTrue(experimentResults.size() > 0);
+            assertFalse(experimentResults.isEmpty());
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -133,7 +133,8 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
         JsonNode payload = new ObjectMapper().readTree(resourceToString("data/config-quickstart.jvm.json"));
 
         try {
-            horreumClient.runService.addRunFromData("$.start", "$.stop", dummyTest.name, dummyTest.owner, Access.PUBLIC,
+            horreumClient.runService.addRunFromData("$.start", "$.stop", dummyTest.name, dummyTest.owner,
+                    Access.PUBLIC,
                     null, "test", payload);
         } catch (BadRequestException badRequestException) {
             fail(badRequestException.getMessage()


### PR DESCRIPTION
Refactor the process such that runs and related datasets get created/persisted synchronously whereas the datasets processing (label values calculation and so on) is deferred to the async process by making use if the dataset-even queue

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1976

## Changes proposed

This change proposes to slightly update how the Run upload is managed, moving from a completely sync process to a hybrid one.

The process can be summarized as follow:
1. Persist the Run and any related dataset in the same transaction (if everything goes fine obv).
2. Once run and datasets are flushed, send dataset events to the `dataset-event` queue to process label values (and change point detection and so on) asynchronously.

TODOs/Open points:
- [ ] What to do with the datastore uploads, should we follow the same process even if more than 10 runs are passed?
- [x] Change the API to always return `202` if the process succeeded with the `runId` that was created.
- [x] Adapt tests
- ~[ ] Adapt the UI~ nothing to do here

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
