### PR TITLE
[0.18] Enable release profile during release in the ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           NEXT_VER=$(echo ${PROJECT_VERSION} | awk -F '-' '{ print $1}' | awk -F'.' '{print $1+0"."$2+0"."$3+1"-SNAPSHOT"}' | sed s/[.]$//)
           echo "CUR_VER=$CUR_VER" >> "$GITHUB_ENV"
           mvn -B -ntp -DskipTests clean javadoc:javadoc install
-          mvn -B -ntp -Darguments=-DskipTests -Dtag=$CUR_VER release:prepare release:perform -DreleaseVersion=$CUR_VER -DdevelopmentVersion=$NEXT_VER -Dresume=false
+          mvn -B -ntp -Darguments=-DskipTests -Dtag=$CUR_VER release:prepare release:perform -Prelease -DreleaseVersion=$CUR_VER -DdevelopmentVersion=$NEXT_VER -Dresume=false
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2387

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Looks like we were missing the `release` profile when performing the release in the CI

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
