### PR TITLE
Remove view recalc queue

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -1082,9 +1082,8 @@ public class RunServiceImpl implements RunService {
     @Transactional
     @Override
     public List<Integer> recalculateDatasets(int runId) {
-        transform(runId, true);
-        return session.createNativeQuery("SELECT id FROM dataset WHERE runid = ? ORDER BY ordinal", Integer.class)
-                .setParameter(1, runId).getResultList();
+        log.infof("Transforming run id %d", runId);
+        return transform(runId, true);
     }
 
     @RolesAllowed(Roles.ADMIN)

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -669,6 +669,7 @@ public class TestServiceImpl implements TestService {
                             status.finished++;
                             status.datasets += newDatasets;
                             if (status.finished == status.totalRuns) {
+                                log.infof("Datasets recalculation for test %d (%s) completed", testId, test.name);
                                 recalculations.remove(testId, status);
                             }
                         }

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4757,5 +4757,43 @@
             WHERE backendconfig.id = updated.id;
         </sql>
     </changeSet>
+    <changeSet id="127" author="lampajr">
+        <validCheckSum>ANY</validCheckSum>
+        <sql>
+            -- drop triggers
+            DROP TRIGGER IF EXISTS dsv_after_delete ON viewcomponent;
+            DROP TRIGGER IF EXISTS dsv_after_update ON viewcomponent;
+            DROP TRIGGER IF EXISTS recalc_dataset_view ON view_recalc_queue;
+            DROP TRIGGER IF EXISTS dsv_after_insert ON label_values;
 
+            -- drop functions
+            DROP FUNCTION dsv_after_vc_delete_func;
+            DROP FUNCTION dsv_after_vc_update_func;
+            DROP FUNCTION recalc_dataset_view;
+            DROP FUNCTION dsv_after_lv_insert_func;
+
+            -- drop view_recalc_queue table as not needed anymore
+            DROP TABLE view_recalc_queue;
+
+            -- still need db procedure until https://hibernate.atlassian.net/browse/HHH-17314 is fixed in quarkus
+            -- viewId can be NULL
+            CREATE OR REPLACE PROCEDURE calc_dataset_view(datasetId bigint, viewId bigint DEFAULT NULL) AS $$
+            BEGIN
+            WITH view_agg AS (
+                SELECT
+                    vc.view_id, vc.id as vcid, array_agg(DISTINCT label.id) as label_ids, jsonb_object_agg(label.name, lv.value) as value FROM dataset_schemas ds
+                JOIN label ON label.schema_id = ds.schema_id
+                JOIN viewcomponent vc ON vc.labels ? label.name
+                JOIN label_values lv ON lv.label_id = label.id AND lv.dataset_id = ds.dataset_id
+                WHERE ds.dataset_id = datasetId AND (viewId IS NULL OR vc.view_id = viewId)
+                    AND vc.view_id IN (SELECT view.id FROM view JOIN dataset ON view.test_id = dataset.testid WHERE dataset.id = datasetId)
+                GROUP BY vc.view_id, vcid
+            )
+            INSERT INTO dataset_view (dataset_id, view_id, label_ids, value)
+                SELECT datasetId, view_id, array_agg(DISTINCT label_id), jsonb_object_agg(vcid, value) FROM view_agg, unnest(label_ids) as label_id
+                GROUP BY view_id;
+            END
+            $$ LANGUAGE plpgsql;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Followup pull request of https://github.com/Hyperfoil/Horreum/pull/2202

This is not meant to be backported.

Fixes https://github.com/Hyperfoil/Horreum/issues/2220

## Changes proposed

Move the `dataset_view` update logic from db to Horreum java logic.

As part of this refactoring the following entities have been removed:
- Tables
   -  view_recalc_queue and:
    
- Triggers
    - dsv_after_delete
    - dsv_after_update
    - recalc_dataset_view
    - dsv_after_insert
    
- Functions:
    - dsv_after_vc_delete_func
    - dsv_after_vc_update_func
    - recalc_dataset_view
    - dsv_after_lv_insert_func

Moreover the `calc_dataset_view(datasetId bigint, viewId bigint DEFAULT NULL)` signature has changed
such that it can be called in two different scenarios, i.e., by dataset or by dataset-view.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
