### PR TITLE
Trash run even if it is already trashed

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -119,7 +119,6 @@ public class TestServiceImpl implements TestService {
         if (mediator.testMode())
             Util.registerTxSynchronization(tm,
                     txStatus -> mediator.publishEvent(AsyncEventChannels.TEST_DELETED, test.id, TestMapper.from(test)));
-        ;
     }
 
     @Override

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceNoRestTest.java
@@ -1,11 +1,18 @@
 package io.hyperfoil.tools.horreum.svc;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 import io.hyperfoil.tools.horreum.api.data.Access;
 import io.hyperfoil.tools.horreum.api.data.Extractor;
 import io.hyperfoil.tools.horreum.api.data.Label;
+import io.hyperfoil.tools.horreum.api.data.Run;
 import io.hyperfoil.tools.horreum.api.data.Schema;
 import io.hyperfoil.tools.horreum.api.data.Test;
 import io.hyperfoil.tools.horreum.api.data.Transformer;
@@ -18,6 +25,9 @@ public abstract class BaseServiceNoRestTest {
     protected static final String FOO_TESTER = "foo-tester";
     protected static final String FOO_UPLOADER = "foo-uploader";
     protected static final String BAR_TEAM = "bar-team";
+
+    @Inject
+    protected EntityManager em;
 
     protected Schema createSampleSchema(String name, String uri, String owner) {
         Schema schema = new Schema();
@@ -84,5 +94,19 @@ public abstract class BaseServiceNoRestTest {
         test.datastoreId = datastoreId;
         test.folder = folder == null ? "" : folder;
         return test;
+    }
+
+    protected Run createSampleRun(int testId, JsonNode runJson, String owner) {
+        Instant instant = Instant.now();
+
+        Run run = new Run();
+        run.testid = testId;
+        run.data = runJson;
+        run.trashed = false;
+        run.start = instant;
+        run.stop = instant;
+        run.owner = owner == null ? FOO_TEAM : owner;
+
+        return run;
     }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
@@ -1,0 +1,116 @@
+package io.hyperfoil.tools.horreum.svc;
+
+import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.DEFAULT_USER;
+import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.FOO_TEAM;
+import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.FOO_TESTER;
+import static io.hyperfoil.tools.horreum.svc.BaseServiceNoRestTest.FOO_UPLOADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import io.hyperfoil.tools.horreum.api.data.Access;
+import io.hyperfoil.tools.horreum.api.data.Run;
+import io.hyperfoil.tools.horreum.api.data.Test;
+import io.hyperfoil.tools.horreum.api.services.RunService;
+import io.hyperfoil.tools.horreum.api.services.TestService;
+import io.hyperfoil.tools.horreum.entity.data.RunDAO;
+import io.hyperfoil.tools.horreum.entity.data.TestDAO;
+import io.hyperfoil.tools.horreum.test.HorreumTestProfile;
+import io.hyperfoil.tools.horreum.test.PostgresResource;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+
+@QuarkusTest
+@QuarkusTestResource(PostgresResource.class)
+@TestProfile(HorreumTestProfile.class)
+@TestTransaction
+@TestSecurity(user = DEFAULT_USER, roles = { Roles.TESTER, Roles.VIEWER, Roles.UPLOADER, FOO_TEAM, FOO_TESTER, FOO_UPLOADER })
+class RunServiceNoRestTest extends BaseServiceNoRestTest {
+
+    @Inject
+    RunService runService;
+
+    @Inject
+    TestService testService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @org.junit.jupiter.api.Test
+    void testUploadRun() {
+        Test t1 = createSampleTest("test", null, null, null);
+
+        Test created1 = testService.add(t1);
+        assertNotNull(created1.id);
+        assertEquals(1, TestDAO.count());
+
+        int runId = uploadRun(created1.id, FOO_TEAM, JsonNodeFactory.instance.objectNode());
+        assertEquals(1, RunDAO.count());
+        assertNotNull(RunDAO.findById(runId));
+    }
+
+    @org.junit.jupiter.api.Test
+    void testTrashRun() {
+        Test t1 = createSampleTest("test", null, null, null);
+
+        Test created1 = testService.add(t1);
+        assertNotNull(created1.id);
+        assertEquals(1, TestDAO.count());
+
+        int runId = uploadRun(created1.id, FOO_TEAM, JsonNodeFactory.instance.objectNode());
+        assertEquals(1, RunDAO.count());
+        RunDAO run = RunDAO.findById(runId);
+        assertFalse(run.trashed);
+
+        runService.trash(runId, true);
+        assertTrue(run.trashed);
+    }
+
+    @org.junit.jupiter.api.Test
+    void testTrashAlreadyTrashedRun() {
+        Test t1 = createSampleTest("test", null, null, null);
+
+        Test created1 = testService.add(t1);
+        assertNotNull(created1.id);
+        assertEquals(1, TestDAO.count());
+
+        int runId = uploadRun(created1.id, FOO_TEAM, JsonNodeFactory.instance.objectNode());
+        assertEquals(1, RunDAO.count());
+        RunDAO run = RunDAO.findById(runId);
+        assertFalse(run.trashed);
+
+        runService.trash(runId, true);
+        assertTrue(run.trashed);
+
+        // trash again the same trashed run
+        runService.trash(runId, true);
+        assertTrue(run.trashed);
+    }
+
+    // utility to create a sample test and add to Horreum
+    private Test addTest(String name, String owner, String folder, Integer datastoreId) {
+        Test test = createSampleTest(name, owner, folder, datastoreId);
+        return testService.add(test);
+    }
+
+    // utility to create a sample test and add to Horreum
+    private int uploadRun(int testId, String owner, JsonNode runData) {
+        Run run = createSampleRun(testId, runData, owner);
+
+        try (Response resp = runService.add(String.valueOf(testId), owner, Access.PUBLIC, run)) {
+            assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());
+            return Integer.parseInt(resp.getEntity().toString());
+        }
+    }
+}


### PR DESCRIPTION
Trashing a run that was already trashed should have no effects and it should not throw an exception

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2160

## Changes proposed

Trying to trash a run that has been already trashed will result in a no-operation

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
