### PR TITLE
docs: Add a note that label id is only required when updating label

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1551,7 +1551,8 @@ paths:
     post:
       tags:
       - Schema
-      description: Save new or update existing Label for a Schema
+      description: Save new or update existing Label for a Schema (Label id only required
+        when updating existing one)
       operationId: addOrUpdateLabel
       parameters:
       - name: schemaId

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -168,7 +168,7 @@ public interface SchemaService {
     @POST
     @Path("{schemaId}/labels")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "Save new or update existing Label for a Schema")
+    @Operation(description = "Save new or update existing Label for a Schema (Label id only required when updating existing one)")
     @Parameters(value = {
             @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
     })


### PR DESCRIPTION
## Fixes Issue

Looking into https://horreum.hyperfoil.io/openapi/#tag/Schema/operation/addOrUpdateLabel API doc says `id` ("Unique ID for Label") is required. This should be only required when you are updating label, not adding new one. It confused me.

## Changes proposed

Just a tiny docs change.