### PR TITLE
Improve datasets comparison UI

### DIFF
--- a/horreum-web/src/domain/runs/DatasetComparison.tsx
+++ b/horreum-web/src/domain/runs/DatasetComparison.tsx
@@ -2,13 +2,15 @@ import { SetStateAction, useContext, useEffect, useMemo, useRef, useState } from
 import { useSelector } from "react-redux"
 import {
     ActionGroup,
+    Breadcrumb,
+    BreadcrumbItem,
     Bullseye,
     Card,
     CardBody,
     EmptyState,
     EmptyStateBody,
     PageSection,
-    Spinner,
+    Spinner, Toolbar, ToolbarContent,
 } from "@patternfly/react-core"
 import {
     Caption,
@@ -25,7 +27,7 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import { NavLink } from "react-router-dom"
+import { Link, NavLink } from "react-router-dom"
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, YAxis } from "recharts"
 
 import {datasetApi, fetchTest, fetchViews, Test, View} from "../../api"
@@ -105,6 +107,24 @@ export default function DatasetComparison() {
 
     return (
         <PageSection>
+            <Toolbar>
+                <ToolbarContent>
+                    <Breadcrumb>
+                        <BreadcrumbItem>
+                            <Link to="/test">Tests</Link>
+                        </BreadcrumbItem>
+                        {test?.folder && (
+                            <BreadcrumbItem>
+                                <Link to={`/test?folder=${test.folder!}`}>{test.folder}</Link>
+                            </BreadcrumbItem>
+                        )}
+                        <BreadcrumbItem>
+                            <Link to={`/test/${test?.id}#data`}>{test?.name || "undefined"}</Link>
+                        </BreadcrumbItem>
+                        <BreadcrumbItem>Datasets comparison</BreadcrumbItem>
+                    </Breadcrumb>
+                </ToolbarContent>
+            </Toolbar>
             <Card>
                 <CardBody>
                     {headers.length <= 1 ? (

--- a/horreum-web/src/domain/runs/TestDatasets.tsx
+++ b/horreum-web/src/domain/runs/TestDatasets.tsx
@@ -119,7 +119,7 @@ export default function TestDatasets() {
     const pagination = useMemo(() => ({ page, perPage, sortBy }), [page, perPage, sortBy])
     const [loading, setLoading] = useState(false)
     const [datasets, setDatasets] = useState<DatasetList>()
-    const [comparedDatasets, setComparedDatasets] = useState<DatasetSummary[]>()
+    const [comparedDatasets, setComparedDatasets] = useState<DatasetSummary[]>([])
     const teams = useSelector(teamsSelector)
     const token = useSelector(tokenSelector)
 
@@ -158,33 +158,32 @@ export default function TestDatasets() {
 
     const columns = useMemo(() => {
         const allColumns = [...staticColumns]
-        if (comparedDatasets) {
-            allColumns.unshift({
-                Header: "",
-                accessor: "id",
-                disableSortBy: true,
-                Cell: (arg: CellProps<DatasetSummary>) => {
-                    if (comparedDatasets.some(ds => ds.id === arg.cell.value)) {
-                        return (
-                            <Button
-                                variant="secondary"
-                                onClick={() =>
-                                    setComparedDatasets(comparedDatasets.filter(ds => ds.id !== arg.cell.value))
-                                }
-                            >
-                                Remove
-                            </Button>
-                        )
-                    } else {
-                        return (
-                            <Button onClick={() => setComparedDatasets([...comparedDatasets, arg.row.original])}>
-                                Add to comparison
-                            </Button>
-                        )
-                    }
-                },
-            })
-        }
+        allColumns.unshift({
+            Header: "",
+            accessor: "id",
+            disableSortBy: true,
+            Cell: (arg: CellProps<DatasetSummary>) => {
+                if (comparedDatasets.some(ds => ds.id === arg.cell.value)) {
+                    return (
+                        <Button
+                            variant="secondary"
+                            onClick={() =>
+                                setComparedDatasets(comparedDatasets.filter(ds => ds.id !== arg.cell.value))
+                            }
+                        >
+                            Remove
+                        </Button>
+                    )
+                } else {
+                    return (
+                        <Button onClick={() => setComparedDatasets([...comparedDatasets, arg.row.original])}>
+                            Compare
+                        </Button>
+                    )
+                }
+            },
+        })
+
         const view = views?.find(v => v.id === viewId) || views?.at(0)
         const components = view?.components || []
         components.forEach(vc => {
@@ -248,20 +247,18 @@ export default function TestDatasets() {
                         </Flex>
                     </ToolbarItem>
 
-                    <ToolbarItem>
-                        <Button
-                            variant="secondary"
-                            onClick={() => {
-                                if (comparedDatasets) {
-                                    setComparedDatasets(undefined)
-                                } else {
+                    {comparedDatasets.length > 0 && (
+                        <ToolbarItem>
+                            <Button
+                                variant="secondary"
+                                onClick={() => {
                                     setComparedDatasets([])
-                                }
-                            }}
-                        >
-                            {comparedDatasets ? "Cancel comparison" : "Select for comparison"}
-                        </Button>
-                    </ToolbarItem>
+                                }}
+                            >
+                                Clear comparison
+                            </Button>
+                        </ToolbarItem>
+                    )}
                 </ToolbarGroup>
             </ToolbarContent>
         </Toolbar>
@@ -271,7 +268,7 @@ export default function TestDatasets() {
         <>
             {toolbar}
 
-            {(comparedDatasets) && (
+            {(comparedDatasets.length > 0) && (
                 <PageSection variant="default" isCenterAligned>
 
                 {comparedDatasets && comparedDatasets.length > 0 && (

--- a/horreum-web/src/domain/tests/Test.tsx
+++ b/horreum-web/src/domain/tests/Test.tsx
@@ -142,7 +142,6 @@ export default function TestView() {
                             >
                                 <TestDatasets/>
                             </SavedTab>
-
                             <SavedTab
                                 title="Changes"
                                 fragment="changes"
@@ -152,9 +151,7 @@ export default function TestView() {
                                 onSave={() => Promise.resolve()}
                                 onReset={() => Promise.resolve()}
                             >
-
                                 <Changes testID={testIdVal}/>
-
                             </SavedTab>
 
                             <SavedTab


### PR DESCRIPTION
Keep the test navigation bar
Make the datasets comparisons always enabled

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/1882

## Changes proposed

- [ ] Kept the original test navigation bar on top
- [ ] Refactor the UI to keep the datasets comparison always enabled

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
