### PR TITLE
[0.18] Process dataset-event with different priorities

### DIFF
--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Dataset.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Dataset.java
@@ -167,5 +167,22 @@ public class Dataset extends ProtectedTimeType {
                     ", isRecalculation=" + isRecalculation +
                     '}';
         }
+
+        /**
+         * Define messages priorities based on the event type
+         * NEW_DATASET, i.e., when uploading new run, has higher priority than RECALC_DATASET, i.e.,
+         * when updating label schema.
+         * The default priority for AMQP messages is 4
+         */
+        public enum Priority {
+            NEW_DATASET((short) 5),
+            RECALC_DATASET((short) 4);
+
+            public final short value;
+
+            Priority(short priority) {
+                this.value = priority;
+            }
+        }
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/RunServiceImpl.java
@@ -1439,10 +1439,11 @@ public class RunServiceImpl implements RunService {
     }
 
     private void queueDatasetProcessing(DatasetDAO ds, boolean isRecalculation) {
-        mediator.queueDatasetEvents(new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation));
+        Dataset.EventNew event = new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation);
+        mediator.queueDatasetEvents(event);
         if (mediator.testMode())
             Util.registerTxSynchronization(tm, txStatus -> mediator.publishEvent(AsyncEventChannels.DATASET_NEW, ds.testid,
-                    new Dataset.EventNew(DatasetMapper.from(ds), isRecalculation)));
+                    event));
     }
 
     @WithRoles(extras = Roles.HORREUM_SYSTEM)

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -25,6 +25,13 @@ quarkus.datasource.jdbc.initial-size=3
 %prod.amqp-password=secret
 %prod.amqp-reconnect-attempts=100
 %prod.amqp-reconnect-interval=1000
+
+
+# thread pool sizes
+smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.run.pool.max-concurrency=6
+smallrye.messaging.worker.horreum.schema.pool.max-concurrency=5
+
 # dataset-event incoming
 mp.messaging.incoming.dataset-event-in.connector=smallrye-amqp
 mp.messaging.incoming.dataset-event-in.address=dataset-event
@@ -39,6 +46,7 @@ mp.messaging.outgoing.dataset-event-out.durable=true
 mp.messaging.outgoing.dataset-event-out.container-id=horreum-broker
 mp.messaging.outgoing.dataset-event-out.link-name=dataset-event
 mp.messaging.outgoing.dataset-event-out.failure-strategy=modified-failed
+
 # re-calc incoming
 mp.messaging.incoming.run-recalc-in.connector=smallrye-amqp
 mp.messaging.incoming.run-recalc-in.address=run-recalc
@@ -53,6 +61,7 @@ mp.messaging.outgoing.run-recalc-out.durable=true
 mp.messaging.outgoing.run-recalc-out.container-id=horreum-broker
 mp.messaging.outgoing.run-recalc-out.link-name=run-recalc
 mp.messaging.outgoing.run-recalc-out.failure-strategy=modified-failed
+
 # schema-sync incoming
 mp.messaging.incoming.schema-sync-in.connector=smallrye-amqp
 mp.messaging.incoming.schema-sync-in.address=schema-sync
@@ -67,6 +76,7 @@ mp.messaging.outgoing.schema-sync-out.durable=true
 mp.messaging.outgoing.schema-sync-out.container-id=horreum-broker
 mp.messaging.outgoing.schema-sync-out.link-name=schema-sync
 mp.messaging.outgoing.schema-sync-out.failure-strategy=modified-failed
+
 # run-upload incoming
 mp.messaging.incoming.run-upload-in.connector=smallrye-amqp
 mp.messaging.incoming.run-upload-in.address=run-upload
@@ -107,12 +117,6 @@ quarkus.hibernate-orm.database.generation=validate
 horreum.test-mode=false
 
 #quarkus.native.additional-build-args=
-
-# thread pool sizes
-smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=7
-smallrye.messaging.worker.horreum.run.pool.max-concurrency=7
-smallrye.messaging.worker.horreum.schema.pool.max-concurrency=7
-
 
 hibernate.jdbc.time_zone=UTC
 


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2395

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Alternative approach that fixes https://github.com/Hyperfoil/Horreum/issues/2391 as suggested in https://github.com/Hyperfoil/Horreum/pull/2392

## Changes proposed

- [x] Introduce the concept of priority when sending `dataset-event` to the queue
- [x] By default (in case of recalc) use the previous priority of `4`, and use `5` for new datasets 
- [x] Add some logging when label update trigger recalc
- [x] Increase concurrency for `dataset.pool` and reduced the others

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
