### PR TITLE
Fix `runApi.addRunFromData()` invocation

### DIFF
--- a/horreum-web/src/domain/runs/RunImportModal.tsx
+++ b/horreum-web/src/domain/runs/RunImportModal.tsx
@@ -55,10 +55,9 @@ export const RunImportModal = (props: RunImportModalProps) => {
                  props.test?.name || "",
                  props.owner,
                  access,
-                 undefined,
                  schemaUrn,
                  undefined,
-                  JSON.parse(payloadData || "")
+                 JSON.parse(payloadData || "")
              )
              , alerting, "UPLOAD_ERROR", "Failed to upload run data")
              .then(noop)


### PR DESCRIPTION
## Changes proposed

Removes redundant argument that used to be internal/test `token`.  The
parameter was removed in https://github.com/Hyperfoil/Horreum/pull/2100

This essentially fixes the "Import Data"/"Import New Run" form which currently always results in using the `schemaUrn` as a description, and `undefined` as the payload.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
