### PR TITLE
docs: enable offline search

### DIFF
--- a/docs/site/hugo.toml
+++ b/docs/site/hugo.toml
@@ -121,13 +121,13 @@ github_subdir = "docs/site"
 github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "d72aa9b2712488cc3"
+# gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Algolia DocSearch
 algolia_docsearch = false
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
Enable the offline search and simultaneously disable the google custom search engine that was pointing to the docsy dev site

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2188

## Changes proposed

- [x] Disable google search engine
- [x] Enable the `offline` search

This is the result:

![image](https://github.com/user-attachments/assets/5af7188a-ee22-403b-bfd1-0dcac3330433)


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
