### PR TITLE
Trash/restore a run from run page

### DIFF
--- a/horreum-web/src/api.tsx
+++ b/horreum-web/src/api.tsx
@@ -345,7 +345,7 @@ export function recalculateDatasets(id: number, testid: number, alerting: AlertC
     return apiCall(runApi.recalculateRunDatasets(id), alerting, "RECALCULATE_DATASETS", "Failed to recalculate datasets");
 }
 
-export function trash(alerting: AlertContextType, id: number, testid: number, isTrashed = true) : Promise<void> {
+export function trash(alerting: AlertContextType, id: number, isTrashed = true) : Promise<void> {
     return apiCall(runApi.trash(id, isTrashed), alerting, "RUN_TRASH", "Failed to trash run ID " + id);
 }
 

--- a/horreum-web/src/components/ConfirmRestoreModal.tsx
+++ b/horreum-web/src/components/ConfirmRestoreModal.tsx
@@ -1,0 +1,57 @@
+import {useState} from "react"
+
+import {Button, Modal, Spinner, Split, SplitItem, Stack, StackItem} from "@patternfly/react-core"
+
+type ConfirmRestoreModalProps = {
+    isOpen: boolean
+    onClose(): void
+    onRestore(): Promise<any>
+    description: string
+    extra?: string
+    restoreButtonText?: string
+}
+
+export default function ConfirmRestoreModal({isOpen, onClose, onRestore, description, extra, restoreButtonText}: ConfirmRestoreModalProps) {
+    const [restoring, setRestoring] = useState(false)
+    return (
+        <Modal variant="small" title="Confirm Restore" isOpen={isOpen} onClose={onClose}>
+
+            <Stack hasGutter>
+                <StackItem>
+                    <div>Do you really want to { restoreButtonText?.toLowerCase() ?? "restore"} {description}?</div>
+                </StackItem>
+                <StackItem>{extra}</StackItem>
+                <StackItem>
+                    <Split hasGutter>
+                        <SplitItem>
+                            <Button
+                                isDisabled={restoring}
+                                variant="primary"
+                                onClick={() => {
+                                    setRestoring(true)
+                                    onRestore().finally(() => {
+                                        setRestoring(false)
+                                        onClose()
+                                    })
+                                }}
+                            >
+                                {restoreButtonText ?? "Restore"}
+                                {restoring && (
+                                    <>
+                                        {" "}
+                                        <Spinner size="md"/>
+                                    </>
+                                )}
+                            </Button></SplitItem>
+                        <SplitItem>
+                            <Button variant="secondary" onClick={onClose}>
+                                Cancel
+                            </Button>
+                        </SplitItem>
+                    </Split>
+
+                </StackItem>
+            </Stack>
+        </Modal>
+    )
+}

--- a/horreum-web/src/domain/runs/RunList.tsx
+++ b/horreum-web/src/domain/runs/RunList.tsx
@@ -16,7 +16,7 @@ import { NavLink } from "react-router-dom"
 import { Duration } from "luxon"
 import { toEpochMillis, noop } from "../../utils"
 
-import { teamsSelector, teamToName } from "../../auth"
+import {isAuthenticatedSelector, teamsSelector, teamToName} from "../../auth"
 
 import { fetchTest } from "../../api"
 
@@ -46,6 +46,7 @@ export default function RunList() {
     const { alerting } = useContext(AppContext) as AppContextType;
     const { testId } = useParams()
     const testIdInt = parseInt(testId ?? "-1")
+    const isAuthenticated = useSelector(isAuthenticatedSelector)
 
     const [test, setTest] = useState<Test | undefined>(undefined)
     const [selectedRows, setSelectedRows] = useState<Record<string, boolean>>({})
@@ -241,18 +242,20 @@ export default function RunList() {
                             onChange={(_event, val) => setShowTrashed(!showTrashed)}
                         />
                     </ToolbarItem>
-                    <ToolbarItem>
-                        <Split hasGutter>
-                            <SplitItem>
-                                <Button
-                                    isDisabled={false}
-                                    variant="primary"
-                                    onClick={toggleNewRunModal}
-                                >
-                                    Import Data
-                                </Button></SplitItem>
-                        </Split>
-                    </ToolbarItem>
+                    {isAuthenticated &&
+                        <ToolbarItem>
+                            <Split hasGutter>
+                                <SplitItem>
+                                    <Button
+                                        isDisabled={false}
+                                        variant="primary"
+                                        onClick={toggleNewRunModal}
+                                    >
+                                        Import Data
+                                    </Button></SplitItem>
+                            </Split>
+                        </ToolbarItem>
+                    }
                     {test && test.compareUrl && (
                         <ToolbarItem>
                             <Button

--- a/horreum-web/src/domain/runs/components.tsx
+++ b/horreum-web/src/domain/runs/components.tsx
@@ -86,7 +86,7 @@ function useRestore(run: RunSummary): MenuItem<RunSummary> {
                         key="restore"
                         onClick={() => {
                             close()
-                            trash(alerting, run.id, run.testid, false).then()
+                            trash(alerting, run.id, false).then()
                         }}
                     >
                         Restore
@@ -165,7 +165,7 @@ export function Menu(run: RunSummary, refreshCallback: () => void, clearSelected
         onAccessUpdate: (id, owner, access) => updateRunAccess(id, run.testid, owner, access, alerting).then(refreshCallback),
     })
     const del = useDelete({
-        onDelete: id => trash(alerting, id, run.testid).then(refreshCallback)
+        onDelete: id => trash(alerting, id).then(refreshCallback)
             .then(clearSelected),
     })
     const recalculate = useRecalculateDatasets(run)


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2331

## Changes proposed

- [x] Make run delete/restore operations available in the Run page
- [x] Show "Import Data" if authenticated
- [x] Fix `trash()` frontend api by removing unnecessary `testId` param

![image](https://github.com/user-attachments/assets/506178cb-e206-4b38-b117-f166f3a73edc)
![image](https://github.com/user-attachments/assets/384347cd-7118-4bf3-9c5d-35f4b72c6239)


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
