### PR TITLE
Make persistRun transactional

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -222,6 +222,7 @@ public interface RunService {
             @Parameter(name = "description", description = "Run description", example = "AWS runs"),
 
     })
+    @Produces(MediaType.TEXT_PLAIN)
     @APIResponses(value = {
             @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
                     + "or an empty list if processing is still ongoing. Label values and change detection processing " +
@@ -242,6 +243,7 @@ public interface RunService {
     @Path("data")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(description = "Upload a new Run with metadata", hidden = true)
+    @Produces(MediaType.TEXT_PLAIN)
     @APIResponses(value = {
             @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
                     + "or an empty list if processing is still ongoing. Label values and change detection processing " +

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -535,6 +535,7 @@ public class RunServiceImpl implements RunService {
                 .build();
     }
 
+    @Transactional
     void persistRun(ServiceMediator.RunUpload runUpload) {
         runUpload.roles.add("horreum.system");
         roleManager.setRoles(String.join(",", runUpload.roles));


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2242

## Changes proposed

After deeper investigations it turned out the bug was introduced with https://github.com/Hyperfoil/Horreum/pull/2172 that basically removed the `@Transactional` annotation around the `persistRun` method, which is the one invoked by the `upload-run` async emitter.

My guess is that, given that there is not explicit transaction wrapping that method the `roleManager.setRoles(String.join(",", runUpload.roles));` instructions is not visible from the rest of the logic (where the run is persisted) resulting in missing roles at the db level.

Changes:
- [x] Reinstate the `@Transactional` to the `persistRun` method
- [x] Force the addRunFromData to produce `text/plain`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
