### PR TITLE
[0.16] Fix horreum-client javadoc generation

### DIFF
--- a/horreum-client/src/main/java/io/hyperfoil/tools/auth/HorreumApiKeyAuthentication.java
+++ b/horreum-client/src/main/java/io/hyperfoil/tools/auth/HorreumApiKeyAuthentication.java
@@ -7,7 +7,7 @@ import org.jboss.logging.Logger;
 
 public class HorreumApiKeyAuthentication implements ClientRequestFilter {
 
-    /** sync with {@link io.hyperfoil.tools.horreum.server.ApiKeyAuthenticationMechanism} */
+    /** sync with io.hyperfoil.tools.horreum.server.ApiKeyAuthenticationMechanism */
     public static final String HORREUM_AUTHENTICATION_HEADER = "X-Horreum-API-Key";
 
     private static final Logger LOG = Logger.getLogger(HorreumApiKeyAuthentication.class);


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2179

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes the horreum-client generation, in particular:
```
Error:  /home/runner/work/Horreum/Horreum/horreum-client/src/main/java/io/hyperfoil/tools/auth/HorreumApiKeyAuthentication.java:10: error: reference not found
Error:      /** sync with {@link io.hyperfoil.tools.horreum.server.ApiKeyAuthenticationMechanism} */
Error:                           ^
```

## Changes proposed

Remove the link in the javadoc comment

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
