### PR TITLE
[0.18] Fix test import with actions

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionServiceImpl.java
@@ -368,7 +368,7 @@ public class ActionServiceImpl implements ActionService {
     void importTest(TestExport test) {
         for (Action a : test.actions) {
             ActionDAO action = ActionMapper.to(a);
-            if (ActionDAO.findById(action.id) == null) {
+            if (action.id == null || action.id <= 0 || ActionDAO.findById(action.id) == null) {
                 action.id = null;
                 action.persist();
             } else


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2368

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes the following issue:

```bash
Details:
	Error id f14c801d-fbbc-4252-9d2d-8b85c0d0a3d4-1, java.lang.IllegalArgumentException: id to load is required for loading
Decorate (Source code):
	Exception in ActionServiceImpl.java:371
	  369          for (Action a : test.actions) {
	  370              ActionDAO action = ActionMapper.to(a);
	→ 371              if (ActionDAO.findById(action.id) == null) {
	  372                  action.id = null;
	  373                  action.persist();
Stack:
	java.lang.IllegalArgumentException: id to load is required for loading
	at org.hibernate.event.spi.LoadEvent.<init>(LoadEvent.java:77)
	at org.hibernate.event.spi.LoadEvent.<init>(LoadEvent.java:43)
	at org.hibernate.loader.internal.IdentifierLoadAccessImpl.load(IdentifierLoadAccessImpl.java:207)
	at org.hibernate.loader.internal.IdentifierLoadAccessImpl.doLoad(IdentifierLoadAccessImpl.java:161)
	at org.hibernate.loader.internal.IdentifierLoadAccessImpl.lambda$load$1(IdentifierLoadAccessImpl.java:150)
	at org.hibernate.loader.internal.IdentifierLoadAccessImpl.perform(IdentifierLoadAccessImpl.java:113)
	at org.hibernate.loader.internal.IdentifierLoadAccessImpl.load(IdentifierLoadAccessImpl.java:150)
	at org.hibernate.internal.SessionImpl.find(SessionImpl.java:2459)
	at org.hibernate.internal.SessionImpl.find(SessionImpl.java:2425)
```

## Changes proposed

- [x] Check the Action.id before running ActionDAO.findById

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
