### PR TITLE
Migrate to Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Setup release SSH key
@@ -55,8 +55,8 @@ jobs:
           mvn -B -ntp -DskipTests clean javadoc:javadoc install
           mvn -B -ntp -Darguments=-DskipTests -Dtag=$CUR_VER release:prepare release:perform -DreleaseVersion=$CUR_VER -DdevelopmentVersion=$NEXT_VER -Dresume=false
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
           CI: true

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,7 @@ Open https://github.com/Hyperfoil/Horreum/actions/workflows/release.yml and run 
 
 This workflow will take care of releasing all artifacts and container images on the appropriate registries:
 * Create a new GitHub tag following the semantic versioning (e.g., 0.17.0-SNAPSHOT → 0.17.0)
-* Push the maven artifacts to [Sonatype](https://s01.oss.sonatype.org/#nexus-search;quick~horreum)
+* Push the maven artifacts to [Central Sonatype](https://central.sonatype.com/search?q=horreum)
 * Push the generated container image to [quay.io/hyperfoil/horreum](https://quay.io/repository/hyperfoil/horreum)
 
 The only missing step is the creation of the GitHub release, a step that at the moment needs to be done manually using the GitHub UI. Consider using the “Generate release notes” feature to pre-populate the release notes automatically after selecting the correct tags.

--- a/horreum-backend/pom.xml
+++ b/horreum-backend/pom.xml
@@ -303,13 +303,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <configuration>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,10 @@
 
     <distributionManagement>
         <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/releases</url>
+            <id>central</id>
+            <url>https://central.sonatype.com</url>
         </repository>
     </distributionManagement>
-
 
     <!-- Licenses -->
     <licenses>
@@ -68,7 +67,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <use.java11plus>true</use.java11plus>
 
-        <version.sonatype.nexus>1.7.0</version.sonatype.nexus>
+        <version.sonatype.central>0.7.0</version.sonatype.central>
         <version.maven.antrun>3.1.0</version.maven.antrun>
         <version.maven.compiler>3.14.0</version.maven.compiler>
         <version.maven.gpg>3.2.7</version.maven.gpg>
@@ -286,9 +285,9 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${version.sonatype.nexus}</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${version.sonatype.central}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -446,13 +445,12 @@
                 <plugins>
                     <!-- To release to Nexus -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <!-- To generate javadoc -->


### PR DESCRIPTION
Migrate from the end-of-life OSSRH sonatype service to the new Central Portal one

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Migrating from OSSRH service to Central Portal one by following https://central.sonatype.org/publish/publish-portal-maven/#publishing guide.

## Changes proposed

- [x] Switched from `nexus-staging-maven-plugin` to `central-publishing-maven-plugin`
- [x] Updated credentials and serverId

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
