### PR TITLE
[0.16] Fix Horreum and AMQ test containers

### DIFF
--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/ArtemisMQResource.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/ArtemisMQResource.java
@@ -1,6 +1,15 @@
 package io.hyperfoil.tools.horreum.infra.common.resources;
 
-import static io.hyperfoil.tools.horreum.infra.common.Const.*;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_AMQP_ENABLED;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_AMQP_IMAGE;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_AMQP_NETWORK_ALIAS;
+import static java.lang.Boolean.parseBoolean;
+import static java.time.Duration.ofSeconds;
+import static org.testcontainers.containers.wait.strategy.Wait.defaultWaitStrategy;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 import java.util.Collections;
 import java.util.Map;
@@ -8,35 +17,35 @@ import java.util.Optional;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.utility.MountableFile;
 
-import io.hyperfoil.tools.horreum.infra.common.Const;
 import io.hyperfoil.tools.horreum.infra.common.ResourceLifecycleManager;
 
 public class ArtemisMQResource implements ResourceLifecycleManager {
+
+    private static final String BROKER_XML_CONTAINER_PATH = "/var/lib/artemis-instance/etc-override/broker.xml";
+
     private GenericContainer<?> amqpContainer;
-    private boolean inContainer = false;
-    private String networkAlias = "";
+    private boolean inContainer;
+    private String networkAlias;
 
     @Override
     public void init(Map<String, String> initArgs) {
-        if (initArgs.containsKey(HORREUM_DEV_AMQP_ENABLED) && initArgs.get(HORREUM_DEV_AMQP_ENABLED).equals("true")) {
+        if (initArgs.containsKey(HORREUM_DEV_AMQP_ENABLED) && parseBoolean(initArgs.get(HORREUM_DEV_AMQP_ENABLED))) {
             if (!initArgs.containsKey(HORREUM_DEV_AMQP_IMAGE)) {
                 throw new RuntimeException("Arguments did not contain AMQP image.");
             }
-            final String AMQP_IMAGE = initArgs.get(Const.HORREUM_DEV_AMQP_IMAGE);
-            inContainer = initArgs.containsKey("inContainer") && initArgs.get("inContainer").equals("true");
-            networkAlias = initArgs.get(HORREUM_DEV_AMQP_NETWORK_ALIAS);
+            inContainer = initArgs.containsKey("inContainer") && parseBoolean(initArgs.get("inContainer"));
+            networkAlias = initArgs.getOrDefault(HORREUM_DEV_AMQP_NETWORK_ALIAS, DEFAULT_AMQP_NETWORK_ALIAS);
 
-            amqpContainer = new GenericContainer<>(AMQP_IMAGE);
-            amqpContainer.withEnv("ARTEMIS_USER", initArgs.get("amqp-username"))
-                    .withEnv("ARTEMIS_PASSWORD", initArgs.get("amqp-password"))
+            amqpContainer = new GenericContainer<>(initArgs.get(HORREUM_DEV_AMQP_IMAGE));
+            amqpContainer.waitingFor(defaultWaitStrategy().withStartupTimeout(ofSeconds(120)))
+                    .withEnv("AMQ_USER", initArgs.getOrDefault("amqp-username", DEFAULT_AMQP_USERNAME))
+                    .withEnv("AMQ_PASSWORD", initArgs.getOrDefault("amqp-password", DEFAULT_AMQP_PASSWORD))
                     .withEnv("AMQ_ROLE", "admin")
                     .withEnv("EXTRA_ARGS",
                             " --role admin --name broker --allow-anonymous --force --no-autotune --mapped --no-fsync  --relax-jolokia ")
                     .withExposedPorts(5672)
-                    .withCopyFileToContainer(MountableFile.forClasspathResource("broker.xml"),
-                            "/var/lib/artemis-instance/etc-override/broker.xml");
+                    .withCopyFileToContainer(forClasspathResource("broker.xml"), BROKER_XML_CONTAINER_PATH);
         }
     }
 
@@ -53,8 +62,7 @@ public class ArtemisMQResource implements ResourceLifecycleManager {
         String mappedPort = amqpContainer.getMappedPort(5672).toString();
         String host = inContainer ? networkAlias : "localhost";
 
-        return Map.of("artemis.container.name", host,
-                "artemis.container.port", mappedPort);
+        return Map.of("artemis.container.name", host, "artemis.container.port", mappedPort);
     }
 
     @Override

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumResource.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumResource.java
@@ -1,6 +1,16 @@
 package io.hyperfoil.tools.horreum.infra.common.resources;
 
-import static io.hyperfoil.tools.horreum.infra.common.Const.*;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_PASSWORD;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_AMQP_USERNAME;
+import static io.hyperfoil.tools.horreum.infra.common.Const.DEFAULT_HORREUM_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_HORREUM_CONTAINER_PORT;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_HORREUM_HORREUM_IMAGE;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_HORREUM_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_KEYCLOAK_NETWORK_ALIAS;
+import static io.hyperfoil.tools.horreum.infra.common.Const.HORREUM_DEV_POSTGRES_NETWORK_ALIAS;
+import static java.lang.Boolean.parseBoolean;
+import static java.time.Duration.ofSeconds;
 
 import java.util.Collections;
 import java.util.Map;
@@ -9,6 +19,7 @@ import java.util.Optional;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import io.hyperfoil.tools.horreum.infra.common.HorreumResources;
 import io.hyperfoil.tools.horreum.infra.common.ResourceLifecycleManager;
@@ -16,25 +27,30 @@ import io.hyperfoil.tools.horreum.infra.common.ResourceLifecycleManager;
 public class HorreumResource implements ResourceLifecycleManager {
 
     private static GenericContainer<?> horreumContainer;
-    private boolean inContainer = false;
-
-    private String networkAlias = "";
+    private boolean inContainer;
+    private String networkAlias;
 
     public void init(Map<String, String> initArgs) {
         if (!initArgs.containsKey(HORREUM_DEV_HORREUM_HORREUM_IMAGE)) {
             throw new RuntimeException("Horreum dev image argument not configured");
         }
 
-        final String HORREUM_IMAGE = initArgs.get(HORREUM_DEV_HORREUM_HORREUM_IMAGE);
+        String horreumImage = initArgs.get(HORREUM_DEV_HORREUM_HORREUM_IMAGE);
 
-        inContainer = initArgs.containsKey("inContainer") && initArgs.get("inContainer").equals("true");
-        networkAlias = initArgs.get(HORREUM_DEV_HORREUM_NETWORK_ALIAS);
+        inContainer = initArgs.containsKey("inContainer") && parseBoolean(initArgs.get("inContainer"));
+        networkAlias = initArgs.getOrDefault(HORREUM_DEV_HORREUM_NETWORK_ALIAS, DEFAULT_HORREUM_NETWORK_ALIAS);
         Network network = HorreumResources.getNetwork();
 
         horreumContainer = (initArgs.containsKey(HORREUM_DEV_HORREUM_CONTAINER_PORT))
-                ? new FixedHostPortGenericContainer<>(HORREUM_IMAGE)
+                ? new FixedHostPortGenericContainer<>(horreumImage)
                         .withFixedExposedPort(Integer.parseInt(initArgs.get(HORREUM_DEV_HORREUM_CONTAINER_PORT)), 8080)
-                : new GenericContainer<>(HORREUM_IMAGE).withExposedPorts(8080);
+                : new GenericContainer<>(horreumImage).withExposedPorts(8080);
+
+        // wait for the startup log instead of relying on the port opening
+        horreumContainer.waitingFor(new LogMessageWaitStrategy()
+                .withRegEx(".*horreum-backend.*started in.*Listening on.*")
+                .withStartupTimeout(ofSeconds(60)));
+
         String keycloakHostUrl = initArgs.get("keycloak.host");
         String jdbcUrl = initArgs.get("quarkus.datasource.jdbc.url");
         if (inContainer) {
@@ -64,10 +80,10 @@ public class HorreumResource implements ResourceLifecycleManager {
                 .withEnv("quarkus.datasource.jdbc.url", jdbcUrl)
                 .withEnv("quarkus.datasource.migration.jdbc.url", jdbcUrl)
                 .withEnv("quarkus.datasource.jdbc.additional-jdbc-properties.sslmode", "require")
-                .withEnv("amqp-host", initArgs.get("amqp.host"))
-                .withEnv("amqp-port", initArgs.get("amqp.mapped.port"))
-                .withEnv("amqp-username", initArgs.get("amqp-username"))
-                .withEnv("amqp-password", initArgs.get("amqp-password"))
+                .withEnv("amqp-host", initArgs.getOrDefault("amqp.host", DEFAULT_AMQP_NETWORK_ALIAS))
+                .withEnv("amqp-port", initArgs.getOrDefault("amqp.mapped.port", "5672"))
+                .withEnv("amqp-username", initArgs.getOrDefault("amqp-username", DEFAULT_AMQP_USERNAME))
+                .withEnv("amqp-password", initArgs.getOrDefault("amqp-password", DEFAULT_AMQP_PASSWORD))
                 .withEnv("amqp-reconnect-attempts", "100")
                 .withEnv("amqp-reconnect-interval", "1000")
                 .withEnv("quarkus.profile", "test")
@@ -84,18 +100,16 @@ public class HorreumResource implements ResourceLifecycleManager {
         if (horreumContainer == null) {
             return Collections.emptyMap();
         }
-        if (!network.isPresent()) {
+        if (network.isPresent()) {
             horreumContainer.withNetwork(network.get());
             horreumContainer.withNetworkAliases(networkAlias);
         }
 
         horreumContainer.start();
-        String horreumContainerName = horreumContainer.getContainerName().replaceAll("/", "");
-        horreumContainerName = inContainer ? networkAlias : horreumContainerName;
-        Integer port = horreumContainer.getMappedPort(8080);
+        String containerName = inContainer ? networkAlias : horreumContainer.getContainerName().replaceAll("/", "");
+        String port = horreumContainer.getMappedPort(8080).toString();
 
-        return Map.of("horreum.container.name", horreumContainerName,
-                "horreum.container.port", port.toString());
+        return Map.of("horreum.container.name", containerName, "horreum.container.port", port);
     }
 
     @Override


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2181

1. change `ARTEMIS_USER / ARTEMIS_PASSWORD` to `AMQ_USER / AMQ_PASSWORD` that are the variable names defined in https://github.com/artemiscloud/activemq-artemis-broker-image/blob/main/image.yaml 
2. add wait strategy to both AMQ and Horreum containers
3. misc code improvements