### PR TITLE
change API_KEY examples to avoid ansible issues

### DIFF
--- a/docs/site/content/en/docs/Reference/APIFilterQueryReference.md
+++ b/docs/site/content/en/docs/Reference/APIFilterQueryReference.md
@@ -12,7 +12,7 @@ API operations that support Filter Query provide an HTTP request parameter named
 To use the Filter Query with an operation that returns a [Run](/docs/concepts/core-concepts/#run) data can be done as follows.
 
 ```bash
-curl -s  'http://localhost:8080/api/sql/1/queryrun?query=$.*&array=true'  -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY
+curl -s  'http://localhost:8080/api/sql/1/queryrun?query=$.*&array=true'  -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY"
 {
   "valid": true,
   "jsonpath": "$.*",
@@ -29,7 +29,7 @@ The response contains an enclosing JSON object that is common for Filter Query o
 To filter the above API operation to retrieve only the *results* property of the uploaded [Run](/docs/concepts/core-concepts/#run) object the *query* parameter is defined as `$.results`
 
 ```bash
-curl -s  'http://localhost:8080/api/sql/1/queryrun?query=$.results&array=true'  -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY
+curl -s  'http://localhost:8080/api/sql/1/queryrun?query=$.results&array=true'  -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY"
 {
   "valid": true,
   "jsonpath": "$.results",

--- a/docs/site/content/en/docs/Tasks/import-export/index.md
+++ b/docs/site/content/en/docs/Tasks/import-export/index.md
@@ -44,7 +44,7 @@ Click on Schema/Test and there is a button where you can select either _Import S
 ```bash
 curl 'http://localhost:8080/api/schema/import/' \
     -s -X POST -H 'content-type: application/json' \
-    -H 'X-Horreum-API-Key: '$API_KEY \
+    -H "X-Horreum-API-Key: $API_KEY" \
     -d @/path/to/schema.json
 ```
 
@@ -55,7 +55,7 @@ If you are unfamiliar with generating an API Key, please see [Upload Run](/docs/
 ```bash
 curl 'http://localhost:8080/api/test/import/' \
     -s -X POST -H 'content-type: application/json' \
-    -H 'X-Horreum-API-Key: '$API_KEY \
+    -H "X-Horreum-API-Key: $API_KEY" \
     -d @/path/to/test.json
 ```
 
@@ -64,7 +64,7 @@ curl 'http://localhost:8080/api/test/import/' \
 ```bash
 SCHEMAID='123'
 curl 'http://localhost:8080/api/schema/export/?id='$SCHEMAID \
-    -H 'X-Horreum-API-Key: '$API_KEY \
+    -H "X-Horreum-API-Key: $API_KEY" \
     -O --output-dir /path/to/folder
 ```
 
@@ -74,6 +74,6 @@ curl 'http://localhost:8080/api/schema/export/?id='$SCHEMAID \
 TESTID='123'
 curl 'http://localhost:8080/api/test/export/?id=$TESTID' \
     -s -X POST -H 'content-type: application/json' \
-    -H 'X-Horreum-API-Key: '$API_KEY \
+    -H "X-Horreum-API-Key: $API_KEY" \
     -O --output-dir /path/to/folder
 ```

--- a/docs/site/content/en/docs/Tasks/manage-reports/index.md
+++ b/docs/site/content/en/docs/Tasks/manage-reports/index.md
@@ -26,5 +26,5 @@ The same task can be repeated using the web API to delete a `Report`. Copy and p
 
 ```bash
 REPORT_ID=<your_report_id_here>
-curl   'http://localhost:8080/api/report/table/'$REPORT_ID   -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY --request DELETE -v
+curl   'http://localhost:8080/api/report/table/'$REPORT_ID   -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY" --request DELETE -v
 ```

--- a/docs/site/content/en/docs/Tasks/upload-run/index.md
+++ b/docs/site/content/en/docs/Tasks/upload-run/index.md
@@ -34,7 +34,7 @@ OWNER='dev-team'
 ACCESS='PUBLIC'
 curl 'http://localhost:8080/api/run/data?test='$TEST'&start='$START'&stop='$STOP'&owner='$OWNER'&access='$ACCESS \
     -s -X POST -H 'content-type: application/json' \
-    -H 'X-Horreum-API-Key: '$API_KEY \
+    -H "X-Horreum-API-Key: $API_KEY" \
     -d @/path/to/data.json
 ```
 

--- a/docs/site/content/en/docs/Tutorials/create-test-run/index.md
+++ b/docs/site/content/en/docs/Tutorials/create-test-run/index.md
@@ -53,7 +53,7 @@ STOP='2021-08-01T10:40:28.00Z'
 OWNER='dev-team'
 ACCESS='PUBLIC'
 curl 'http://localhost:8080/api/run/data?test='$TEST'&start='$START'&stop='$STOP'&owner='$OWNER'&access='$ACCESS \
-    -s -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY \
+    -s -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY" \
     -d @/tmp/run.json
 ```
 

--- a/docs/site/content/en/docs/Tutorials/query-collector/index.md
+++ b/docs/site/content/en/docs/Tutorials/query-collector/index.md
@@ -49,7 +49,7 @@ The query can be executed by making a call to the Horreum API;
 
 ```bash
 $ curl 'http://localhost:8080/api/run/data?test='$TEST'&start='$START'&stop='$STOP'&owner='$OWNER'&access='$ACCESS \
-    -s -H 'content-type: application/json'  -H 'X-Horreum-API-Key: '$API_KEY \
+    -s -H 'content-type: application/json'  -H "X-Horreum-API-Key: $API_KEY" \
     -d @/tmp/collector_query.json
 ```
 

--- a/docs/site/content/en/docs/Tutorials/query-elasticserach/index.md
+++ b/docs/site/content/en/docs/Tutorials/query-elasticserach/index.md
@@ -52,7 +52,7 @@ The document query can then be sumitted to the Horreum API;
 
 ```bash 
 $ curl 'http://localhost:8080/api/run/data?test='$TEST'&start='$START'&stop='$STOP'&owner='$OWNER'&access='$ACCESS \
-    -s -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY \
+    -s -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY" \
     -d @/tmp/elastic_payload.json
 ```
 
@@ -101,7 +101,7 @@ The query can be executed by making a call to the Horreum API;
 
 ```bash
 $ curl 'http://localhost:8080/api/run/data?test='$TEST'&start='$START'&stop='$STOP'&owner='$OWNER'&access='$ACCESS \
-    -s -H 'content-type: application/json' -H 'X-Horreum-API-Key: '$API_KEY \
+    -s -H 'content-type: application/json' -H "X-Horreum-API-Key: $API_KEY" \
     -d @/tmp/elastic_query.json
 ```
 


### PR DESCRIPTION
This is in response to issues user experienced using the examples from the docs in ansible automation. Placing the `$API_KEY` variable reference outside of the single quote parameter definition for `curl -H` in ansible did not properly set the request header. It does work if the variable reference is located inside a double quote (`"`). Changing the documented examples will work in bash and avoid providing examples that conflict with ansible's command line processing.