### PR TITLE
Removing remaining database triggers

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
@@ -169,8 +169,8 @@ public class DatasetServiceImpl implements DatasetService {
          LEFT JOIN label_values lv ON dataset.id = lv.dataset_id
          LEFT JOIN label ON label.id = label_id
          """;
-
     //@formatter:on
+
     @Inject
     EntityManager em;
 

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4796,4 +4796,48 @@
             $$ LANGUAGE plpgsql;
         </sql>
     </changeSet>
+    <changeSet id="128" author="lampajr">
+        <validCheckSum>ANY</validCheckSum>
+        <sql>
+            -- drop triggers
+            DROP TRIGGER IF EXISTS rs_after_run_untrash ON run;
+            DROP TRIGGER IF EXISTS rs_after_run_update ON run;
+            DROP TRIGGER IF EXISTS before_schema_update ON schema;
+            DROP TRIGGER IF EXISTS ds_after_insert ON dataset;
+
+            -- drop functions
+            DROP FUNCTION rs_after_run_update;
+            DROP FUNCTION before_schema_update_func;
+            DROP FUNCTION ds_after_dataset_insert_func;
+        </sql>
+    </changeSet>
+    <changeSet id="129" author="lampajr">
+        <validCheckSum>ANY</validCheckSum>
+        <sql>
+            -- drop triggers
+            DROP TRIGGER IF EXISTS after_run_update_non_data ON run;
+            DROP TRIGGER IF EXISTS delete_run_validations ON run;
+
+            -- drop functions
+            DROP FUNCTION after_run_update_non_data_func;
+            DROP FUNCTION delete_run_validations;
+        </sql>
+    </changeSet>
+    <changeSet id="130" author="lampajr">
+        <validCheckSum>ANY</validCheckSum>
+        <sql>
+            -- drop triggers
+            DROP TRIGGER IF EXISTS lv_before_update ON label;
+            DROP TRIGGER IF EXISTS lv_after_update ON label;
+            DROP TRIGGER IF EXISTS recalc_labels ON label_recalc_queue;
+
+            -- drop functions
+            DROP FUNCTION lv_before_label_update_func;
+            DROP FUNCTION lv_after_label_update_func;
+            DROP FUNCTION recalc_label_values;
+
+            -- drop table as no longer used
+            DROP TABLE label_recalc_queue;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
@@ -404,7 +404,7 @@ public class AlertingServiceTest extends BaseServiceTest {
         em.clear();
 
         pollMissingDataRuleResultsByDataset(thirdEvent.datasetId, 1);
-        trashRun(thirdRunId, test.id);
+        trashRun(thirdRunId, test.id, true);
         pollMissingDataRuleResultsByDataset(thirdEvent.datasetId, 0);
 
         alertingService.checkMissingDataset();

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -237,16 +237,6 @@ public class BaseServiceTest {
         return test;
     }
 
-    public static List<View> createExampleViews(int testId) {
-        View defaultView = new View();
-        defaultView.name = "Default";
-        defaultView.testId = testId;
-        defaultView.components = new ArrayList<>();
-        defaultView.components.add(new io.hyperfoil.tools.horreum.api.data.ViewComponent("Some column", null, "foo"));
-
-        return Collections.singletonList(defaultView);
-    }
-
     public static String getAccessToken(String userName, String... groups) {
         return Jwt.preferredUserName(userName)
                 .groups(new HashSet<>(Arrays.asList(groups)))
@@ -616,10 +606,12 @@ public class BaseServiceTest {
         return array;
     }
 
-    protected BlockingQueue<Integer> trashRun(int runId, Integer testId) throws InterruptedException {
+    protected BlockingQueue<Integer> trashRun(int runId, Integer testId, boolean trashed) throws InterruptedException {
         BlockingQueue<Integer> trashedQueue = serviceMediator.getEventQueue(AsyncEventChannels.RUN_TRASHED, testId);
-        jsonRequest().post("/api/run/" + runId + "/trash").then().statusCode(204);
-        assertEquals(runId, trashedQueue.poll(10, TimeUnit.SECONDS));
+        jsonRequest().post("/api/run/" + runId + "/trash?isTrashed=" + trashed).then().statusCode(204);
+        if (trashed) {
+            assertEquals(runId, trashedQueue.poll(10, TimeUnit.SECONDS));
+        }
         return trashedQueue;
     }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
@@ -663,9 +663,15 @@ class SchemaServiceTest extends BaseServiceTest {
         assertNotNull(updatedSchema);
         assertEquals(schema.id, updatedSchema.id);
 
-        List<?> runSchemasAfter = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1").setParameter(1, runId)
-                .getResultList();
-        assertEquals(0, runSchemasAfter.size());
+        TestUtil.eventually(() -> {
+            Util.withTx(tm, () -> {
+                List<?> runSchemasAfter = em.createNativeQuery("SELECT * FROM run_schemas WHERE runid = ?1")
+                        .setParameter(1, runId)
+                        .getResultList();
+                assertEquals(0, runSchemasAfter.size());
+                return null;
+            });
+        });
     }
 
     @org.junit.jupiter.api.Test


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2228
Fixes https://github.com/Hyperfoil/Horreum/issues/2231

## Changes proposed

Moved the logic to update `run_schemas` and `dataset_schemas` into Horreum logic and as a consequence I removed the following entities:

Triggers:
- ds_after_insert
- rs_after_run_untrash
- rs_after_run_update
- before_schema_update

Functions:
- ds_after_dataset_insert_func
- rs_after_run_update
- before_schema_update_func

I kept the procedure `update_run_schemas` in the db as it is always called by the Horreum directly.

Additionally with commit https://github.com/Hyperfoil/Horreum/pull/2230/commits/714223f199ed0cac77e5fec2c65faa21d9d7e392 I removed the remaining triggers on `Run` table:
- after_run_update_non_data, moved logic into Horreum
- delete_run_validations, we are not even allowing Runs to be deleted so no need to keep that

With commit d18fcc7dfb089c86e8ca3fa2904ff6c9d6ad9975 I also removed all triggers associated to the `label` table:
- lv_before_update
- lv_after_update
- recalc_labels

And related functions. Moreover I also deleted the `label_recalc_queue` table as no longer used.

## Preconditions

- [x] This PR is based on https://github.com/Hyperfoil/Horreum/pull/2203, therefore we have to merge that first and then rebase this one.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
