### PR TITLE
Split add and update schema apis

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1567,12 +1567,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Label"
-    post:
+    put:
       tags:
       - Schema
-      description: Save new or update existing Label for a Schema (Label id only required
-        when updating existing one)
-      operationId: addOrUpdateLabel
+      description: Update existing Label for a Schema (Label id only required when
+        updating existing one)
+      operationId: updateLabel
       parameters:
       - name: schemaId
         in: path
@@ -1590,7 +1590,36 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Schema updated successfully
+          content:
+            application/json:
+              schema:
+                format: int32
+                type: integer
+    post:
+      tags:
+      - Schema
+      description: Save new or update existing Label for a Schema (Label id only required
+        when updating existing one)
+      operationId: addLabel
+      parameters:
+      - name: schemaId
+        in: path
+        description: Schema ID
+        required: true
+        schema:
+          format: int32
+          type: integer
+        example: 101
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Label"
+        required: true
+      responses:
+        "201":
+          description: New schema created successfully
           content:
             application/json:
               schema:

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1283,6 +1283,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SchemaQueryResult"
+    put:
+      tags:
+      - Schema
+      description: Update an existing Schema
+      operationId: update
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Schema"
+      responses:
+        "200":
+          description: Schema updated successfully
+          content:
+            application/json:
+              schema:
+                format: int32
+                type: integer
+              example: 103
     post:
       tags:
       - Schema
@@ -1294,8 +1313,8 @@ paths:
             schema:
               $ref: "#/components/schemas/Schema"
       responses:
-        "200":
-          description: Import a new Schema
+        "201":
+          description: New schema created successfully
           content:
             application/json:
               schema:

--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1675,11 +1675,11 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Transformer"
-    post:
+    put:
       tags:
       - Schema
-      description: Save new or update existing Transformer defintion
-      operationId: addOrUpdateTransformer
+      description: Save new or update existing Transformer definition
+      operationId: updateTransformer
       parameters:
       - name: schemaId
         in: path
@@ -1697,7 +1697,35 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Transformer updated successfully
+          content:
+            application/json:
+              schema:
+                format: int32
+                type: integer
+    post:
+      tags:
+      - Schema
+      description: Save new or update existing Transformer definition
+      operationId: addTransformer
+      parameters:
+      - name: schemaId
+        in: path
+        description: Schema ID
+        required: true
+        schema:
+          format: int32
+          type: integer
+        example: 101
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Transformer"
+        required: true
+      responses:
+        "201":
+          description: New transformer created successfully
           content:
             application/json:
               schema:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Label.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Label.java
@@ -49,6 +49,10 @@ public class Label extends ProtectedType {
         this.schemaId = schemaId;
     }
 
+    public void clearIds() {
+        id = null;
+    }
+
     public static class Value implements Serializable {
         public int datasetId;
         public int labelId;

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Schema.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Schema.java
@@ -66,4 +66,8 @@ public class Schema extends ProtectedType {
                     '}';
         }
     }
+
+    public void clearIds() {
+        id = null;
+    }
 }

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Transformer.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Transformer.java
@@ -69,7 +69,7 @@ public class Transformer extends ProtectedType {
                 '}';
     }
 
-    public void clearId() {
+    public void clearIds() {
         id = null;
     }
 }

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -175,10 +175,26 @@ public interface SchemaService {
     @Path("{schemaId}/labels")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(description = "Save new or update existing Label for a Schema (Label id only required when updating existing one)")
+    @ResponseStatus(201)
     @Parameters(value = {
             @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
     })
-    Integer addOrUpdateLabel(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Label label);
+    @APIResponses(value = {
+            @APIResponse(responseCode = "201", description = "New schema created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+    })
+    Integer addLabel(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Label label);
+
+    @PUT
+    @Path("{schemaId}/labels")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(description = "Update existing Label for a Schema (Label id only required when updating existing one)")
+    @Parameters(value = {
+            @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
+    })
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "Schema updated successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+    })
+    Integer updateLabel(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Label label);
 
     @DELETE
     @Path("{schemaId}/labels/{labelId}")

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -146,12 +146,28 @@ public interface SchemaService {
     @Path("{schemaId}/transformers")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Save new or update existing Transformer defintion")
+    @Operation(description = "Save new or update existing Transformer definition")
+    @ResponseStatus(201)
     @Parameters(value = {
             @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
     })
-    int addOrUpdateTransformer(@PathParam("schemaId") int schemaId,
-            @RequestBody(required = true) Transformer transformer);
+    @APIResponses(value = {
+            @APIResponse(responseCode = "201", description = "New transformer created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+    })
+    int addTransformer(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Transformer transformer);
+
+    @PUT
+    @Path("{schemaId}/transformers")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Save new or update existing Transformer definition")
+    @Parameters(value = {
+            @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
+    })
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "Transformer updated successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+    })
+    int updateTransformer(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Transformer transformer);
 
     @DELETE
     @Path("{schemaId}/transformers/{transformerId}")

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -26,6 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.ResponseStatus;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -67,11 +69,15 @@ public interface SchemaService {
     int idByUri(@PathParam("uri") String uri);
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Save a new Schema")
-    @APIResponse(responseCode = "200", description = "Import a new Schema", content = @Content(schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(type = SchemaType.INTEGER, implementation = Integer.class), example = "103"))
+    @ResponseStatus(201)
+    @APIResponse(responseCode = "201", description = "New schema created successfully", content = @Content(schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(type = SchemaType.INTEGER, implementation = Integer.class), example = "103"))
     Integer add(Schema schema);
+
+    @PUT
+    @Operation(description = "Update an existing Schema")
+    @APIResponse(responseCode = "200", description = "Schema updated successfully", content = @Content(schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(type = SchemaType.INTEGER, implementation = Integer.class), example = "103"))
+    Integer update(Schema schema);
 
     @GET
     @Operation(description = "Retrieve a paginated list of Schemas with available count")

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -760,7 +760,7 @@ public class BaseServiceTest {
         transformer.function = function;
         transformer.targetSchemaUri = postFunctionSchemaUri(schema);
         Integer id = jsonRequest().body(transformer).post("/api/schema/" + schema.id + "/transformers")
-                .then().statusCode(200).extract().as(Integer.class);
+                .then().statusCode(201).extract().as(Integer.class);
         transformer.id = id;
         return transformer;
     }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -505,9 +505,8 @@ public class BaseServiceTest {
         schema.access = Access.PUBLIC;
         schema.name = name + "." + displayName;
         schema.uri = "urn:" + className + ":" + displayName + ":1.0";
-        Integer id = jsonRequest().body(schema).post("/api/schema").then()
-                .statusCode(200).extract().as(Integer.class);
-        schema.id = id;
+        schema.id = jsonRequest().body(schema).post("/api/schema").then()
+                .statusCode(201).extract().as(Integer.class);
 
         if (label) {
             addLabel(schema, "value", null, new Extractor("value", "$.value", false));
@@ -526,7 +525,7 @@ public class BaseServiceTest {
         schema.name = name;
         schema.uri = uri;
         schema.schema = jsonSchema;
-        return addOrUpdateSchema(schema);
+        return addSchema(schema);
     }
 
     protected Schema getSchema(int id, String token) {
@@ -538,8 +537,15 @@ public class BaseServiceTest {
                 .extract().as(Schema.class);
     }
 
-    protected Schema addOrUpdateSchema(Schema schema) {
+    protected Schema addSchema(Schema schema) {
         Response response = jsonRequest().body(schema).post("/api/schema");
+        response.then().statusCode(201);
+        schema.id = Integer.parseInt(response.body().asString());
+        return schema;
+    }
+
+    protected Schema updateSchema(Schema schema) {
+        Response response = jsonRequest().body(schema).put("/api/schema");
         response.then().statusCode(200);
         schema.id = Integer.parseInt(response.body().asString());
         return schema;
@@ -951,7 +957,7 @@ public class BaseServiceTest {
                 readFile(p.resolve("acme_benchmark_schema.json").toFile()), Schema.class);
         assertEquals("dev-team", s.owner);
         s.owner = "foo-team";
-        s = addOrUpdateSchema(s);
+        s = addSchema(s);
 
         Label l = new ObjectMapper().readValue(
                 readFile(p.resolve("throughput_label.json").toFile()), Label.class);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasetServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/DatasetServiceTest.java
@@ -465,7 +465,7 @@ public class DatasetServiceTest extends BaseServiceTest {
         schema.access = Access.PRIVATE;
         schema.name = "private-schema";
         schema.uri = "urn:private";
-        addOrUpdateSchema(schema);
+        addSchema(schema);
         postLabel(schema, "value", null, l -> l.access = Access.PRIVATE, new Extractor("value", "$.value", false));
 
         Test test = createExampleTest("private-test");

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
@@ -1001,7 +1001,7 @@ public class RunServiceTest extends BaseServiceTest {
         schema.name = "Dummy";
         schema.owner = test.owner;
         schema.access = Access.PUBLIC;
-        schema = addOrUpdateSchema(schema);
+        schema = addSchema(schema);
 
         long now = System.currentTimeMillis();
         String ts = String.valueOf(now);
@@ -1046,7 +1046,7 @@ public class RunServiceTest extends BaseServiceTest {
             schema.name = "test";
             schema.owner = test.owner;
             schema.access = Access.PUBLIC;
-            schema = addOrUpdateSchema(schema);
+            schema = addSchema(schema);
 
             //2. Define schema labels
             Label lblCpu = new Label();

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
@@ -115,7 +115,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         schema.id = id;
         schema.name = "urn:dummy:schema:v1";
 
-        int afterUpdateId = schemaService.add(schema);
+        int afterUpdateId = schemaService.update(schema);
         assertEquals(id, afterUpdateId);
 
         SchemaDAO savedSchema = SchemaDAO.findById(id);
@@ -132,9 +132,9 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         schema.id = 9999;
 
         // try to update a not existing schema
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.add(schema));
-        assertEquals("An id was given, but it does not exist.", thrown.getMessage());
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.update(schema));
+        assertEquals("Missing schema id or schema with id 9999 does not exist", thrown.getMessage());
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), thrown.getResponse().getStatus());
     }
 
     @org.junit.jupiter.api.Test

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
@@ -301,7 +301,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
 
         TransformerDAO transformer = TransformerDAO.findById(id);
         assertNotNull(transformer);
@@ -315,11 +315,11 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id1 = schemaService.addOrUpdateTransformer(s.id, t);
+        int id1 = schemaService.addTransformer(s.id, t);
         // create another transformer with different name and additional extractor
         t.name = "Albalb";
         t.extractors.add(new Extractor("z", "$.z", false));
-        int id2 = schemaService.addOrUpdateTransformer(s.id, t);
+        int id2 = schemaService.addTransformer(s.id, t);
 
         TransformerDAO transformer1 = TransformerDAO.findById(id1);
         assertNotNull(transformer1);
@@ -343,7 +343,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
 
         TransformerDAO transformer = TransformerDAO.findById(id);
         assertNotNull(transformer);
@@ -352,7 +352,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         t.id = id;
         t.extractors.add(new Extractor("z", "$.z", false));
 
-        id = schemaService.addOrUpdateTransformer(s.id, t);
+        id = schemaService.updateTransformer(s.id, t);
         transformer = TransformerDAO.findById(id);
         assertNotNull(transformer);
         assertEquals(3, transformer.extractors.size());
@@ -365,7 +365,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, "another-team", "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addOrUpdateTransformer(s.id, t));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addTransformer(s.id, t));
         assertEquals("This user is not a member of team another-team", thrown.getMessage());
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), thrown.getResponse().getStatus());
     }
@@ -377,13 +377,13 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         // empty name
         Transformer t = createSampleTransformer("", s, null, "({x, y}) => ({ z: 1 })");
 
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addOrUpdateTransformer(s.id, t));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addTransformer(s.id, t));
         assertEquals("Transformer must have a name!", thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
 
         // null name
         t.name = null;
-        thrown = assertThrows(ServiceException.class, () -> schemaService.addOrUpdateTransformer(s.id, t));
+        thrown = assertThrows(ServiceException.class, () -> schemaService.addTransformer(s.id, t));
         assertEquals("Transformer must have a name!", thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
     }
@@ -395,7 +395,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
 
         TransformerDAO transformer = TransformerDAO.findById(id);
         assertNotNull(transformer);
@@ -404,7 +404,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         t.id = id;
         t.extractors.add(new Extractor("z", "$.z", false));
 
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addOrUpdateTransformer(999, t));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.updateTransformer(999, t));
         assertTrue(
                 thrown.getMessage().contains(String.format("Transformer id=%d, name=%s belongs to a different schema: %d(%s)",
                         t.id, t.name, s.id, s.uri)));
@@ -418,7 +418,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
         assertEquals(1, TransformerDAO.count());
 
         schemaService.deleteTransformer(s.id, id);
@@ -432,7 +432,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
         assertEquals(1, TransformerDAO.count());
 
         // wrong transformer id, not found
@@ -454,7 +454,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Transformer t = createSampleTransformer("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addOrUpdateTransformer(s.id, t);
+        int id = schemaService.addTransformer(s.id, t);
         assertEquals(1, TransformerDAO.count());
 
         // TODO: create a Test that references this transformer and try to remove it

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
@@ -107,9 +107,10 @@ class SchemaServiceTest extends BaseServiceTest {
         schema.uri = "urn:invalid-id:schema";
         schema.id = 9999; // does not exist
 
+        // expect 201 as the id is cleared up when creating new schema
         jsonRequest().body(schema).post("/api/schema")
                 .then()
-                .statusCode(400);
+                .statusCode(201);
     }
 
     @org.junit.jupiter.api.Test
@@ -232,7 +233,7 @@ class SchemaServiceTest extends BaseServiceTest {
 
         allowAnySchema.schema = allowNone.deepCopy();
         ((ObjectNode) allowAnySchema.schema).set("$id", allowAny.path("$id").deepCopy());
-        addOrUpdateSchema(allowAnySchema);
+        updateSchema(allowAnySchema);
 
         Schema.ValidationEvent runValidation2 = runValidations.poll(10, TimeUnit.SECONDS);
         assertNotNull(runValidation2);
@@ -269,7 +270,7 @@ class SchemaServiceTest extends BaseServiceTest {
 
         schema.name = "Different name";
         schema.description = "Bla bla";
-        schema = addOrUpdateSchema(schema);
+        schema = updateSchema(schema);
         checkEntities(labelId, transformerId);
         //check labels and transformers using the rest interface as well
         labels = jsonRequest().get("/api/schema/" + schema.id + "/labels")
@@ -283,13 +284,13 @@ class SchemaServiceTest extends BaseServiceTest {
 
         schema.uri = "http://example.com/otherschema";
         schema.description = null;
-        addOrUpdateSchema(schema);
+        updateSchema(schema);
         checkEntities(labelId, transformerId);
 
         // back to original
         schema.name = "My schema";
         schema.uri = "urn:my:schema";
-        schema = addOrUpdateSchema(schema);
+        schema = updateSchema(schema);
         assertEquals("urn:my:schema", schema.uri);
         checkEntities(labelId, transformerId);
 
@@ -659,7 +660,7 @@ class SchemaServiceTest extends BaseServiceTest {
 
         // update the schema uri afterward
         schema.uri = "urn:new-dummy:schema";
-        Schema updatedSchema = addOrUpdateSchema(schema);
+        Schema updatedSchema = updateSchema(schema);
         assertNotNull(updatedSchema);
         assertEquals(schema.id, updatedSchema.id);
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceTest.java
@@ -420,7 +420,7 @@ class SchemaServiceTest extends BaseServiceTest {
 
         // add another extractor
         t.extractors.add(new Extractor("z", "$.z", false));
-        Integer id = jsonRequest().body(t).post("/api/schema/" + schema.id + "/transformers")
+        Integer id = jsonRequest().body(t).put("/api/schema/" + schema.id + "/transformers")
                 .then().statusCode(200).extract().as(Integer.class);
 
         TransformerDAO transformer = TransformerDAO.findById(id);
@@ -441,7 +441,7 @@ class SchemaServiceTest extends BaseServiceTest {
         t.extractors.add(new Extractor("z", "$.z", false));
         jsonRequest()
                 .auth().oauth2(getAdminToken())
-                .body(t).post("/api/schema/" + schema.id + "/transformers")
+                .body(t).put("/api/schema/" + schema.id + "/transformers")
                 .then().statusCode(403);
     }
 

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceWithAsyncProcessingTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceWithAsyncProcessingTest.java
@@ -111,8 +111,8 @@ class TestServiceWithAsyncProcessingTest extends BaseServiceTest {
         String name = info.getTestClass().map(Class::getName).orElse("<unknown>") + "." + info.getDisplayName();
         Schema schema = createSchema(name, uriForTest(info, "1.0"));
 
-        addLabel(schema, "filter-1", null, true, false, new Extractor("filter", "$.filter1", false));
-        addLabel(schema, "filter-2", null, true, false, new Extractor("filter", "$.filter2", false));
+        addLabel(schema, "filter-1", null, new Extractor("filter", "$.filter1", false));
+        addLabel(schema, "filter-2", null, new Extractor("filter", "$.filter2", false));
 
         BlockingQueue<Dataset.LabelsUpdatedEvent> newDatasetQueue = serviceMediator
                 .getEventQueue(AsyncEventChannels.DATASET_UPDATED_LABELS, test.id);

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -278,7 +278,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblCpu.owner = dummyTest.owner;
             lblCpu.metrics = true;
             lblCpu.filtering = false;
-            lblCpu.id = horreumClient.schemaService.addOrUpdateLabel(schema.id, lblCpu);
+            lblCpu.id = horreumClient.schemaService.addLabel(schema.id, lblCpu);
 
             Label lblThroughput = new Label();
             lblThroughput.name = "throughput";
@@ -288,7 +288,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblThroughput.owner = dummyTest.owner;
             lblThroughput.metrics = true;
             lblThroughput.filtering = false;
-            lblThroughput.id = horreumClient.schemaService.addOrUpdateLabel(schema.id, lblThroughput);
+            lblThroughput.id = horreumClient.schemaService.addLabel(schema.id, lblThroughput);
 
             Label lblJob = new Label();
             lblJob.name = "job";
@@ -298,7 +298,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblJob.owner = dummyTest.owner;
             lblJob.metrics = false;
             lblJob.filtering = true;
-            lblJob.id = horreumClient.schemaService.addOrUpdateLabel(schema.id, lblJob);
+            lblJob.id = horreumClient.schemaService.addLabel(schema.id, lblJob);
 
             Label lblBuildID = new Label();
             lblBuildID.name = "build-id";
@@ -308,7 +308,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblBuildID.owner = dummyTest.owner;
             lblBuildID.metrics = false;
             lblBuildID.filtering = true;
-            lblBuildID.id = horreumClient.schemaService.addOrUpdateLabel(schema.id, lblBuildID);
+            lblBuildID.id = horreumClient.schemaService.addLabel(schema.id, lblBuildID);
 
             //3. Config change detection variables
             Variable variable = new Variable();

--- a/horreum-web/src/domain/schemas/Labels.tsx
+++ b/horreum-web/src/domain/schemas/Labels.tsx
@@ -69,7 +69,7 @@ export default function Labels({ schemaId, schemaUri, funcsRef }: LabelsProps) {
                 ...labels
                     .filter(l => l.modified)
                     .map(l =>
-                        schemaApi.addOrUpdateLabel(l.schemaId, l).then(id => {
+                        (l.id > 0 ? schemaApi.updateLabel(l.schemaId, l) : schemaApi.addLabel(l.schemaId, l)).then(id => {
                             l.id = id
                             l.modified = false
                         })

--- a/horreum-web/src/domain/schemas/Transformers.tsx
+++ b/horreum-web/src/domain/schemas/Transformers.tsx
@@ -93,10 +93,11 @@ export default function Transformers(props: TransformersProps) {
                 ...transformers
                     .filter(t => t.modified)
                     .map(t =>
-                        schemaApi.addOrUpdateTransformer(t.schemaId, t).then(id => {
-                            t.id = id
-                            t.modified = false
-                        })
+                        (t.id > 0 ? schemaApi.updateTransformer(t.schemaId, t) : schemaApi.addTransformer(t.schemaId, t))
+                            .then(id => {
+                                t.id = id
+                                t.modified = false
+                            })
                     ),
                 ...deleted.map(t =>
                     schemaApi.deleteTransformer(t.schemaId, t.id).catch(e => {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

**Schema**
- [x] Split `add` and `update` APIs for Schema creation and update
- [x] Use `POST` for creation
- [x] Use `PUT` for update
- [x] Return 201 for creation
- [x] Return 200 for update
- [x] Update the tests accordingly
- [x] Update the UI

**Labels**
- [x] Split `add` and `update` APIs for Schema Labels creation and update
- [x] Use `POST` for creation
- [x] Use `PUT` for update
- [x] Return 201 for creation
- [x] Return 200 for update
- [x] Update the tests accordingly
- [x] Update the UI

**Transformers**
- [x] Split `add` and `update` APIs for Schema Transformers creation and update
- [x] Use `POST` for creation
- [x] Use `PUT` for update
- [x] Return 201 for creation
- [x] Return 200 for update
- [x] Update the tests accordingly
- [x] Update the UI

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
