### PR TITLE
[0.17] Fix the return type of Run.add to be array of ints

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/RunService.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.ResponseStatus;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.Separator;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
@@ -166,13 +167,14 @@ public interface RunService {
             @Parameter(name = "access", description = "New Access level", example = "0"),
     })
     @RequestBody(name = "runBody", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Run.class)), required = true)
+    @ResponseStatus(202) // ACCEPTED
     @APIResponses(value = {
             @APIResponse(responseCode = "202", description = "The request has been accepted for processing. Returns a list of created run IDs if available, "
                     + "or an empty list if processing is still ongoing. Label values and change detection processing " +
                     "is performed asynchronously.", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = Integer.class, example = "[101, 102, 103]"), example = "[101, 102, 103]")),
             @APIResponse(responseCode = "400", description = "Some fields are missing or invalid", content = @Content(mediaType = MediaType.APPLICATION_JSON))
     })
-    Response add(@QueryParam("test") String testNameOrId,
+    List<Integer> add(@QueryParam("test") String testNameOrId,
             @QueryParam("owner") String owner,
             @QueryParam("access") Access access,
             Run run);

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -35,7 +35,6 @@ import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -382,7 +381,7 @@ public class RunServiceImpl implements RunService {
     @RolesAllowed(Roles.UPLOADER)
     @WithRoles
     @Override
-    public Response add(String testNameOrId, String owner, Access access, Run run) {
+    public List<Integer> add(String testNameOrId, String owner, Access access, Run run) {
         if (owner != null) {
             run.owner = owner;
         }
@@ -392,7 +391,7 @@ public class RunServiceImpl implements RunService {
         log.debugf("About to add new run to test %s using owner", testNameOrId, owner);
         if (testNameOrId == null || testNameOrId.isEmpty()) {
             if (run.testid == null || run.testid == 0) {
-                return Response.status(Response.Status.BAD_REQUEST).entity("No test name or id provided").build();
+                throw ServiceException.badRequest("No test name or id provided");
             } else
                 testNameOrId = run.testid.toString();
         }
@@ -408,9 +407,7 @@ public class RunServiceImpl implements RunService {
                 Log.warnf("Dataset with id %d not found, cannot process it", dsId);
             }
         });
-        return Response.status(Response.Status.ACCEPTED).entity(String.valueOf(runPersistence.runId))
-                .header(HttpHeaders.LOCATION, "/run/" + runPersistence.runId)
-                .build();
+        return Collections.singletonList(runPersistence.runId);
     }
 
     @Override

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -632,7 +632,7 @@ public class BaseServiceTest {
                         .oauth2(getUploaderToken())
                         .body(run)
                         .post("/api/run/test");
-                run.id = response.body().as(Integer.class);
+                run.id = (int) response.body().as(List.class).get(0);
                 log.debugf("Run ID: %d, for test ID: %d", run.id, run.testid);
             } finally {
                 if (tm.getTransaction().getStatus() == Status.STATUS_ACTIVE) {
@@ -961,7 +961,7 @@ public class BaseServiceTest {
                 .body(r)
                 .post("/api/run/test");
         assertEquals(202, response.statusCode());
-
+        assertEquals(1, response.getBody().as(List.class).size());
     }
 
     String readFile(File file) {

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceNoRestTest.java
@@ -9,8 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -108,9 +109,8 @@ class RunServiceNoRestTest extends BaseServiceNoRestTest {
     private int uploadRun(int testId, String owner, JsonNode runData) {
         Run run = createSampleRun(testId, runData, owner);
 
-        try (Response resp = runService.add(String.valueOf(testId), owner, Access.PUBLIC, run)) {
-            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
-            return Integer.parseInt(resp.getEntity().toString());
-        }
+        List<Integer> runIds = runService.add(String.valueOf(testId), owner, Access.PUBLIC, run);
+        assertEquals(1, runIds.size());
+        return runIds.get(0);
     }
 }

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceNoRestTest.java
@@ -515,11 +515,7 @@ class TestServiceNoRestTest extends BaseServiceNoRestTest {
         assertEquals(1, TestDAO.count());
 
         Run run1 = createSampleRun(created1.id, JsonNodeFactory.instance.objectNode(), FOO_TEAM);
-        int runId;
-        try (Response resp = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1)) {
-            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
-            runId = Integer.parseInt(resp.getEntity().toString());
-        }
+        int runId = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1).get(0);
         assertEquals(1, RunDAO.count());
 
         // flush data
@@ -544,11 +540,7 @@ class TestServiceNoRestTest extends BaseServiceNoRestTest {
         assertEquals(1, TestDAO.count());
 
         Run run1 = createSampleRun(created1.id, JsonNodeFactory.instance.objectNode(), FOO_TEAM);
-        int runId;
-        try (Response resp = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1)) {
-            assertEquals(Response.Status.ACCEPTED.getStatusCode(), resp.getStatus());
-            runId = Integer.parseInt(resp.getEntity().toString());
-        }
+        int runId = runService.add(created1.name, FOO_TEAM, Access.PUBLIC, run1).get(0);
         assertEquals(1, RunDAO.count());
 
         // flush data


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Backport https://github.com/Hyperfoil/Horreum/pull/2326

## Fixes Issue

The method `Run.addRun` was properly configured to return an array of ints but the implementation was returning it as String.

This is causing some issues on the auto generate Python client as it is expecting an array but getting a single element instead - The same problem does not happen in Golang as for some reason it is able to parse it anyway.

This method is not used anywhere in the source code, nor in the Jenkins plugin.

## Changes proposed

- [x] Simply return the List (with one single element though to avoid breaking the API)
- [x] Do not add any header as not actually required (especially because not used)

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
