### PR TITLE
Clear id's importing a new test, check for null

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/TestExport.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/TestExport.java
@@ -48,19 +48,23 @@ public class TestExport extends Test {
         if (experiments != null && !experiments.isEmpty()) {
             for (ExperimentProfile experiment : experiments) {
                 experiment.testId = id;
+                experiment.id = null;
             }
         }
         if (actions != null && !actions.isEmpty()) {
             for (Action action : actions) {
                 action.testId = id;
+                action.id = null;
             }
         }
         if (subscriptions != null) {
             subscriptions.testId = id;
+            subscriptions.id = null;
         }
         if (missingDataRules != null && !missingDataRules.isEmpty()) {
             for (MissingDataRule rule : missingDataRules) {
                 rule.testId = id;
+                rule.id = null;
             }
         }
     }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -385,7 +385,7 @@ public class AlertingServiceImpl implements AlertingService {
 
     void importMissingDataRules(TestExport test) {
         for (var rule : test.missingDataRules) {
-            if (MissingDataRuleDAO.findById(rule.id) != null) {
+            if (rule.id != null && rule.id > 0 && MissingDataRuleDAO.findById(rule.id) != null) {
                 em.merge(MissingDataRuleMapper.to(rule));
             } else {
                 rule.id = null;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -739,7 +739,6 @@ public class TestServiceImpl implements TestService {
             if (!exists) {
                 newTest.datastore.id = datastore.id;
             }
-
         }
         Test t = add(newTest);
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import io.hyperfoil.tools.horreum.action.ExperimentResultToMarkdown;
 import io.hyperfoil.tools.horreum.api.SortDirection;
+import io.hyperfoil.tools.horreum.api.alerting.MissingDataRule;
 import io.hyperfoil.tools.horreum.api.alerting.Variable;
 import io.hyperfoil.tools.horreum.api.alerting.Watch;
 import io.hyperfoil.tools.horreum.api.data.Action;
@@ -440,10 +441,17 @@ class TestServiceTest extends BaseServiceTest {
         ep.baselineFilter = "value => {return true;}";
         ep.comparisons = new ArrayList<>();
         ep.extraLabels = JSON_NODE_FACTORY.arrayNode();
+        var msdr = new MissingDataRule();
+        msdr.testId = testExport.id;
+        msdr.name = "imported missing rule";
+        msdr.maxStaleness = 42;
+        testExport.missingDataRules = Collections.singletonList(msdr);
         jsonRequest().body(testExport).post("/api/test/import").then().statusCode(204);
         ExperimentProfileDAO epDAO = ExperimentProfileDAO.<ExperimentProfileDAO> find("name", "acme Quarkus experiment")
                 .firstResult();
         assertNotNull(epDAO);
+        MissingDataRuleDAO mdr = MissingDataRuleDAO.find("name", "imported missing rule").firstResult();
+        assertEquals(42, mdr.maxStaleness);
     }
 
     private void addSubscription(Test test) {


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/Horreum/issues/2249

Clears existing id's if we're importing a new test. Also check for null on the id field that caused the import issue.