### PR TITLE
updates to quarkus, maven plugins and bouncycastle:bcpkix

### DIFF
--- a/horreum-api/pom.xml
+++ b/horreum-api/pom.xml
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.12.0</version>
+                <version>7.15.0</version>
                 <executions>
                     <execution>
                         <id>typescript</id>

--- a/infra/horreum-infra-common/pom.xml
+++ b/infra/horreum-infra-common/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.81</version>
+            <version>1.82</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.maven.gpg>3.2.8</version.maven.gpg>
         <version.maven.install>3.1.4</version.maven.install>
         <version.maven.jar>3.4.2</version.maven.jar>
-        <version.maven.javadoc>3.11.2</version.maven.javadoc>
+        <version.maven.javadoc>3.11.3</version.maven.javadoc>
         <version.maven.helper>3.6.1</version.maven.helper>
         <version.maven.project-info-reports>3.9.0</version.maven.project-info-reports>
         <version.maven.resources>3.3.1</version.maven.resources>
@@ -84,7 +84,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <commons.math3.version>3.6.1</commons.math3.version>
         <graalvm.version>23.1.2</graalvm.version>
-        <quarkus.version>3.26.3</quarkus.version>
+        <quarkus.version>3.26.4</quarkus.version>
         <quinoa.version>2.6.2</quinoa.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
@@ -106,7 +106,7 @@
 
         <!-- code formatting -->
         <format.skip>false</format.skip>
-        <formatter-maven-plugin.version>2.27.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
org.bouncycastle:bcprov-jdk18on 1.82 seems to still depend on bcpkix 1.81 so leaving it as it is.