### PR TITLE
[0.18] Create and update schema labels in bulk

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -4613,9 +4613,8 @@ paths:
           description: Created
   /api/schema/{schemaId}/labels:
     put:
-      description: Update existing Label for a Schema (Label id only required when
-        updating existing one)
-      operationId: updateLabel
+      description: Update existing Label(s) for a Schema
+      operationId: updateLabels
       tags:
       - Schema
       parameters:
@@ -4628,19 +4627,23 @@ paths:
           type: integer
           format: int32
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              type: array
+              items:
+                $ref: "#/components/schemas/Label"
+        required: true
       responses:
         "200":
           description: Schema updated successfully
           content:
             application/json:
               schema:
-                type: integer
-                format: int32
+                type: array
+                items:
+                  type: integer
+                  format: int32
     get:
       description: Retrieve list of Labels for a Schema by Schema ID
       operationId: labels
@@ -4665,9 +4668,8 @@ paths:
                 items:
                   $ref: "#/components/schemas/Label"
     post:
-      description: Save new or update existing Label for a Schema (Label id only required
-        when updating existing one)
-      operationId: addLabel
+      description: Save new Label for a Schema
+      operationId: addLabels
       tags:
       - Schema
       parameters:
@@ -4684,15 +4686,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              type: array
+              items:
+                $ref: "#/components/schemas/Label"
       responses:
         "201":
           description: New schema created successfully
           content:
             application/json:
               schema:
-                type: integer
-                format: int32
+                type: array
+                items:
+                  type: integer
+                  format: int32
   /api/schema/{schemaId}/labels/{labelId}:
     delete:
       description: Delete existing Label from a Schema

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Dataset.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/Dataset.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.horreum.api.data;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -136,7 +137,7 @@ public class Dataset extends ProtectedTimeType {
         public int datasetId;
         public int testId;
         public int runId;
-        public int labelId = -1;
+        public Integer[] labelIds;
         public boolean isRecalculation;
 
         public EventNew() {
@@ -146,6 +147,7 @@ public class Dataset extends ProtectedTimeType {
             this.datasetId = dataSet.id;
             this.testId = dataSet.testid;
             this.runId = dataSet.runId;
+            this.labelIds = new Integer[] {};
             this.isRecalculation = isRecalculation;
         }
 
@@ -153,7 +155,15 @@ public class Dataset extends ProtectedTimeType {
             this.datasetId = datasetId;
             this.testId = testId;
             this.runId = runId;
-            this.labelId = labelId;
+            this.labelIds = new Integer[] { labelId };
+            this.isRecalculation = isRecalculation;
+        }
+
+        public EventNew(int datasetId, int testId, int runId, Integer[] labelIds, boolean isRecalculation) {
+            this.datasetId = datasetId;
+            this.testId = testId;
+            this.runId = runId;
+            this.labelIds = labelIds;
             this.isRecalculation = isRecalculation;
         }
 
@@ -163,7 +173,7 @@ public class Dataset extends ProtectedTimeType {
                     "datasetId=" + datasetId +
                     ", testId=" + testId +
                     ", runId=" + runId +
-                    ", labelId=" + labelId +
+                    ", labelIds=" + Arrays.toString(labelIds) +
                     ", isRecalculation=" + isRecalculation +
                     '}';
         }

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/services/SchemaService.java
@@ -190,27 +190,27 @@ public interface SchemaService {
     @POST
     @Path("{schemaId}/labels")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "Save new or update existing Label for a Schema (Label id only required when updating existing one)")
+    @Operation(description = "Save new Label for a Schema")
     @ResponseStatus(201)
     @Parameters(value = {
             @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
     })
     @APIResponses(value = {
-            @APIResponse(responseCode = "201", description = "New schema created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+            @APIResponse(responseCode = "201", description = "New schema created successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(type = SchemaType.ARRAY, implementation = Integer.class)))
     })
-    Integer addLabel(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Label label);
+    List<Integer> addLabels(@PathParam("schemaId") int schemaId, @RequestBody(required = true) List<Label> labels);
 
     @PUT
     @Path("{schemaId}/labels")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "Update existing Label for a Schema (Label id only required when updating existing one)")
+    @Operation(description = "Update existing Label(s) for a Schema")
     @Parameters(value = {
             @Parameter(name = "schemaId", description = "Schema ID", example = "101"),
     })
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", description = "Schema updated successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(implementation = Integer.class)))
+            @APIResponse(responseCode = "200", description = "Schema updated successfully", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(type = SchemaType.ARRAY, implementation = Integer.class)))
     })
-    Integer updateLabel(@PathParam("schemaId") int schemaId, @RequestBody(required = true) Label label);
+    List<Integer> updateLabels(@PathParam("schemaId") int schemaId, @RequestBody List<Label> labels);
 
     @DELETE
     @Path("{schemaId}/labels/{labelId}")

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/RoleManager.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/server/RoleManager.java
@@ -38,9 +38,9 @@ public class RoleManager {
 
         if (Log.isDebugEnabled()) { // enable with: `quarkus.log.category."io.hyperfoil.tools.horreum.server.RoleManager".level=DEBUG`
             try {
-                Log.debugf("Setting roles '%s' (replacing '%s') on transaction %s", roles, row[0], txManager.getTransaction());
+                Log.tracef("Setting roles '%s' (replacing '%s') on transaction %s", roles, row[0], txManager.getTransaction());
             } catch (SystemException e) {
-                Log.debugf("Setting roles '%s' (replacing '%s'), but obtaining current transaction failed due to %s", roles,
+                Log.tracef("Setting roles '%s' (replacing '%s'), but obtaining current transaction failed due to %s", roles,
                         row[0], e.getMessage());
             }
         }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -649,6 +649,7 @@ public class AlertingServiceImpl implements AlertingService {
         }
 
         // this should happen only after reboot, let's start with last change
+        // FIXME: this is happening also when updating a single label for a schema
         if (valid != null) {
             int numDeleted = session.createNativeQuery("DELETE FROM change cc WHERE cc.id IN (" +
                     "SELECT id FROM change c LEFT JOIN fingerprint fp ON c.dataset_id = fp.dataset_id " +

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
@@ -3,6 +3,7 @@ package io.hyperfoil.tools.horreum.svc;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -19,6 +20,7 @@ import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.DefaultValue;
 
+import org.apache.commons.collections4.ListUtils;
 import org.hibernate.Hibernate;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
@@ -60,6 +62,8 @@ import io.quarkus.security.identity.SecurityIdentity;
 @Startup
 public class DatasetServiceImpl implements DatasetService {
 
+    private static final int LABEL_VALUES_RECALC_BATCH_SIZE = 40;
+
     //@formatter:off
     private static final String LABEL_QUERY = """
          WITH
@@ -68,7 +72,7 @@ public class DatasetServiceImpl implements DatasetService {
             FROM dataset_schemas ds
             JOIN label ON label.schema_id = ds.schema_id
             LEFT JOIN label_extractors le ON le.label_id = label.id
-            WHERE ds.dataset_id = ?1 AND (?2 < 0 OR label.id = ?2) GROUP BY label.id, label.name, ds.schema_id
+            WHERE ds.dataset_id = :datasetId AND (:allLabels = TRUE OR label.id IN :labelIds) GROUP BY label.id, label.name, ds.schema_id
          ),
          lvalues AS (
             SELECT ul.label_id, le.name,
@@ -81,7 +85,7 @@ public class DatasetServiceImpl implements DatasetService {
             JOIN dataset_schemas ds ON dataset.id = ds.dataset_id
             JOIN used_labels ul ON ul.schema_id = ds.schema_id
             LEFT JOIN label_extractors le ON ul.label_id = le.label_id
-            WHERE dataset.id = ?1
+            WHERE dataset.id = :datasetId
          )
          SELECT lvalues.label_id, ul.name, function,
                (CASE
@@ -410,17 +414,15 @@ public class DatasetServiceImpl implements DatasetService {
         return DatasetMapper.from(dataset);
     }
 
-    @WithRoles(extras = Roles.HORREUM_SYSTEM)
-    @Transactional
-    void calculateLabelValues(int testId, int datasetId, int queryLabelId, boolean isRecalculation) {
-        Log.debugf("Calculating label values for dataset %d, label %d", datasetId, queryLabelId);
+    private List<Object[]> calculateLabelValues(int datasetId, boolean allLabels, List<Integer> queryLabelIds) {
         List<Object[]> extracted;
         try {
             // Note: we are fetching even labels that are marked as private/could be otherwise inaccessible
             // to the uploading user. However, the uploader should not have rights to fetch these anyway...
             extracted = em.unwrap(Session.class).createNativeQuery(LABEL_QUERY, Object[].class)
-                    .setParameter(1, datasetId)
-                    .setParameter(2, queryLabelId)
+                    .setParameter("datasetId", datasetId)
+                    .setParameter("allLabels", allLabels)
+                    .setParameterList("labelIds", queryLabelIds, Integer.class)
                     .addScalar("label_id", StandardBasicTypes.INTEGER)
                     .addScalar("name", StandardBasicTypes.TEXT)
                     .addScalar("function", StandardBasicTypes.TEXT)
@@ -430,19 +432,39 @@ public class DatasetServiceImpl implements DatasetService {
             logMessageInNewTx(datasetId, PersistentLogDAO.ERROR,
                     "Failed to extract data (JSONPath expression error?): " + Util.explainCauses(e));
             findFailingExtractor(datasetId);
-            return;
+            return Collections.emptyList();
         }
 
         // While any change should remove the label_value first via trigger it is possible
         // that something triggers two events after each other, removing the data (twice)
         // before the first event is processed. The second event would then find the label_value
         // already present and would fail with a constraint violation.
-        if (queryLabelId < 0) {
+        if (allLabels) {
             LabelValueDAO.delete("datasetId", datasetId);
         } else {
-            LabelValueDAO.delete("datasetId = ?1 AND labelId = ?2", datasetId, queryLabelId);
+            LabelValueDAO.delete("datasetId = ?1 AND labelId IN ?2", datasetId, queryLabelIds);
         }
 
+        return extracted;
+    }
+
+    @WithRoles(extras = Roles.HORREUM_SYSTEM)
+    @Transactional
+    void calculateLabelValues(int testId, int datasetId, Integer[] queryLabelIds, boolean isRecalculation) {
+        Log.debugf("Calculating label values for dataset %d, labels %s", datasetId, Arrays.toString(queryLabelIds));
+        List<Object[]> extracted;
+        if (queryLabelIds == null || queryLabelIds.length == 0) {
+            extracted = this.calculateLabelValues(datasetId, true, Collections.emptyList());
+        } else {
+            // apply batching if the number of labels is too big
+            extracted = new ArrayList<>();
+            List<List<Integer>> batches = ListUtils.partition(Arrays.asList(queryLabelIds), LABEL_VALUES_RECALC_BATCH_SIZE);
+            for (List<Integer> batch : batches) {
+                extracted.addAll(this.calculateLabelValues(datasetId, false, new ArrayList<>(batch)));
+            }
+        }
+
+        // Delete data before re-computing Dataset specific data
         FingerprintDAO.deleteById(datasetId);
         Util.evaluateWithCombinationFunction(extracted,
                 (row) -> (String) row[2],
@@ -451,7 +473,8 @@ public class DatasetServiceImpl implements DatasetService {
                 (row) -> createLabelValue(datasetId, testId, (int) row[0], (JsonNode) row[3]),
                 (row, e, jsCode) -> logMessage(datasetId, PersistentLogDAO.ERROR,
                         "Evaluation of label %s failed: '%s' Code:<pre>%s</pre>", row[0], e.getMessage(), jsCode),
-                (out) -> logMessage(datasetId, PersistentLogDAO.DEBUG, "Output while calculating labels: <pre>%s</pre>", out));
+                (out) -> logMessage(datasetId, PersistentLogDAO.DEBUG, "Output while calculating labels: <pre>%s</pre>",
+                        out));
 
         // create new dataset views from the recently created label values
         calcDatasetViews(datasetId);
@@ -599,7 +622,7 @@ public class DatasetServiceImpl implements DatasetService {
     }
 
     public void onNewDataset(Dataset.EventNew event) {
-        calculateLabelValues(event.testId, event.datasetId, event.labelId, event.isRecalculation);
+        calculateLabelValues(event.testId, event.datasetId, event.labelIds, event.isRecalculation);
     }
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -210,7 +210,8 @@ mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD
 
 # Do not log warnings on retried transactions
 %dev.quarkus.log.level=INFO
-%dev.quarkus.log.category."io.hyperfoil.tools.horreum".level=INFO
+%dev.quarkus.log.category."io.hyperfoil.tools.horreum".level=DEBUG
+#%test.quarkus.log.category."io.hyperfoil.tools.horreum".level=DEBUG
 %dev.quarkus.log.category."org.hibernate".level=INFO
 %dev.quarkus.log.category."org.postgresql.jdbc".level=INFO
 #%test.quarkus.log.category."io.hyperfoil".level=DEBUG

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/RunServiceTest.java
@@ -1057,7 +1057,7 @@ public class RunServiceTest extends BaseServiceTest {
             lblCpu.owner = test.owner;
             lblCpu.metrics = true;
             lblCpu.filtering = false;
-            lblCpu.id = addOrUpdateLabel(schema.id, lblCpu);
+            lblCpu.id = addLabel(schema.id, lblCpu);
 
             Label lblThroughput = new Label();
             lblThroughput.name = "throughput";
@@ -1067,7 +1067,7 @@ public class RunServiceTest extends BaseServiceTest {
             lblThroughput.owner = test.owner;
             lblThroughput.metrics = true;
             lblThroughput.filtering = false;
-            lblThroughput.id = addOrUpdateLabel(schema.id, lblThroughput);
+            lblThroughput.id = addLabel(schema.id, lblThroughput);
 
             Label lblJob = new Label();
             lblJob.name = "job";
@@ -1077,7 +1077,7 @@ public class RunServiceTest extends BaseServiceTest {
             lblJob.owner = test.owner;
             lblJob.metrics = false;
             lblJob.filtering = true;
-            lblJob.id = addOrUpdateLabel(schema.id, lblJob);
+            lblJob.id = addLabel(schema.id, lblJob);
 
             Label lblBuildID = new Label();
             lblBuildID.name = "build-id";
@@ -1087,7 +1087,7 @@ public class RunServiceTest extends BaseServiceTest {
             lblBuildID.owner = test.owner;
             lblBuildID.metrics = false;
             lblBuildID.filtering = true;
-            lblBuildID.id = addOrUpdateLabel(schema.id, lblBuildID);
+            lblBuildID.id = addLabel(schema.id, lblBuildID);
 
             //3. Config change detection variables
             Variable variable = new Variable();

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/SchemaServiceNoRestTest.java
@@ -515,7 +515,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
         LabelDAO label = LabelDAO.findById(id);
         assertNotNull(label);
@@ -531,13 +531,13 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
         // empty name
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabel(s.id, l));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabels(s.id, List.of(l)));
         assertEquals("Label must have a non-blank name", thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
 
         // null name
         l.name = null;
-        thrown = assertThrows(ServiceException.class, () -> schemaService.addLabel(s.id, l));
+        thrown = assertThrows(ServiceException.class, () -> schemaService.addLabels(s.id, List.of(l)));
         assertEquals("Label must have a non-blank name", thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
     }
@@ -551,7 +551,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         l.id = 999;
 
         // adding a label ensure the id is cleared if not existing
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
         LabelDAO label = LabelDAO.findById(id);
         assertNotNull(label);
@@ -568,12 +568,11 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
         // null label dto
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabel(s.id, null));
-        assertEquals("No label?", thrown.getMessage());
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
+        List<Integer> createdLabelIds = schemaService.addLabels(s.id, null);
+        assertEquals(0, createdLabelIds.size());
 
         // not existing schema
-        thrown = assertThrows(ServiceException.class, () -> schemaService.addLabel(999, l));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabels(999, List.of(l)));
         assertEquals("Schema 999 not found", thrown.getMessage());
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), thrown.getResponse().getStatus());
     }
@@ -585,14 +584,14 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
 
         // update the label
         l.id = id;
         l.name = "AnotherName";
         l.extractors.add(new Extractor("z", "$.z", false));
-        int afterUpdateId = schemaService.updateLabel(s.id, l);
+        int afterUpdateId = schemaService.updateLabels(s.id, List.of(l)).get(0);
         assertEquals(id, afterUpdateId);
 
         assertEquals(1, LabelDAO.count());
@@ -609,12 +608,12 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
 
         // update the label passing the wrong schema id
         l.id = id;
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.updateLabel(999, l));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.updateLabels(999, List.of(l)));
         assertEquals("Label id=%d, name=%s belongs to a different schema: %d(%s)".formatted(
                 l.id, l.name, s.id, s.uri), thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
@@ -627,13 +626,13 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
 
-        // update the label passing the wrong schema id
+        // trying to add existing label
         l.id = id;
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabel(999, l));
-        assertEquals("Label with id %d already exists".formatted(l.id), thrown.getMessage());
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.addLabels(999, List.of(l)));
+        assertEquals("Trying to add already existing labels [%d]".formatted(l.id), thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
     }
 
@@ -645,14 +644,14 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
         Label another = createSampleLabel("AnotherLabel", s, null, "({x, y}) => ({ z: 1 })");
 
-        int id = schemaService.addLabel(s.id, l);
-        schemaService.addLabel(s.id, another);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
+        schemaService.addLabels(s.id, List.of(another));
         assertEquals(2, LabelDAO.count());
 
         // update the label
         l.id = id;
         l.name = "AnotherLabel";
-        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.updateLabel(s.id, l));
+        ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.updateLabels(s.id, List.of(l)));
         assertEquals("There is an existing label with the same name (%s) in this schema; please choose different name."
                 .formatted(l.name), thrown.getMessage());
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), thrown.getResponse().getStatus());
@@ -665,7 +664,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
 
         schemaService.deleteLabel(s.id, id);
@@ -679,7 +678,7 @@ class SchemaServiceNoRestTest extends BaseServiceNoRestTest {
         Label l = createSampleLabel("Blabla", s, null, "({x, y}) => ({ z: 1 })",
                 new Extractor("x", "$.x", true), new Extractor("y", "$.y", false));
 
-        int id = schemaService.addLabel(s.id, l);
+        int id = schemaService.addLabels(s.id, List.of(l)).get(0);
         assertEquals(1, LabelDAO.count());
 
         ServiceException thrown = assertThrows(ServiceException.class, () -> schemaService.deleteLabel(s.id, 999));

--- a/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
+++ b/horreum-integration-tests/src/test/java/io/hyperfoil/tools/horreum/it/HorreumClientIT.java
@@ -278,7 +278,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblCpu.owner = dummyTest.owner;
             lblCpu.metrics = true;
             lblCpu.filtering = false;
-            lblCpu.id = horreumClient.schemaService.addLabel(schema.id, lblCpu);
+            lblCpu.id = horreumClient.schemaService.addLabels(schema.id, List.of(lblCpu)).get(0);
 
             Label lblThroughput = new Label();
             lblThroughput.name = "throughput";
@@ -288,7 +288,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblThroughput.owner = dummyTest.owner;
             lblThroughput.metrics = true;
             lblThroughput.filtering = false;
-            lblThroughput.id = horreumClient.schemaService.addLabel(schema.id, lblThroughput);
+            lblThroughput.id = horreumClient.schemaService.addLabels(schema.id, List.of(lblThroughput)).get(0);
 
             Label lblJob = new Label();
             lblJob.name = "job";
@@ -298,7 +298,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblJob.owner = dummyTest.owner;
             lblJob.metrics = false;
             lblJob.filtering = true;
-            lblJob.id = horreumClient.schemaService.addLabel(schema.id, lblJob);
+            lblJob.id = horreumClient.schemaService.addLabels(schema.id, List.of(lblJob)).get(0);
 
             Label lblBuildID = new Label();
             lblBuildID.name = "build-id";
@@ -308,7 +308,7 @@ public class HorreumClientIT implements QuarkusTestBeforeTestExecutionCallback, 
             lblBuildID.owner = dummyTest.owner;
             lblBuildID.metrics = false;
             lblBuildID.filtering = true;
-            lblBuildID.id = horreumClient.schemaService.addLabel(schema.id, lblBuildID);
+            lblBuildID.id = horreumClient.schemaService.addLabels(schema.id, List.of(lblBuildID)).get(0);
 
             //3. Config change detection variables
             Variable variable = new Variable();

--- a/infra/horreum-infra-common/pom.xml
+++ b/infra/horreum-infra-common/pom.xml
@@ -21,12 +21,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2483

<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Horreum/issues/2401

<!-- Example: Closes #31 -->

## Changes proposed

When multiple labels are updated/created/deleted, issue one single dataset event that will re-compute only those label values related to the labels that have been updated, and after that triggers the change detection recalculation only **once**

**Breaking change**
- Create/update label endpoints now expect a list of labels rather than only one label

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
