### PR TITLE
Inherit quarkus-test-keycloak-server from quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,6 @@
         <quinoa.version>2.5.3</quinoa.version>
         <surefire-plugin.version>3.5.3</surefire-plugin.version>
         <failsafe-plugin.version>3.5.3</failsafe-plugin.version>
-        <keycloak-admin-client.version>23.0.3</keycloak-admin-client.version>
-        <quarkus-test-keycloak.version>3.14.4</quarkus-test-keycloak.version>
         <validator.version>1.5.6</validator.version>
         <jayway.jsonpath.version>2.9.0</jayway.jsonpath.version>
 
@@ -248,14 +246,6 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-authz-client</artifactId>
                 <version>${keycloak.version}</version>
-            </dependency>
-
-            <!-- Force quarkus test keycloak server -->
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-test-keycloak-server</artifactId>
-                <version>${quarkus-test-keycloak.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Looks like we don't need to specify an older version of `quarkus-test-keycloak-server` to make ITs working.

## Changes proposed

- [ ] Remove the explicit `quarkus-test-keycloak-server` dependency
- [ ] Remove unused `keycloak-admin-client.version` version property

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
