### PR TITLE
Replace stripped tables with highlight current row

### DIFF
--- a/horreum-web/src/components/CustomTable.tsx
+++ b/horreum-web/src/components/CustomTable.tsx
@@ -100,7 +100,7 @@ function CustomTable<D extends object>({
                 </CardHeader>
             )}
             <CardBody style={{ overflowX: "auto" }}>
-                <Table borders={false} isStriped variant="compact" {...table} style={{tableLayout: tableLayout}}>
+                <Table borders={false} variant="compact" {...table} style={{tableLayout: tableLayout}}>
                     {isLoading && (
                         <Thead>
                             <Tr>

--- a/horreum-web/src/index.css
+++ b/horreum-web/src/index.css
@@ -43,8 +43,8 @@ code {
     --pf-v6-c-card--BorderWidth: 0
 }
 
-.pf-v6-c-table.pf-m-striped {
-    --pf-v6-c-table--m-striped__tr--BackgroundColor: var(--pf-t--global--background--color--primary--hover);
+tr.pf-v6-c-table__tr:active, tr.pf-v6-c-table__tr:focus, tr.pf-v6-c-table__tr:hover {
+    background-color: var(--pf-t--global--background--color--primary--hover);
 }
 
 .pf-v6-c-button {


### PR DESCRIPTION
simplify the visual of tables by removing the stripe pattern and highlight the current row instead.