### PR TITLE
Add new Dataset Labels Computed event

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionEvent.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ActionEvent.java
@@ -4,7 +4,8 @@ public enum ActionEvent {
     TEST_NEW("test/new"),
     RUN_NEW("run/new"),
     CHANGE_NEW("change/new"),
-    EXPERIMENT_RESULT_NEW("experiment_result/new"),;
+    EXPERIMENT_RESULT_NEW("experiment_result/new"),
+    DATASET_LABELS_COMPUTED("dataset_labels/computed");
 
     // this represents the value stored in the database
     private final String value;

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -163,6 +163,10 @@ public class ServiceMediator {
 
     void onNewDataset(Dataset.EventNew eventNew) {
         datasetService.onNewDataset(eventNew);
+        // if labelId > 0, you are not recomputing the entire dataset label values
+        if (eventNew.labelId <= 0) {
+            this.actionService.onDatasetLabelsComputed(eventNew.testId, eventNew.datasetId);
+        }
     }
 
     @Incoming("dataset-event-in")

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ActionServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/ActionServiceTest.java
@@ -112,6 +112,23 @@ public class ActionServiceTest extends BaseServiceTest {
         assertEquals(0, actionService.getActions(ActionEvent.TEST_NEW, test.id).size());
         assertEquals(0, actionService.getActions(ActionEvent.CHANGE_NEW, test.id).size());
         assertEquals(0, actionService.getActions(ActionEvent.EXPERIMENT_RESULT_NEW, test.id).size());
+        assertEquals(0, actionService.getActions(ActionEvent.DATASET_LABELS_COMPUTED, test.id).size());
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testGetTestActionsDatasetLabelsComputed(TestInfo testInfo) {
+        Test test = createTest(createExampleTest(getTestName(testInfo)));
+
+        addAllowedSite("http://localhost:" + port);
+        addTestHttpAction(test, ActionEvent.DATASET_LABELS_COMPUTED, "http://localhost:" + port);
+
+        assertEquals(ActionEvent.DATASET_LABELS_COMPUTED, ActionDAO.<ActionDAO> listAll().get(0).event);
+
+        assertEquals(1, actionService.getActions(ActionEvent.DATASET_LABELS_COMPUTED, test.id).size());
+        assertEquals(0, actionService.getActions(ActionEvent.TEST_NEW, test.id).size());
+        assertEquals(0, actionService.getActions(ActionEvent.CHANGE_NEW, test.id).size());
+        assertEquals(0, actionService.getActions(ActionEvent.EXPERIMENT_RESULT_NEW, test.id).size());
+        assertEquals(0, actionService.getActions(ActionEvent.RUN_NEW, test.id).size());
     }
 
     private void executeTestCase(TestInfo testInfo, String channel, Boolean expectError) {

--- a/horreum-web/src/domain/actions/ActionComponentForm.tsx
+++ b/horreum-web/src/domain/actions/ActionComponentForm.tsx
@@ -31,7 +31,7 @@ import {
     SlackChannelMessageActionConfigFromJSON,
 } from "../../api"
 import HttpActionUrlSelector from "../../components/HttpActionUrlSelector"
-import { CHANGE_NEW, EXPERIMENT_RESULT_NEW, TEST_NEW } from "./reducers"
+import { CHANGE_NEW, EXPERIMENT_RESULT_NEW, TEST_NEW, DATASET_LABELS_COMPUTED } from "./reducers"
 import {SimpleSelect} from "@patternfly/react-templates";
 
 function defaultConfig(type: string): ActionConfig {

--- a/horreum-web/src/domain/actions/reducers.ts
+++ b/horreum-web/src/domain/actions/reducers.ts
@@ -2,6 +2,7 @@ export const TEST_NEW = "test/new"
 export const RUN_NEW = "run/new"
 export const EXPERIMENT_RESULT_NEW = "experiment_result/new"
 export const CHANGE_NEW = "change/new"
+export const DATASET_LABELS_COMPUTED = "dataset_labels/computed"
 export const testEventTypes = [
   [
     RUN_NEW,
@@ -85,6 +86,26 @@ export const testEventTypes = [
   }
 }`,
   ],
+  [
+      DATASET_LABELS_COMPUTED,
+      `{
+  "id": 123,
+  "description": "Run on ...",
+  "testid": 10,
+  "data": {
+    "key": "value"
+  },
+  "ordinal": 1,
+  "validationErrors": [],
+  "runId": 456,
+  "getInfo": {
+    "id": 123,
+    "runId": 456,
+    "ordinal": 1,
+    "testId": 10
+  }
+}`,
+    ],
 ]
 export const globalEventTypes = [
   ...testEventTypes,


### PR DESCRIPTION
## Fixes Issue

https://issues.redhat.com/browse/MPL-960

**Problem**
At the moment users can get notified when a new Run is uploaded, but given the async nature of the run upload logic (which means that label values are calculated asynchronously after some time) they cannot rely on such event to retrieve label values data.

**Proposal**
Introduce a new event "new/dataset" that, if subscribed (through actions config), users can get notifed when a "dataset" is completely computed - this means that this should be triggered when label values for a specific datasets are finalized (or recalculated?)

**Acceptance criteria**
Introduce additional "new/dataset" event
Ensure configured actions gets called when all label values are computed for that dataset

## Changes proposed

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
