### PR TITLE
[0.19] fix LabelFilter display when label value is an object

### DIFF
--- a/horreum-web/src/components/LabelFilter/LabelFilter.tsx
+++ b/horreum-web/src/components/LabelFilter/LabelFilter.tsx
@@ -137,7 +137,7 @@ export default function LabelFilter({selection, onSelect, source, emptyPlacehold
                     }
                     return true
                 })
-                .map(value => convertPartial(value))
+                .map(value => convertLabelValue(value))
                 .sort()
 
             return (


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2552

it prevents the UI from crashing. 

further research is needed to understand how to do filtering when the label value is an object.
