### PR TITLE
Improve run change detection process

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/FingerprintDAO.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/entity/FingerprintDAO.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 
 import org.hibernate.annotations.Type;
 
@@ -31,11 +33,22 @@ public class FingerprintDAO extends PanacheEntityBase {
     @Column(columnDefinition = "jsonb")
     public JsonNode fingerprint;
 
+    @Column(name = "fp_hash")
+    public Integer fpHash;
+
+    @PrePersist
+    @PreUpdate
+    // guarantees the hash is computed before persisting the fingerprint
+    public void populateHash() {
+        this.fpHash = fingerprint != null ? fingerprint.hashCode() : null;
+    }
+
     @Override
     public String toString() {
         return "FP{" +
                 "datasetId=" + datasetId +
                 ", fingerprint=" + fingerprint +
+                ", fpHash=" + fpHash +
                 '}';
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/migration/BackfillFingerprintHashChangeSet.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/migration/BackfillFingerprintHashChangeSet.java
@@ -1,0 +1,84 @@
+package io.hyperfoil.tools.horreum.migration;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+
+public class BackfillFingerprintHashChangeSet implements CustomTaskChange {
+    private static final int BATCH_SIZE = 500;
+
+    @Override
+    public void execute(Database database) throws CustomChangeException {
+        JdbcConnection connection = (JdbcConnection) database.getConnection();
+        ObjectMapper mapper = new ObjectMapper();
+        int count = 0;
+
+        String selectSql = "SELECT dataset_id, fingerprint FROM Fingerprint WHERE fp_hash IS NULL";
+        String updateSql = "UPDATE fingerprint SET fp_hash = ? WHERE dataset_id = ?";
+
+        try (Statement selectStmt = connection.createStatement();
+                PreparedStatement updateStmt = connection.prepareStatement(updateSql)) {
+
+            ResultSet rs = selectStmt.executeQuery(selectSql);
+            System.out.println("Starting fingerprint hash backfill...");
+
+            while (rs.next()) {
+                int datasetId = rs.getInt("dataset_id");
+                String fingerprintJson = rs.getString("fingerprint");
+
+                if (fingerprintJson != null) {
+                    JsonNode fingerprintNode = mapper.readTree(fingerprintJson);
+                    int hash = fingerprintNode.hashCode();
+
+                    updateStmt.setLong(1, hash);
+                    updateStmt.setInt(2, datasetId);
+                    updateStmt.addBatch();
+                    count++;
+                }
+
+                if (count % BATCH_SIZE == 0) {
+                    updateStmt.executeBatch();
+                    System.out.println("Updated " + count + " fingerprint hashes...");
+                }
+            }
+
+            // final batch
+            updateStmt.executeBatch();
+            System.out.println("Fingerprint hash backfill complete. Total records updated: " + count);
+
+        } catch (Exception e) {
+            throw new CustomChangeException("Failed to backfill fingerprint hashes", e);
+        }
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Fingerprint hashes backfilled successfully.";
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return new ValidationErrors();
+    }
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/DatasetServiceImpl.java
@@ -644,6 +644,7 @@ public class DatasetServiceImpl implements DatasetService {
         fp.datasetId = datasetId;
         fp.dataset = DatasetDAO.findById(datasetId);
         fp.fingerprint = fpNode;
+        fp.populateHash(); // this call is not really necessary
         if (fp.datasetId > 0 && fp.dataset != null)
             fp.persist();
     }

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -30,7 +30,7 @@ quarkus.datasource.jdbc.initial-size=3
 
 
 # thread pool sizes
-smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=7
 smallrye.messaging.worker.horreum.run.pool.max-concurrency=6
 smallrye.messaging.worker.horreum.schema.pool.max-concurrency=5
 

--- a/horreum-backend/src/main/resources/db/changeLog.xml
+++ b/horreum-backend/src/main/resources/db/changeLog.xml
@@ -4846,4 +4846,8 @@
         <dropSequence sequenceName="transformationlog_seq"/>
         <dropSequence sequenceName="tokenidgenerator"/>
     </changeSet>
+    <changeSet id="132" author="lampajr">
+        <validCheckSum>ANY</validCheckSum>
+        <customChange class="io.hyperfoil.tools.horreum.migration.BackfillFingerprintHashChangeSet" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

This PR aims to improve in some part the change detection re-execution during dataset recalculation.

## Changes proposed

- [x] Re-introduce the concept of `fingerprint hash` 
- [x] Use the hash to perform comparison based on fingerprint instead of jsonb comparisons

> NB: Even if at the moment in prod we don't have hashes collision, this code does not handle that case

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
