### PR TITLE
Fix test import when datastore is provided

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -728,18 +728,20 @@ public class TestServiceImpl implements TestService {
             throw ServiceException.badRequest("Failed to parse Test definition: " + e.getMessage());
         }
 
-        //need to add logic for datastore
-        if (newTest.datastore != null) {
-            //first check if datastore already exists
-            boolean exists = DatastoreConfigDAO.findById(newTest.datastore.id) != null;
+        // if the datastore does NOT exist in our db then create it
+        if (newTest.datastore != null
+                && (newTest.datastore.id == null || (DatastoreConfigDAO.findById(newTest.datastore.id) == null))) {
+            // reset the datastore to be sure we are creating a new one
+            newTest.datastore.id = null;
             DatastoreConfigDAO datastore = DatasourceMapper.to(newTest.datastore);
-            if (!exists)
-                datastore.id = null;
             datastore.persist();
-            if (!exists) {
-                newTest.datastore.id = datastore.id;
-            }
+            newTest.datastore.id = datastore.id;
+            newTest.datastoreId = newTest.datastore.id;
+        } else if (newTest.datastore != null && newTest.datastore.id != null) {
+            // if the datastore already exists in the db simply link its id to the datastoreId field
+            newTest.datastoreId = newTest.datastore.id;
         }
+
         Test t = add(newTest);
 
         if (!Objects.equals(t.id, newTest.id)) {

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -51,6 +51,10 @@ import io.hyperfoil.tools.horreum.api.alerting.Variable;
 import io.hyperfoil.tools.horreum.api.data.*;
 import io.hyperfoil.tools.horreum.api.data.Extractor;
 import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
+import io.hyperfoil.tools.horreum.api.data.datastore.Datastore;
+import io.hyperfoil.tools.horreum.api.data.datastore.DatastoreType;
+import io.hyperfoil.tools.horreum.api.data.datastore.ElasticsearchDatastoreConfig;
+import io.hyperfoil.tools.horreum.api.data.datastore.auth.NoAuth;
 import io.hyperfoil.tools.horreum.api.internal.services.AlertingService;
 import io.hyperfoil.tools.horreum.api.report.ReportComponent;
 import io.hyperfoil.tools.horreum.api.report.TableReportConfig;
@@ -255,6 +259,25 @@ public class BaseServiceTest {
                 .jws()
                 .keyId("1")
                 .sign();
+    }
+
+    protected int createDatastore(String datastoreName) {
+        Datastore newDatastore = new Datastore();
+        newDatastore.name = datastoreName;
+        newDatastore.type = DatastoreType.ELASTICSEARCH;
+        newDatastore.access = Access.PRIVATE;
+        newDatastore.owner = TESTER_ROLES[0];
+
+        ElasticsearchDatastoreConfig elasticConfig = new ElasticsearchDatastoreConfig();
+        elasticConfig.url = "http://localhost:9999";
+        elasticConfig.authentication = new NoAuth();
+
+        newDatastore.config = mapper.valueToTree(elasticConfig);
+
+        JsonNode datasourceTree = mapper.valueToTree(newDatastore);
+
+        return jsonRequest().body(datasourceTree.toString()).post("/api/config/datastore")
+                .then().statusCode(200).extract().as(Integer.class);
     }
 
     protected int uploadRun(Object runJson, String test) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2248

## Changes proposed

Changes affected the Test import feature as follows:

- [x] If the provided datasore does NOT exist, create it in the database
- [x] If the provided datasore exists, simply link the (new) Test to that without changing the original datastore content

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
