### PR TITLE
[0.18] Create custom action events enum

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/converter/ActionEventConverter.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/converter/ActionEventConverter.java
@@ -1,0 +1,20 @@
+package io.hyperfoil.tools.horreum.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import io.hyperfoil.tools.horreum.svc.ActionEvent;
+
+@Converter(autoApply = true)
+public class ActionEventConverter implements AttributeConverter<ActionEvent, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ActionEvent attribute) {
+        return attribute != null ? attribute.getValue() : null;
+    }
+
+    @Override
+    public ActionEvent convertToEntityAttribute(String dbData) {
+        return dbData != null ? ActionEvent.fromValue(dbData) : null;
+    }
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/ActionDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/data/ActionDAO.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.horreum.entity.data;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
@@ -10,8 +11,10 @@ import org.hibernate.annotations.Type;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import io.hyperfoil.tools.horreum.converter.ActionEventConverter;
 import io.hyperfoil.tools.horreum.entity.CustomSequenceGenerator;
 import io.hyperfoil.tools.horreum.hibernate.JsonBinaryType;
+import io.hyperfoil.tools.horreum.svc.ActionEvent;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity(name = "Action")
@@ -22,7 +25,8 @@ public class ActionDAO extends PanacheEntityBase {
 
     @NotNull
     @Column(name = "event")
-    public String event;
+    @Convert(converter = ActionEventConverter.class)
+    public ActionEvent event;
 
     /*
      * The type options were found in horreum-web/src/domain/actions/ActionComponentForm.tsx#L73
@@ -68,7 +72,7 @@ public class ActionDAO extends PanacheEntityBase {
     public ActionDAO() {
     }
 
-    public ActionDAO(Integer id, String event, String type, ObjectNode config, ObjectNode secrets,
+    public ActionDAO(Integer id, ActionEvent event, String type, ObjectNode config, ObjectNode secrets,
             Integer testId, boolean active, boolean runAlways) {
         this.id = id;
         this.event = event;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/ActionMapper.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/mapper/ActionMapper.java
@@ -2,17 +2,18 @@ package io.hyperfoil.tools.horreum.mapper;
 
 import io.hyperfoil.tools.horreum.api.data.Action;
 import io.hyperfoil.tools.horreum.entity.data.ActionDAO;
+import io.hyperfoil.tools.horreum.svc.ActionEvent;
 
 public class ActionMapper {
 
     public static Action from(ActionDAO action) {
-        return new Action(action.id, action.event, action.type,
+        return new Action(action.id, action.event.getValue(), action.type,
                 action.config, action.secrets, action.testId, action.active, action.runAlways);
 
     }
 
     public static ActionDAO to(Action action) {
-        return new ActionDAO(action.id, action.event, action.type,
+        return new ActionDAO(action.id, ActionEvent.fromValue(action.event), action.type,
                 action.config, action.secrets, action.testId, action.active, action.runAlways);
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionEvent.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionEvent.java
@@ -1,0 +1,33 @@
+package io.hyperfoil.tools.horreum.svc;
+
+public enum ActionEvent {
+    TEST_NEW("test/new"),
+    RUN_NEW("run/new"),
+    CHANGE_NEW("change/new"),
+    EXPERIMENT_RESULT_NEW("experiment_result/new"),;
+
+    // this represents the value stored in the database
+    private final String value;
+
+    ActionEvent(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    public static ActionEvent fromValue(String value) {
+        for (ActionEvent event : ActionEvent.values()) {
+            if (event.getValue().equals(value)) {
+                return event;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -796,9 +796,9 @@ public class BaseServiceTest {
                 .body(prefix).post("/api/action/allowedSites").then().statusCode(200);
     }
 
-    protected Response addTestHttpAction(Test test, AsyncEventChannels event, String url) {
+    protected Response addTestHttpAction(Test test, ActionEvent event, String url) {
         Action action = new Action();
-        action.event = event.name();
+        action.event = event.getValue();
         action.type = HttpAction.TYPE_HTTP;
         action.active = true;
         action.testId = test.id;
@@ -806,10 +806,10 @@ public class BaseServiceTest {
         return jsonRequest().auth().oauth2(getTesterToken()).body(action).post("/api/action");
     }
 
-    protected Response addTestGithubIssueCommentAction(Test test, AsyncEventChannels event, String formatter, String owner,
+    protected Response addTestGithubIssueCommentAction(Test test, ActionEvent event, String formatter, String owner,
             String repo, String issue, String secretToken) {
         Action action = new Action();
-        action.event = event.name();
+        action.event = event.getValue();
         action.type = GitHubIssueCommentAction.TYPE_GITHUB_ISSUE_COMMENT;
         action.active = true;
         action.config = JsonNodeFactory.instance.objectNode()
@@ -821,9 +821,9 @@ public class BaseServiceTest {
         return jsonRequest().body(action).post("/api/test/" + test.id + "/action");
     }
 
-    protected Response addGlobalAction(AsyncEventChannels event, String url) {
+    protected Response addGlobalAction(ActionEvent event, String url) {
         Action action = new Action();
-        action.event = event.name();
+        action.event = event.getValue();
         action.type = "http";
         action.active = true;
         action.config = JsonNodeFactory.instance.objectNode().put("url", url);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/TestServiceTest.java
@@ -1,11 +1,6 @@
 package io.hyperfoil.tools.horreum.svc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -186,11 +181,11 @@ class TestServiceTest extends BaseServiceTest {
                 .get("/api/log/action/" + test.id).then().statusCode(200).extract().body().jsonPath().getList(".");
         assertFalse(actionLog.isEmpty());
 
-        addTestHttpAction(test, AsyncEventChannels.RUN_NEW, "https://attacker.com").then().statusCode(400);
+        addTestHttpAction(test, ActionEvent.RUN_NEW, "https://attacker.com").then().statusCode(400);
 
         addAllowedSite("https://example.com");
 
-        Action action = addTestHttpAction(test, AsyncEventChannels.RUN_NEW, "https://example.com/foo/bar").then()
+        Action action = addTestHttpAction(test, ActionEvent.RUN_NEW, "https://example.com/foo/bar").then()
                 .statusCode(200).extract().body().as(Action.class);
         assertNotNull(action.id);
         assertTrue(action.active);
@@ -244,8 +239,8 @@ class TestServiceTest extends BaseServiceTest {
         view.testId = test.id;
         updateView(view);
 
-        addTestHttpAction(test, AsyncEventChannels.RUN_NEW, "http://example.com");
-        addTestGithubIssueCommentAction(test, AsyncEventChannels.EXPERIMENT_RESULT_NEW,
+        addTestHttpAction(test, ActionEvent.RUN_NEW, "http://example.com");
+        addTestGithubIssueCommentAction(test, ActionEvent.EXPERIMENT_RESULT_NEW,
                 ExperimentResultToMarkdown.NAME, "hyperfoil", "horreum", "123", "super-secret-github-token");
 
         addChangeDetectionVariable(test, schema.id);


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2348

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2347

## Changes proposed

- [x] Create ad-hoc `ActionEvent` enum with proper db mapping
- [x] Don't use `AsyncEventChannel` as webhook events

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
