### PR TITLE
Show datapoints till the first 2 non-zero decimals

### DIFF
--- a/horreum-web/src/domain/alerting/PanelChart.tsx
+++ b/horreum-web/src/domain/alerting/PanelChart.tsx
@@ -24,9 +24,15 @@ function tsToDate(timestamp: number) {
 }
 
 function formatValue(value: number | string) {
+    // string version of the value
+    let valueAsString
     if (typeof value === "string") {
+        valueAsString = value;
         value = parseInt(value)
+    } else {
+        valueAsString = value.toString()
     }
+
     let suffix = ""
     if (value > 10000000) {
         value /= 1000000
@@ -36,7 +42,22 @@ function formatValue(value: number | string) {
         value /= 1000
         suffix = " k"
     }
-    return Number(value).toFixed(2) + suffix
+
+    value = Number(value)
+
+    const [_, decPart] = valueAsString.split(".")
+    let nonZeroIdx = 0
+    if (decPart) {
+        // set a limit to 10 decimal digits
+        for (nonZeroIdx; nonZeroIdx < 10; nonZeroIdx++) {
+            if (decPart[nonZeroIdx] != "0") {
+                // exit at the first non-zero digit
+                break;
+            }
+        }
+    }
+
+    return value.toFixed(nonZeroIdx+2) + suffix
 }
 
 function ellipsis(str: string) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2140

## Changes proposed

- [x] Show datapoints truncated at the first 2 non-zero decimals
- [x] Limit that check to 10 decimals

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
