### PR TITLE
Visually distinguish confirmed changes with green dots

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/internal/services/AlertingService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/internal/services/AlertingService.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -49,7 +50,7 @@ public interface AlertingService {
     List<Change> changes(@Parameter(required = true) @QueryParam("var") int varId,
             @QueryParam("fingerprint") String fingerprint);
 
-    @POST
+    @PUT
     @Path("change/{id}")
     void updateChange(@Parameter(required = true) @PathParam("id") int id,
             @RequestBody(required = true) Change change);

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/ChangeDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/alerting/ChangeDAO.java
@@ -21,7 +21,7 @@ import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 /**
  * This marks certain run as following a change (regression) in tested criterion.
  * Change is not necessarily a negative one - e.g. improvement in throughput is still
- * a change to faciliate correct testing of subsequent runs.
+ * a change to facilitate correct testing of subsequent runs.
  * Eventually the change should be manually confirmed (approved) with an explanatory description.
  */
 @Entity(name = "Change")

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -969,22 +969,13 @@ public class AlertingServiceImpl implements AlertingService {
     @WithRoles
     @RolesAllowed(Roles.TESTER)
     @Transactional
-    public void updateChange(int id, Change apiChange) {
-        try {
-            if (id != apiChange.id) {
-                throw ServiceException.badRequest("Path ID and entity don't match");
-            }
-            ChangeDAO jpaChange = em.find(ChangeDAO.class, id);
-            if (jpaChange != null) {
-                jpaChange.confirmed = apiChange.confirmed;
-                em.merge(jpaChange);
-            } else {
-                throw new WebApplicationException(String.format("Could not find change with ID: %s", id));
-            }
-
-        } catch (PersistenceException e) {
-            throw new WebApplicationException(e, Response.serverError().build());
+    public void updateChange(int changeId, Change changeDTO) {
+        if (changeId != changeDTO.id) {
+            throw ServiceException.badRequest("Path ID and entity ID don't match");
         }
+        ChangeDAO change = ChangeDAO.<ChangeDAO> findByIdOptional(changeId)
+                .orElseThrow(() -> ServiceException.notFound("Change with id " + changeDTO.id + " not found"));
+        change.confirmed = changeDTO.confirmed;
     }
 
     @Override

--- a/horreum-web/src/domain/alerting/PanelChart.tsx
+++ b/horreum-web/src/domain/alerting/PanelChart.tsx
@@ -164,14 +164,16 @@ export default function PanelChart({
                     }
                 }
                 if (value != undefined) {
+                    // this is a trick to see whether the change has been confirmed or not
+                    const isConfirmed = a.text?.includes("Confirmed: true") || false
                     return (
                         <ReferenceDot
                             key={a.changeId}
                             x={a.time}
                             y={value}
                             r={8}
-                            stroke="red"
-                            fill="red"
+                            stroke={isConfirmed ? "green" : "red"}
+                            fill={isConfirmed ? "green" : "red"}
                             fillOpacity={0.3}
                             onClick={() => onChangeSelected(a.changeId || 0, a.variableId || 0, a.runId || 0)}
                         />


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2096

## Changes proposed

- [x] Visually display confirmed changes are **green** dots rather than **red**
- [x] Refactor the `updateChange` backend method

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
