### PR TITLE
Remove custom serializer for ExpComparison results

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/ExperimentService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/ExperimentService.java
@@ -1,6 +1,5 @@
 package io.hyperfoil.tools.horreum.api.services;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -27,19 +26,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.KeyDeserializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import io.hyperfoil.tools.horreum.api.alerting.DatasetLog;
 import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
 import io.hyperfoil.tools.horreum.api.data.Dataset;
-import io.hyperfoil.tools.horreum.api.data.ExperimentComparison;
 import io.hyperfoil.tools.horreum.api.data.ExperimentProfile;
 
 @Consumes({ MediaType.APPLICATION_JSON })
@@ -134,10 +125,8 @@ public interface ExperimentService {
         @Schema(description = "A list of Dataset Info for experiment baseline(s)")
         public List<Dataset.Info> baseline;
 
-        @JsonSerialize(keyUsing = ExperimentComparisonSerializer.class)
-        @JsonDeserialize(keyUsing = ExperimentComparisonDeserializer.class)
         @Schema(description = "A Map of all comparisons and results evaluated during an Experiment")
-        public Map<ExperimentComparison, ComparisonResult> results;
+        public Map<String, ComparisonResult> results;
 
         @Schema(implementation = String.class)
         public JsonNode extraLabels;
@@ -148,7 +137,7 @@ public interface ExperimentService {
 
         public ExperimentResult(ExperimentProfile profile, List<DatasetLog> logs,
                 Dataset.Info datasetInfo, List<Dataset.Info> baseline,
-                Map<ExperimentComparison, ComparisonResult> results,
+                Map<String, ComparisonResult> results,
                 JsonNode extraLabels, boolean notify) {
             this.profile = profile;
             this.logs = logs;
@@ -179,21 +168,6 @@ public interface ExperimentService {
             this.experimentValue = experimentValue;
             this.baselineValue = baselineValue;
             this.result = result;
-        }
-    }
-
-    class ExperimentComparisonSerializer extends JsonSerializer<ExperimentComparison> {
-        @Override
-        public void serialize(ExperimentComparison value, JsonGenerator gen, SerializerProvider serializers)
-                throws IOException {
-            gen.writeFieldName(value.variableName);
-        }
-    }
-
-    class ExperimentComparisonDeserializer extends KeyDeserializer {
-        @Override
-        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
-            return key;
         }
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ExperimentServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ExperimentServiceImpl.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.horreum.api.alerting.DataPoint;
 import io.hyperfoil.tools.horreum.api.data.ConditionConfig;
 import io.hyperfoil.tools.horreum.api.data.Dataset;
-import io.hyperfoil.tools.horreum.api.data.ExperimentComparison;
 import io.hyperfoil.tools.horreum.api.data.ExperimentProfile;
 import io.hyperfoil.tools.horreum.api.data.TestExport;
 import io.hyperfoil.tools.horreum.api.services.ExperimentService;
@@ -267,7 +266,7 @@ public class ExperimentServiceImpl implements ExperimentService {
                     .<DataPointDAO> find("dataset.id IN ?1 AND variable.id IN ?2", Sort.descending("timestamp", "dataset.id"),
                             entry.getValue(), variableIds)
                     .stream().forEach(dp -> byVar.computeIfAbsent(dp.variable.id, v -> new ArrayList<>()).add(dp));
-            Map<ExperimentComparison, ComparisonResult> results = new HashMap<>();
+            Map<String, ComparisonResult> results = new HashMap<>();
             for (var comparison : profile.comparisons) {
                 Hibernate.initialize(comparison.variable);
                 ExperimentConditionModel model = MODELS.get(comparison.model);
@@ -290,8 +289,7 @@ public class ExperimentServiceImpl implements ExperimentService {
                             "No datapoint for comparison of variable %s in profile %s", comparison.variable.name, profile.name);
                     continue;
                 }
-                results.put(ExperimentProfileMapper.fromExperimentComparison(comparison),
-                        model.compare(comparison.config, baseline, datapoint));
+                results.put(comparison.variable.name, model.compare(comparison.config, baseline, datapoint));
             }
 
             org.hibernate.query.Query<Dataset.Info> datasetQuery = em.unwrap(Session.class).createQuery(


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

The current `ExperimentComparisonDeserializer` is wrong as it should convert String to ExperimentComparison but it is not: https://github.com/Hyperfoil/Horreum/blob/36985dc81fd95d826be608c42ffd302a9024b279/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/ExperimentService.java#L193-L198

While trying to fix it I did not find any valuable reason to keep ExperimentComparison as the key of the results given that they will be deserialized to string anyway and no-one else is using those results.

## Changes proposed

- [x] Convert results to Map<String, ComparisonResult> directly

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
