### PR TITLE
Emit all datasets recalc in one consumer

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
@@ -876,10 +876,12 @@ public class SchemaServiceImpl implements SchemaService {
             }
 
             Log.infof("Queuing %s datasets for recalculation", datasetIds.size());
-            for (var dataset : datasetIds) {
-                Util.registerTxSynchronization(tm, txStatus -> mediator.queueDatasetEvents(
-                        new Dataset.EventNew((Integer) dataset[0], (Integer) dataset[1], 0, labelId, true)));
-            }
+            Util.registerTxSynchronization(tm, txStatus -> {
+                for (var dataset : datasetIds) {
+                    mediator.queueDatasetEvents(
+                            new Dataset.EventNew((Integer) dataset[0], (Integer) dataset[1], 0, labelId, true));
+                }
+            });
         } catch (NoResultException nre) {
             Log.debugf("Could not find datasetId/testId to recalculate labels: %s", nre.getMessage());
         }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

I am afraid that sending dataset event in different TX callbacks we are sending events completely asynchronously and when there is a huge amount of them we might risk to hit some race condition that could cause wrong credit calculation on amqp client:

```
2025-06-25 10:59:45,580 645a1466d4ef /usr/lib/jvm/java-17-openjdk-17.0.15.0.6-2.el9.x86_64/bin/java[7] ERROR [io.sma.rea.mes.amqp] (vert.x-eventloop-thread-1) SRMSG16225: Failure reported for channel `dataset-event-out`, closing client: java.lang.IllegalArgumentException: Invalid request number, must be greater than 0
	at io.smallrye.mutiny.helpers.Subscriptions.getInvalidRequestException(Subscriptions.java:24)
	at io.smallrye.mutiny.operators.multi.MultiOperatorProcessor.request(MultiOperatorProcessor.java:117)
	at io.smallrye.mutiny.operators.multi.MultiOnRequestInvoke$MultiOnRequestInvokeOperator.request(MultiOnRequestInvoke.java:34)
	at io.smallrye.reactive.messaging.amqp.AmqpCreditBasedSender.setCreditsAndRequest(AmqpCreditBasedSender.java:163)
	at io.smallrye.reactive.messaging.amqp.AmqpCreditBasedSender.lambda$onNoMoreCredit$7(AmqpCreditBasedSender.java:218)
	at io.vertx.mutiny.core.Context.lambda$runOnContext$1(Context.java:136)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:252)
	at io.vertx.core.impl.ContextInternal.lambda$runOnContext$0(ContextInternal.java:50)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

This is just a guess as I don't know how to prove it 🫤 

## Changes proposed

Instead of adding one TX callback for each dataset to change, I am proposing to add a single TX callback that will send all those events synchronously.

This way the messages are sent in order, and sequentially so that there shouldn't be any race condition anymore.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
