### PR TITLE
Fix central portal repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <distributionManagement>
         <repository>
             <id>central</id>
-            <url>https://central.sonatype.com</url>
+            <url>https://central.sonatype.com/artifact</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

```
Error: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.2:deploy (default-deploy) on project horreum: Failed to deploy artifacts: Could not find artifact io.hyperfoil.tools:horreum:pom:0.18.3 in central (https://central.sonatype.com/) -> [Help 1]
Error: [ERROR] 
Error: [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: [ERROR] Re-run Maven using the -X switch to enable full debug logging.
Error: [ERROR] 
Error: [ERROR] For more information about the errors and possible solutions, please read the following articles:
Error: [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

## Changes proposed

- [x] Use `https://central.sonatype.com/artifact` as repository url

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
