### PR TITLE
Reduce AMQP reconnect interval

### DIFF
--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -26,7 +26,7 @@ quarkus.datasource.jdbc.initial-size=3
 %prod.amqp-username=horreum
 %prod.amqp-password=secret
 %prod.amqp-reconnect-attempts=100
-%prod.amqp-reconnect-interval=1000
+%prod.amqp-reconnect-interval=10
 
 
 # thread pool sizes

--- a/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumResource.java
+++ b/infra/horreum-infra-common/src/main/java/io/hyperfoil/tools/horreum/infra/common/resources/HorreumResource.java
@@ -83,7 +83,7 @@ public class HorreumResource implements ResourceLifecycleManager {
                 .withEnv("amqp-username", initArgs.getOrDefault("amqp-username", DEFAULT_AMQP_USERNAME))
                 .withEnv("amqp-password", initArgs.getOrDefault("amqp-password", DEFAULT_AMQP_PASSWORD))
                 .withEnv("amqp-reconnect-attempts", "100")
-                .withEnv("amqp-reconnect-interval", "1000")
+                .withEnv("amqp-reconnect-interval", "10")
                 .withEnv("quarkus.profile", "test")
                 .withEnv("quarkus.test.profile", "test")
                 .withEnv("horreum.bootstrap.password", "secret")


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Based on the documentation at https://quarkus.io/guides/amqp-reference
```
The interval in second between two reconnection attempts

Type: int
```

We are using a too high value for `amqp-reconnect-interval`, as we are using `10000` that in seconds means `>15 mins`

## Changes proposed

- [x] Reducing the reconnect interval to the default value: `10s`

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
