### PR TITLE
[0.18] Add artifact name for Horreum API

### DIFF
--- a/horreum-api/pom.xml
+++ b/horreum-api/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>horreum-api</artifactId>
+    <name>Horreum API</name>
 
     <properties>
         <!-- Due to Jenkins plugin we will keep api and client on Java 11 -->


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2405

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fix Central Portal deployment validation issue:
```
pkg:maven/io.hyperfoil.tools/horreum-api@0.18.4
Project name is missing
```

## Changes proposed

- [x] Adding `name` for Horreum api

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
