### PR TITLE
fix: Add missing owner header

### DIFF
--- a/horreum-web/src/domain/runs/Run.tsx
+++ b/horreum-web/src/domain/runs/Run.tsx
@@ -92,6 +92,7 @@ export default function Run() {
                                     <Tr>
                                         <Th>Id</Th>
                                         <Th>Test</Th>
+                                        <Th>Owner</Th>
                                         <Th>Start</Th>
                                         <Th>Stop</Th>
                                         <Th>Description</Th>


### PR DESCRIPTION
## Fixes Issue

On a Run page (e.g. `/run/53069#run`) one header was missing.

![image](https://github.com/user-attachments/assets/150213a1-2366-4f25-b071-3ff9bfb01e6b)

## Changes proposed

Adding the table header.