### PR TITLE
Update the HorreumClient Run service

### DIFF
--- a/horreum-client/src/main/java/io/hyperfoil/tools/RunServiceExtension.java
+++ b/horreum-client/src/main/java/io/hyperfoil/tools/RunServiceExtension.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.hyperfoil.tools.horreum.api.SortDirection;
 import io.hyperfoil.tools.horreum.api.client.RunService;
 import io.hyperfoil.tools.horreum.api.data.Access;
+import io.hyperfoil.tools.horreum.api.data.ExportedLabelValues;
 import io.hyperfoil.tools.horreum.api.data.Run;
 import io.hyperfoil.tools.horreum.api.services.RunService.RunCount;
 import io.hyperfoil.tools.horreum.api.services.RunService.RunSummary;
@@ -34,47 +35,19 @@ public class RunServiceExtension implements RunService {
         this.delegate = delegate;
     }
 
-    @Override
-    public io.hyperfoil.tools.horreum.api.services.RunService.RunExtended getRun(int id) {
-        return delegate.getRun(id);
+    /**
+     * Additional method provided to add Run from data using JsonNode as data and metadata object
+     * @return Response
+     */
+    public Response addRunFromData(String start, String stop, String test, String owner, Access access, String schemaUri,
+            String description, JsonNode data) {
+        return this.delegate.addRunFromData(start, stop, test, owner, access, schemaUri, description, data);
     }
 
-    @Override
-    public RunSummary getRunSummary(int id) {
-        return delegate.getRunSummary(id);
-    }
-
-    @Override
-    public Object getData(int id, String schemaUri) {
-        return delegate.getData(id, schemaUri);
-    }
-
-    @Override
-    public Object getMetadata(int id, String schemaUri) {
-        return delegate.getMetadata(id, schemaUri);
-    }
-
-    //   @Override
-    //   public QueryResult queryData(int id, String jsonpath, String schemaUri, boolean array) {
-    //      return delegate.queryData(id, jsonpath, schemaUri, array);
-    //   }
-
-    @Override
-    public void updateAccess(int id, String owner, Access access) {
-        delegate.updateAccess(id, owner, access);
-    }
-
-    @Override
-    public Response add(String testNameOrId, String owner, Access access, Run run) {
-        return delegate.add(testNameOrId, owner, access, run);
-    }
-
-    @Override
-    public Response addRunFromData(String start, String stop, String test, String owner, Access access,
-            String schemaUri, String description, JsonNode data) {
-        return delegate.addRunFromData(start, stop, test, owner, access, schemaUri, description, data);
-    }
-
+    /**
+     * Additional method provided to add Run from data using JsonNode as data and metadata object
+     * @return Response
+     */
     public Response addRunFromData(String start, String stop, String test, String owner, Access access,
             String schemaUri, String description, JsonNode data, JsonNode... metadata) {
         MultipartFormDataOutput multipart = new MultipartFormDataOutput();
@@ -104,54 +77,91 @@ public class RunServiceExtension implements RunService {
     }
 
     @Override
+    public io.hyperfoil.tools.horreum.api.services.RunService.RunExtended getRun(int id) {
+        return this.delegate.getRun(id);
+    }
+
+    @Override
+    public RunSummary getRunSummary(int id) {
+        return this.delegate.getRunSummary(id);
+    }
+
+    @Override
+    public Object getData(int id, String schemaUri) {
+        return this.delegate.getData(id, schemaUri);
+    }
+
+    @Override
+    public List<ExportedLabelValues> getRunLabelValues(int runId, String filter, String sort, String direction, int limit,
+            int page, List<String> include, List<String> exclude, boolean multiFilter) {
+        return this.delegate.getRunLabelValues(runId, filter, sort, direction, limit, page, include, exclude, multiFilter);
+    }
+
+    @Override
+    public Object getMetadata(int id, String schemaUri) {
+        return this.delegate.getMetadata(id, schemaUri);
+    }
+
+    @Override
+    public void updateRunAccess(int id, String owner, Access access) {
+        this.delegate.updateRunAccess(id, owner, access);
+    }
+
+    @Override
+    public List<Integer> addRun(String testNameOrId, String owner, Access access, Run run) {
+        return this.delegate.addRun(testNameOrId, owner, access, run);
+    }
+
+    @Override
     public List<String> autocomplete(String query) {
-        return delegate.autocomplete(query);
+        return this.delegate.autocomplete(query);
     }
 
     @Override
     public RunsSummary listAllRuns(String query, boolean matchAll, String roles, boolean trashed, Integer limit, Integer page,
             String sort, SortDirection direction) {
-        return delegate.listAllRuns(query, matchAll, roles, trashed, limit, page, sort, direction);
+        return this.delegate.listAllRuns(query, matchAll, roles, trashed, limit, page, sort, direction);
     }
 
     @Override
     public RunCount runCount(int testId) {
-        return delegate.runCount(testId);
+        return this.delegate.runCount(testId);
     }
 
     @Override
     public RunsSummary listTestRuns(int testId, boolean trashed, Integer limit, Integer page, String sort,
             SortDirection direction) {
-        return delegate.listTestRuns(testId, trashed, limit, page, sort, direction);
+        return this.delegate.listTestRuns(testId, trashed, limit, page, sort, direction);
     }
 
     @Override
-    public RunsSummary listBySchema(String uri, Integer limit, Integer page, String sort, String direction) {
-        return delegate.listBySchema(uri, limit, page, sort, direction);
+    public RunsSummary listRunsBySchema(String uri, Integer limit, Integer page, String sort, SortDirection direction) {
+        return this.delegate.listRunsBySchema(uri, limit, page, sort, direction);
     }
 
     @Override
     public void trash(int id, Boolean isTrashed) {
-        delegate.trash(id, isTrashed);
+        this.delegate.trash(id, isTrashed);
     }
 
     @Override
     public void updateDescription(int id, String description) {
-        delegate.updateDescription(id, description);
+        this.delegate.updateDescription(id, description);
     }
 
     @Override
-    public Map<Integer, String> updateSchema(int id, String path, String schemaUri) {
-        return delegate.updateSchema(id, path, schemaUri);
+    public Map<Integer, String> updateRunSchema(int id, String path, String schemaUri) {
+        return this.delegate.updateRunSchema(id, path, schemaUri);
     }
 
     @Override
-    public List<Integer> recalculateDatasets(int runId) {
-        return delegate.recalculateDatasets(runId);
+    public List<Integer> recalculateRunDatasets(int runId) {
+        return this.delegate.recalculateRunDatasets(runId);
     }
 
     @Override
     public void recalculateAll(String from, String to) {
-        delegate.recalculateAll(from, to);
+        this.delegate.recalculateAll(from, to);
     }
+
 }

--- a/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
+++ b/horreum-client/src/main/java/io/hyperfoil/tools/horreum/api/client/RunService.java
@@ -1,11 +1,10 @@
 package io.hyperfoil.tools.horreum.api.client;
 
-import static io.hyperfoil.tools.horreum.api.services.RunService.RunExtended;
-
 import java.util.List;
 import java.util.Map;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -17,16 +16,15 @@ import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.hyperfoil.tools.horreum.api.ApiIgnore;
 import io.hyperfoil.tools.horreum.api.SortDirection;
 import io.hyperfoil.tools.horreum.api.data.Access;
+import io.hyperfoil.tools.horreum.api.data.ExportedLabelValues;
 import io.hyperfoil.tools.horreum.api.data.Run;
-import io.hyperfoil.tools.horreum.api.services.RunService.RunCount;
-import io.hyperfoil.tools.horreum.api.services.RunService.RunSummary;
-import io.hyperfoil.tools.horreum.api.services.RunService.RunsSummary;
 
 /**
  * THIS IS A DUPLICATE CLASS specifically for the client.
- * This class is missing the `addRunFromData` that leaks resteasy reactive types in the API
+ * This class is missing the `addRunFromData` that leaks resteasy reactive types in the API (FileUpload)
  * A Custom implementation for the `addRunFromData` method is included in RunServiceExtension
  */
 
@@ -34,47 +32,11 @@ import io.hyperfoil.tools.horreum.api.services.RunService.RunsSummary;
 @Consumes({ MediaType.APPLICATION_JSON })
 @Produces(MediaType.APPLICATION_JSON)
 public interface RunService {
-    @GET
-    @Path("{id}")
-    RunExtended getRun(@PathParam("id") int id);
-
-    @GET
-    @Path("{id}/summary")
-    RunSummary getRunSummary(@PathParam("id") int id);
-
-    @GET
-    @Path("{id}/data")
-    Object getData(@PathParam("id") int id, @QueryParam("schemaUri") String schemaUri);
-
-    @GET
-    @Path("{id}/metadata")
-    Object getMetadata(@PathParam("id") int id, @QueryParam("schemaUri") String schemaUri);
-
-    //   @GET
-    //   @Path("{id}/query")
-    //   QueryResult queryData(@PathParam("id") int id,
-    //                         @QueryParam("query") String jsonpath,
-    //                         @QueryParam("uri") String schemaUri,
-    //                         @QueryParam("array") @DefaultValue("false") boolean array);
-
-    @POST
-    @Path("{id}/updateAccess")
-    // TODO: it would be nicer to use @FormParams but fetchival on client side doesn't support that
-    void updateAccess(@PathParam("id") int id,
-            @QueryParam("owner") String owner,
-            @QueryParam("access") Access access);
-
-    @POST
-    @Path("test")
-    @Consumes(MediaType.APPLICATION_JSON)
-    Response add(@QueryParam("test") String testNameOrId,
-            @QueryParam("owner") String owner,
-            @QueryParam("access") Access access,
-            Run run);
-
+    // This is the main change wrt to the original RunService
+    // NB: this changes the data type to JsonNode
     @POST
     @Path("data")
-    @Produces(MediaType.TEXT_PLAIN) // array of generated Run IDs
+    @Produces(MediaType.TEXT_PLAIN)
     Response addRunFromData(@QueryParam("start") String start,
             @QueryParam("stop") String stop,
             @QueryParam("test") String test,
@@ -85,12 +47,59 @@ public interface RunService {
             JsonNode data);
 
     @GET
+    @Path("{id}")
+    io.hyperfoil.tools.horreum.api.services.RunService.RunExtended getRun(@PathParam("id") int id);
+
+    @GET
+    @Path("{id}/summary")
+    io.hyperfoil.tools.horreum.api.services.RunService.RunSummary getRunSummary(@PathParam("id") int id);
+
+    @GET
+    @Path("{id}/data")
+    Object getData(@PathParam("id") int id,
+            @QueryParam("schemaUri") String schemaUri);
+
+    @GET
+    @Path("{id}/labelValues")
+    List<ExportedLabelValues> getRunLabelValues(
+            @PathParam("id") int runId,
+            @QueryParam("filter") @DefaultValue("{}") String filter,
+            @QueryParam("sort") @DefaultValue("") String sort,
+            @QueryParam("direction") @DefaultValue("Ascending") String direction,
+            @QueryParam("limit") @DefaultValue("" + Integer.MAX_VALUE) int limit,
+            @QueryParam("page") @DefaultValue("0") int page,
+            @QueryParam("include") List<String> include,
+            @QueryParam("exclude") List<String> exclude,
+            @QueryParam("multiFilter") @DefaultValue("false") boolean multiFilter);
+
+    @GET
+    @Path("{id}/metadata")
+    Object getMetadata(@PathParam("id") int id,
+            @QueryParam("schemaUri") String schemaUri);
+
+    @POST
+    @Path("{id}/updateAccess")
+    // TODO: it would be nicer to use @FormParams but fetchival on client side doesn't support that
+    void updateRunAccess(@PathParam("id") int id,
+            @QueryParam("owner") String owner,
+            @QueryParam("access") Access access);
+
+    @POST
+    @Path("test")
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<Integer> addRun(@QueryParam("test") String testNameOrId,
+            @QueryParam("owner") String owner,
+            @QueryParam("access") Access access,
+            Run run);
+
+    @GET
     @Path("autocomplete")
+    @ApiIgnore
     List<String> autocomplete(@QueryParam("query") String query);
 
     @GET
     @Path("list")
-    RunsSummary listAllRuns(@QueryParam("query") String query,
+    io.hyperfoil.tools.horreum.api.services.RunService.RunsSummary listAllRuns(@QueryParam("query") String query,
             @QueryParam("matchAll") boolean matchAll,
             @QueryParam("roles") String roles,
             @QueryParam("trashed") boolean trashed,
@@ -101,11 +110,11 @@ public interface RunService {
 
     @GET
     @Path("count")
-    RunCount runCount(@QueryParam("testId") int testId);
+    io.hyperfoil.tools.horreum.api.services.RunService.RunCount runCount(@QueryParam("testId") int testId);
 
     @GET
     @Path("list/{testId}")
-    RunsSummary listTestRuns(@PathParam("testId") int testId,
+    io.hyperfoil.tools.horreum.api.services.RunService.RunsSummary listTestRuns(@PathParam("testId") int testId,
             @QueryParam("trashed") boolean trashed,
             @QueryParam("limit") Integer limit,
             @QueryParam("page") Integer page,
@@ -114,11 +123,11 @@ public interface RunService {
 
     @GET
     @Path("bySchema")
-    RunsSummary listBySchema(@QueryParam("uri") String uri,
+    io.hyperfoil.tools.horreum.api.services.RunService.RunsSummary listRunsBySchema(@QueryParam("uri") String uri,
             @QueryParam("limit") Integer limit,
             @QueryParam("page") Integer page,
             @QueryParam("sort") String sort,
-            @QueryParam("direction") String direction);
+            @QueryParam("direction") SortDirection direction);
 
     @POST
     @Path("{id}/trash")
@@ -132,14 +141,14 @@ public interface RunService {
     @POST
     @Path("{id}/schema")
     @Consumes(MediaType.TEXT_PLAIN)
-    Map<Integer, String> updateSchema(@PathParam("id") int id, @QueryParam("path") String path, String schemaUri);
+    Map<Integer, String> updateRunSchema(@PathParam("id") int id,
+            @QueryParam("path") String path, String schemaUri);
 
     @POST
     @Path("{id}/recalculate")
-    List<Integer> recalculateDatasets(@PathParam("id") int runId);
+    List<Integer> recalculateRunDatasets(@PathParam("id") int runId);
 
     @POST
     @Path("recalculateAll")
     void recalculateAll(@QueryParam("from") String from, @QueryParam("to") String to);
-
 }

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
-import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Assertions;
 
@@ -120,9 +119,9 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             run.testid = -1; // should be ignored
             run.data = new ObjectMapper().readTree(resourceToString("data/config-quickstart.jvm.json"));
             run.description = "Test description";
-            try (Response response = apiClient.runService.add(dummyTest.name, dummyTest.owner, Access.PRIVATE, run)) {
-                assertEquals(202, response.getStatus());
-            }
+            List<Integer> ids = apiClient.runService.addRun(dummyTest.name, dummyTest.owner, Access.PRIVATE, run);
+            assertEquals(1, ids.size());
+            assertTrue(ids.get(0) > 0);
         } finally {
             horreumClient.testService.updateTestAccess(dummyTest.id, dummyTest.owner, Access.PUBLIC);
         }
@@ -164,7 +163,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
         run.testid = -1; // should be ignored
         run.data = new ObjectMapper().readTree(resourceToString("data/config-quickstart.jvm.json"));
         run.description = "Test description";
-        horreumClient.runService.add(dummyTest.name, dummyTest.owner, Access.PUBLIC, run);
+        horreumClient.runService.addRun(dummyTest.name, dummyTest.owner, Access.PUBLIC, run);
     }
 
     // Javascript execution gets often broken with new Quarkus releases, this should catch it


### PR DESCRIPTION
This aims to include all methods from originl RunService but the addRunFromData that has FileUpload as param

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

I noticed that the HorreumClient is overriding the `RunService` because of the `addRunFromData`, which is leaking some reactive objects (i.e., `FileUpload`). Thus, the RunService defined in the client is not up to date wrt to the latest changes and improvements.

I am proposing to update so that we include all methods in the client RunService (e.g., get Run label values was missing).

## Changes proposed

- [x] Re-define the `client.RunService` to include all methods from `services.RunService` but `addRunFromData` which is overridden by a new version that takes data/metadata as `JsonNode` type
- [x] Adapt the method names to the new ones, as defined in the `services.RunService`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
