### PR TITLE
Split queues for new dataset uploads

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -1439,7 +1439,7 @@ public class RunServiceImpl implements RunService {
     }
 
     private void queueDatasetProcessing(DatasetDAO ds, boolean isRecalculation) {
-        mediator.queueDatasetEvents(new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation));
+        mediator.queueNewDatasetEvents(new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation));
         if (mediator.testMode())
             Util.registerTxSynchronization(tm, txStatus -> mediator.publishEvent(AsyncEventChannels.DATASET_NEW, ds.testid,
                     new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation)));

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
@@ -96,6 +96,13 @@ public class SchemaServiceImpl implements SchemaService {
          FROM schema
          INNER JOIN refs ON schema.uri = refs.uri
          """;
+    private static final String datasetIdQuery = """
+        SELECT ds.id, ds.testId
+        from dataset_schemas
+        LEFT JOIN dataset ds on ds.id = dataset_schemas.dataset_id
+        WHERE schema_id = ?1
+        ORDER BY dataset_id DESC;
+        """;
     //@formatter:on
 
     private static final JsonSchemaFactory JSON_SCHEMA_FACTORY = new JsonSchemaFactory.Builder()
@@ -768,6 +775,8 @@ public class SchemaServiceImpl implements SchemaService {
             throw ServiceException.badRequest("Label with id " + labelDTO.id + " already exists");
         }
 
+        Log.info("Adding label " + labelDTO.name + " for schema " + schemaId);
+
         // ensure we are creating new instance by clearing the id
         labelDTO.clearIds();
 
@@ -787,6 +796,7 @@ public class SchemaServiceImpl implements SchemaService {
             throw ServiceException.notFound("Missing label id or label with id " + labelDTO.id + " does not exist");
         }
 
+        Log.info("Updating label " + labelDTO.name + " with id " + labelDTO.id + " for schema " + schemaId);
         labelDTO.schemaId = schemaId;
         return addOrUpdateLabel(labelDTO);
     }
@@ -854,14 +864,6 @@ public class SchemaServiceImpl implements SchemaService {
     }
 
     private void emitLabelChanged(int labelId, int schemaId) {
-        String datasetIdQuery = """
-                SELECT ds.id, ds.testId
-                from dataset_schemas
-                LEFT JOIN dataset ds on ds.id = dataset_schemas.dataset_id
-                WHERE schema_id = ?1
-                ORDER BY dataset_id DESC;
-                """;
-
         try {
             List<Object[]> datasetIds = session
                     .createNativeQuery(datasetIdQuery, Object[].class)
@@ -872,8 +874,9 @@ public class SchemaServiceImpl implements SchemaService {
                 return;
             }
 
+            Log.info("Recalculating label " + labelId + " values for " + datasetIds.size() + " datasets");
             for (var dataset : datasetIds) {
-                Util.registerTxSynchronization(tm, txStatus -> mediator.queueDatasetEvents(
+                Util.registerTxSynchronization(tm, txStatus -> mediator.queueDatasetEventsForRecalculation(
                         new Dataset.EventNew((Integer) dataset[0], (Integer) dataset[1], 0, labelId, true)));
             }
         } catch (NoResultException nre) {

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -25,20 +25,43 @@ quarkus.datasource.jdbc.initial-size=3
 %prod.amqp-password=secret
 %prod.amqp-reconnect-attempts=100
 %prod.amqp-reconnect-interval=1000
-# dataset-event incoming
+
+# thread pool sizes
+smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.run.pool.max-concurrency=4
+smallrye.messaging.worker.horreum.schema.pool.max-concurrency=4
+smallrye.messaging.worker.horreum.new-dataset.pool.max-concurrency=3
+
+# dataset-event incoming - for recalculation
 mp.messaging.incoming.dataset-event-in.connector=smallrye-amqp
 mp.messaging.incoming.dataset-event-in.address=dataset-event
 mp.messaging.incoming.dataset-event-in.durable=true
 mp.messaging.incoming.dataset-event-in.container-id=horreum-broker
 mp.messaging.incoming.dataset-event-in.link-name=dataset-event
 mp.messaging.incoming.dataset-event-in.failure-strategy=modified-failed
-# dataset-event outgoing
+# dataset-event outgoing - for recalculation
 mp.messaging.outgoing.dataset-event-out.connector=smallrye-amqp
 mp.messaging.outgoing.dataset-event-out.address=dataset-event
 mp.messaging.outgoing.dataset-event-out.durable=true
 mp.messaging.outgoing.dataset-event-out.container-id=horreum-broker
 mp.messaging.outgoing.dataset-event-out.link-name=dataset-event
 mp.messaging.outgoing.dataset-event-out.failure-strategy=modified-failed
+
+# new-dataset-event incoming - just for new run uploads
+mp.messaging.incoming.new-dataset-event-in.connector=smallrye-amqp
+mp.messaging.incoming.new-dataset-event-in.address=new-dataset-event
+mp.messaging.incoming.new-dataset-event-in.durable=true
+mp.messaging.incoming.new-dataset-event-in.container-id=horreum-broker
+mp.messaging.incoming.new-dataset-event-in.link-name=new-dataset-event
+mp.messaging.incoming.new-dataset-event-in.failure-strategy=modified-failed
+# new-dataset-event outgoing - just for new run uploads
+mp.messaging.outgoing.new-dataset-event-out.connector=smallrye-amqp
+mp.messaging.outgoing.new-dataset-event-out.address=new-dataset-event
+mp.messaging.outgoing.new-dataset-event-out.durable=true
+mp.messaging.outgoing.new-dataset-event-out.container-id=horreum-broker
+mp.messaging.outgoing.new-dataset-event-out.link-name=new-dataset-event
+mp.messaging.outgoing.new-dataset-event-out.failure-strategy=modified-failed
+
 # re-calc incoming
 mp.messaging.incoming.run-recalc-in.connector=smallrye-amqp
 mp.messaging.incoming.run-recalc-in.address=run-recalc
@@ -53,6 +76,7 @@ mp.messaging.outgoing.run-recalc-out.durable=true
 mp.messaging.outgoing.run-recalc-out.container-id=horreum-broker
 mp.messaging.outgoing.run-recalc-out.link-name=run-recalc
 mp.messaging.outgoing.run-recalc-out.failure-strategy=modified-failed
+
 # schema-sync incoming
 mp.messaging.incoming.schema-sync-in.connector=smallrye-amqp
 mp.messaging.incoming.schema-sync-in.address=schema-sync
@@ -67,6 +91,7 @@ mp.messaging.outgoing.schema-sync-out.durable=true
 mp.messaging.outgoing.schema-sync-out.container-id=horreum-broker
 mp.messaging.outgoing.schema-sync-out.link-name=schema-sync
 mp.messaging.outgoing.schema-sync-out.failure-strategy=modified-failed
+
 # run-upload incoming
 mp.messaging.incoming.run-upload-in.connector=smallrye-amqp
 mp.messaging.incoming.run-upload-in.address=run-upload
@@ -107,12 +132,6 @@ quarkus.hibernate-orm.database.generation=validate
 horreum.test-mode=false
 
 #quarkus.native.additional-build-args=
-
-# thread pool sizes
-smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=7
-smallrye.messaging.worker.horreum.run.pool.max-concurrency=7
-smallrye.messaging.worker.horreum.schema.pool.max-concurrency=7
-
 
 hibernate.jdbc.time_zone=UTC
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2391

## Changes proposed

- [x] Creat new queue `new-dataset-event` for processing new datasets creation
- [x] Add some logging when label update trigger recalc
- [x] Increase concurrency for `dataset.pool` and reduced the others

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
