### PR TITLE
Increase default buffer size for dataset-event-out

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
@@ -875,6 +875,7 @@ public class SchemaServiceImpl implements SchemaService {
                 return;
             }
 
+            Log.infof("Queuing %s datasets for recalculation", datasetIds.size());
             for (var dataset : datasetIds) {
                 Util.registerTxSynchronization(tm, txStatus -> mediator.queueDatasetEvents(
                         new Dataset.EventNew((Integer) dataset[0], (Integer) dataset[1], 0, labelId, true)));

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -88,7 +88,8 @@ public class ServiceMediator {
     @ConfigProperty(name = "horreum.test-mode", defaultValue = "false")
     Boolean testMode;
 
-    @OnOverflow(value = OnOverflow.Strategy.BUFFER, bufferSize = 10000)
+    // configure buffer size through mp.messaging.emitter.default-buffer-size
+    @OnOverflow(value = OnOverflow.Strategy.BUFFER)
     @Channel("dataset-event-out")
     Emitter<Dataset.EventNew> dataSetEmitter;
 

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -32,6 +32,9 @@ smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
 smallrye.messaging.worker.horreum.run.pool.max-concurrency=6
 smallrye.messaging.worker.horreum.schema.pool.max-concurrency=5
 
+# default buffer size for those channels that don't explicitly set on OnOverflow
+mp.messaging.emitter.default-buffer-size=500000
+
 # dataset-event incoming
 mp.messaging.incoming.dataset-event-in.connector=smallrye-amqp
 mp.messaging.incoming.dataset-event-in.address=dataset-event


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Increase the default buffer size for `dataset-event-out` to accomodate datasets recalc on schema label updates

## Changes proposed

- [ ] Add `mp.messaging.emitter.default-buffer-size` config to control the buffer size for the `dataset-event-out` channel

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
