### PR TITLE
Changes to recalculation

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/AlertingServiceImpl.java
@@ -38,6 +38,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.graalvm.polyglot.Value;
 import org.hibernate.Session;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.type.StandardBasicTypes;
@@ -54,7 +55,6 @@ import io.hyperfoil.tools.horreum.api.data.*;
 import io.hyperfoil.tools.horreum.api.data.changeDetection.ChangeDetectionModelType;
 import io.hyperfoil.tools.horreum.api.internal.services.AlertingService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
-import io.hyperfoil.tools.horreum.bus.BlockingTaskDispatcher;
 import io.hyperfoil.tools.horreum.changedetection.ChangeDetectionException;
 import io.hyperfoil.tools.horreum.changedetection.ChangeDetectionModel;
 import io.hyperfoil.tools.horreum.changedetection.ChangeDetectionModelResolver;
@@ -201,9 +201,6 @@ public class AlertingServiceImpl implements AlertingService {
 
     @Inject
     EntityManager em;
-
-    @Inject
-    BlockingTaskDispatcher messageBus;
 
     @Inject
     SecurityIdentity identity;
@@ -404,7 +401,43 @@ public class AlertingServiceImpl implements AlertingService {
     @Transactional
     void calculateDatapoints(DatasetDAO dataset, boolean notify, boolean debug, Recalculation recalculation) {
         Set<String> missingValueVariables = new HashSet<>();
-        List<VariableData> values = session.createNativeQuery(LOOKUP_VARIABLES, Tuple.class)
+
+        List<VariableData> values = fetchVariableValues(dataset);
+        if (debug)
+            logFetchedValuesIfDebug(dataset, values);
+
+        Instant timestamp = resolveTimestamp(dataset);
+
+        Util.evaluateWithCombinationFunction(values,
+                data -> data.calculation,
+                data -> data.value,
+                (data, result) -> handleCalculatedValue(dataset, timestamp, data, result, notify, recalculation,
+                        missingValueVariables),
+                data -> handleNonCalculatedValue(dataset, timestamp, data, notify, recalculation, missingValueVariables),
+                (data, exception, code) -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
+                        "Evaluation of variable %s failed: '%s' Code:<pre>%s</pre>", data.fullName(), exception.getMessage(),
+                        code),
+                output -> logCalculationMessage(dataset, PersistentLogDAO.DEBUG,
+                        "Output while calculating variable: <pre>%s</pre>", output));
+
+        if (!missingValueVariables.isEmpty()) {
+            MissingValuesEvent event = new MissingValuesEvent(dataset.getInfo(), missingValueVariables, notify);
+            if (mediator.testMode()) {
+                mediator.publishEvent(AsyncEventChannels.DATASET_MISSING_VALUES, dataset.testid, event);
+            }
+            mediator.missingValuesDataset(event);
+        }
+        DataPoint.DatasetProcessedEvent event = new DataPoint.DatasetProcessedEvent(DatasetMapper.fromInfo(dataset.getInfo()),
+                notify);
+        if (mediator.testMode()) {
+            Util.registerTxSynchronization(tm,
+                    txStatus -> mediator.publishEvent(AsyncEventChannels.DATAPOINT_PROCESSED, dataset.testid, event));
+        }
+        mediator.dataPointsProcessed(event);
+    }
+
+    private List<VariableData> fetchVariableValues(DatasetDAO dataset) {
+        return session.createNativeQuery(LOOKUP_VARIABLES, Tuple.class)
                 .setParameter(1, dataset.testid)
                 .setParameter(2, dataset.id)
                 .addScalar("variableId", StandardBasicTypes.INTEGER)
@@ -424,12 +457,16 @@ public class AlertingServiceImpl implements AlertingService {
                     return data;
                 })
                 .getResultList();
-        if (debug) {
-            for (VariableData data : values) {
-                logCalculationMessage(dataset, PersistentLogDAO.DEBUG, "Fetched value for variable %s: <pre>%s</pre>",
-                        data.fullName(), data.value);
-            }
+    }
+
+    private void logFetchedValuesIfDebug(DatasetDAO dataset, List<VariableData> values) {
+        for (VariableData data : values) {
+            logCalculationMessage(dataset, PersistentLogDAO.DEBUG,
+                    "Fetched value for variable %s: <pre>%s</pre>", data.fullName(), data.value);
         }
+    }
+
+    private Instant resolveTimestamp(DatasetDAO dataset) {
         List<Object[]> timestampList = session
                 .createNativeQuery(LOOKUP_TIMESTAMP, Object[].class)
                 .setParameter(1, dataset.testid)
@@ -437,96 +474,94 @@ public class AlertingServiceImpl implements AlertingService {
                 .addScalar("timeline_function", StandardBasicTypes.TEXT)
                 .addScalar("value", JsonBinaryType.INSTANCE)
                 .getResultList();
-        Instant timestamp = dataset.start;
-        if (!timestampList.isEmpty()) {
-            String timestampFunction = (String) timestampList.get(0)[0];
-            JsonNode value = (JsonNode) timestampList.get(0)[1];
-            if (timestampFunction != null && !timestampFunction.isBlank()) {
-                value = Util.evaluateOnce(timestampFunction, value, Util::convertToJson,
-                        (code, throwable) -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
-                                "Evaluation of timestamp failed: '%s' Code: <code><pre>%s</pre></code>", throwable.getMessage(),
-                                code),
-                        output -> logCalculationMessage(dataset, PersistentLogDAO.DEBUG,
-                                "Output while calculating timestamp: <pre>%s</pre>", output));
-            }
-            timestamp = Util.toInstant(value);
-            if (timestamp == null) {
-                logCalculationMessage(dataset, PersistentLogDAO.ERROR,
-                        "Cannot parse timestamp, must be number or ISO-8601 timestamp: %s", value);
-                timestamp = dataset.start;
-            }
-        }
-        Instant finalTimestamp = timestamp;
-        Util.evaluateWithCombinationFunction(values, data -> data.calculation, data -> data.value,
-                (data, result) -> {
-                    Double value = Util.toDoubleOrNull(result,
-                            error -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
-                                    "Evaluation of variable %s failed: %s", data.fullName(), error),
-                            info -> logCalculationMessage(dataset, PersistentLogDAO.INFO, "Evaluation of variable %s: %s",
-                                    data.fullName(), info));
-                    if (value != null) {
-                        createDataPoint(dataset, finalTimestamp, data.variableId, value, notify, recalculation);
-                    } else {
-                        if (recalculation != null) {
-                            recalculation.datasetsWithoutValue.put(dataset.id, dataset.getInfo());
-                        }
-                        missingValueVariables.add(data.fullName());
-                    }
-                },
-                data -> {
-                    if (data.numLabels > 1) {
-                        logCalculationMessage(dataset, PersistentLogDAO.WARN,
-                                "Variable %s has more than one label (%s) but no calculation function.", data.fullName(),
-                                data.value.fieldNames());
-                    }
-                    if (data.value == null || data.value.isNull()) {
-                        logCalculationMessage(dataset, PersistentLogDAO.INFO,
-                                "Null value for variable %s - datapoint is not created", data.fullName());
-                        if (recalculation != null) {
-                            recalculation.datasetsWithoutValue.put(dataset.id, dataset.getInfo());
-                        }
-                        missingValueVariables.add(data.fullName());
-                        return;
-                    }
 
-                    Double value = null;
-                    if (data.value.isNumber()) {
-                        value = data.value.asDouble();
-                    } else if (data.value.isTextual()) {
-                        try {
-                            value = Double.parseDouble(data.value.asText());
-                        } catch (NumberFormatException e) {
-                            // ignore
-                        }
-                    }
-                    if (value == null) {
-                        logCalculationMessage(dataset, PersistentLogDAO.ERROR,
-                                "Cannot turn %s into a floating-point value for variable %s", data.value, data.fullName());
-                        if (recalculation != null) {
-                            recalculation.errors++;
-                        }
-                        missingValueVariables.add(data.fullName());
-                    } else {
-                        createDataPoint(dataset, finalTimestamp, data.variableId, value, notify, recalculation);
-                    }
-                },
-                (data, exception, code) -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
-                        "Evaluation of variable %s failed: '%s' Code:<pre>%s</pre>", data.fullName(), exception.getMessage(),
-                        code),
-                output -> logCalculationMessage(dataset, PersistentLogDAO.DEBUG,
-                        "Output while calculating variable: <pre>%s</pre>", output));
-        if (!missingValueVariables.isEmpty()) {
-            MissingValuesEvent event = new MissingValuesEvent(dataset.getInfo(), missingValueVariables, notify);
-            if (mediator.testMode())
-                mediator.publishEvent(AsyncEventChannels.DATASET_MISSING_VALUES, dataset.testid, event);
-            mediator.missingValuesDataset(event);
+        if (timestampList.isEmpty()) {
+            return dataset.start;
         }
-        DataPoint.DatasetProcessedEvent event = new DataPoint.DatasetProcessedEvent(DatasetMapper.fromInfo(dataset.getInfo()),
-                notify);
-        if (mediator.testMode())
-            Util.registerTxSynchronization(tm,
-                    txStatus -> mediator.publishEvent(AsyncEventChannels.DATAPOINT_PROCESSED, dataset.testid, event));
-        mediator.dataPointsProcessed(event);
+
+        String timestampFunction = (String) timestampList.get(0)[0];
+        JsonNode value = (JsonNode) timestampList.get(0)[1];
+
+        if (timestampFunction != null && !timestampFunction.isBlank()) {
+            value = Util.evaluateOnce(
+                    timestampFunction,
+                    value,
+                    Util::convertToJson,
+                    (code, throwable) -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
+                            "Evaluation of timestamp failed: '%s' Code: <code><pre>%s</pre></code>", throwable.getMessage(),
+                            code),
+                    output -> logCalculationMessage(dataset, PersistentLogDAO.DEBUG,
+                            "Output while calculating timestamp: <pre>%s</pre>", output));
+        }
+
+        Instant ts = Util.toInstant(value);
+        if (ts == null) {
+            logCalculationMessage(dataset, PersistentLogDAO.ERROR,
+                    "Cannot parse timestamp, must be number or ISO-8601 timestamp: %s", value);
+            ts = dataset.start;
+        }
+        return ts;
+    }
+
+    private void handleCalculatedValue(DatasetDAO dataset, Instant timestamp, VariableData data,
+            Value result, boolean notify, Recalculation recalculation, Set<String> missingValueVariables) {
+        Double value = Util.toDoubleOrNull(result,
+                error -> logCalculationMessage(dataset, PersistentLogDAO.ERROR,
+                        "Evaluation of variable %s failed: %s", data.fullName(), error),
+                info -> logCalculationMessage(dataset, PersistentLogDAO.INFO,
+                        "Evaluation of variable %s: %s", data.fullName(), info));
+
+        if (value != null) {
+            createDataPoint(dataset, timestamp, data.variableId, value, notify, recalculation);
+            return;
+        }
+
+        if (recalculation != null) {
+            recalculation.datasetsWithoutValue.put(dataset.id, dataset.getInfo());
+        }
+        missingValueVariables.add(data.fullName());
+    }
+
+    private void handleNonCalculatedValue(DatasetDAO dataset, Instant timestamp, VariableData data, boolean notify,
+            Recalculation recalculation, Set<String> missingValueVariables) {
+        if (data.numLabels > 1) {
+            logCalculationMessage(dataset, PersistentLogDAO.WARN,
+                    "Variable %s has more than one label (%s) but no calculation function.", data.fullName(),
+                    data.value.fieldNames());
+        }
+
+        if (data.value == null || data.value.isNull()) {
+            logCalculationMessage(dataset, PersistentLogDAO.INFO,
+                    "Null value for variable %s - datapoint is not created", data.fullName());
+            if (recalculation != null) {
+                recalculation.datasetsWithoutValue.put(dataset.id, dataset.getInfo());
+            }
+            missingValueVariables.add(data.fullName());
+            return;
+        }
+
+        Double value = null;
+        if (data.value.isNumber()) {
+            value = data.value.asDouble();
+        } else if (data.value.isTextual()) {
+            try {
+                value = Double.parseDouble(data.value.asText());
+            } catch (NumberFormatException ignored) {
+                // keep value as null
+            }
+        }
+
+        if (value == null) {
+            logCalculationMessage(dataset, PersistentLogDAO.ERROR,
+                    "Cannot turn %s into a floating-point value for variable %s", data.value, data.fullName());
+            if (recalculation != null) {
+                recalculation.errors++;
+            }
+            missingValueVariables.add(data.fullName());
+            return;
+        }
+
+        createDataPoint(dataset, timestamp, data.variableId, value, notify, recalculation);
     }
 
     @Transactional
@@ -546,12 +581,13 @@ public class AlertingServiceImpl implements AlertingService {
                     Parameters.with("dataset", dataset).and("variable", variableDAO)).firstResult();
         }
         if (dataPoint != null) {
-            DataPoint.Event event = new DataPoint.Event(dataPoint.id, dataset.id, notify);
-            onNewDataPoint(event, recalculation.lastDatapoint); //Test failure if we do not start a new thread and new tx
+            onNewDataPoint(dataPoint, recalculation.lastDatapoint, notify);
 
-            if (mediator.testMode())
+            if (mediator.testMode()) {
+                DataPoint.Event event = new DataPoint.Event(dataPoint.id, dataset.id, notify);
                 Util.registerTxSynchronization(tm,
                         txStatus -> mediator.publishEvent(AsyncEventChannels.DATAPOINT_NEW, dataset.testid, event));
+            }
         } else {
             Log.debugf("DataPoint for dataset %d, variable %d, timestamp %s, value %f not found", dataset.id, variableId,
                     timestamp, value);
@@ -591,14 +627,13 @@ public class AlertingServiceImpl implements AlertingService {
 
     @WithRoles(extras = Roles.HORREUM_SYSTEM)
     @Transactional
-    void onNewDataPoint(DataPoint.Event event, boolean lastDatapoint) {
-        DataPointDAO dataPoint = DataPointDAO.findById(event.dataPointId);
+    void onNewDataPoint(DataPointDAO dataPoint, boolean lastDatapoint, boolean notify) {
         if (dataPoint.variable != null) {
             VariableDAO variable = dataPoint.variable;
             Log.debugf("Processing new datapoint for dataset %d at %s, variable %d (%s), value %f",
-                    event.datasetId, dataPoint.timestamp, variable.id, variable.name, dataPoint.value);
+                    dataPoint.dataset.id, dataPoint.timestamp, variable.id, variable.name, dataPoint.value);
 
-            FingerprintDAO fingerprint = FingerprintDAO.<FingerprintDAO> findByIdOptional(event.datasetId).orElse(null);
+            FingerprintDAO fingerprint = FingerprintDAO.<FingerprintDAO> findByIdOptional(dataPoint.dataset.id).orElse(null);
             JsonNode fpNode = fingerprint != null ? fingerprint.fingerprint : null;
             Integer fpHash = fingerprint != null ? fingerprint.fpHash : null;
 
@@ -612,10 +647,14 @@ public class AlertingServiceImpl implements AlertingService {
                     return current;
                 }
             });
-            runChangeDetection(variable.id, variable.testId, fpNode, fpHash, event.notify, true, lastDatapoint);
+            //before we run change detection, lets see how many changes there are for this dataset
+            long count = ChangeDAO.count("dataset.id", dataPoint.dataset.id);
+            Log.infof("There are %d changes for dataset %d and variable %d", count, dataPoint.dataset.id, variable.id);
+
+            runChangeDetection(variable.id, variable.testId, fpNode, fpHash, notify, true, lastDatapoint);
         } else {
             Log.warnf("Could not process new datapoint for dataset %d when the supplied variable or id reference is null ",
-                    event.datasetId);
+                    dataPoint.dataset.id);
         }
     }
 
@@ -627,10 +666,35 @@ public class AlertingServiceImpl implements AlertingService {
 
     @Transactional
     void runChangeDetection(int variableId, int testId, JsonNode fingerprint, Integer fpHash, boolean notify,
-            boolean expectExists,
-            boolean lastDatapoint) {
+            boolean expectExists, boolean lastDatapoint) {
         UpTo valid = validUpTo.get(new VarAndFingerprint(variableId, fpHash));
-        Instant nextTimestamp = session.createNativeQuery(
+        Instant nextTimestamp = fetchNextTimestamp(variableId, fpHash, valid);
+
+        if (nextTimestamp == null) {
+            Log.debugf("No further datapoints for change detection");
+            return;
+        }
+        if (valid != null) {
+            deleteChangesByTimeframe(variableId, fpHash, valid);
+        }
+
+        Instant changeTimestamp = fetchLastChangeTimestamp(variableId, fpHash, valid);
+        List<DataPointDAO> dataPoints = fetchDataPoints(variableId, fpHash, changeTimestamp, nextTimestamp);
+
+        if (dataPoints.isEmpty()) {
+            if (expectExists) {
+                Log.warn("The published datapoint should be already in the list");
+            }
+        } else {
+            processChangeDetection(variableId, testId, fingerprint, notify, lastDatapoint, dataPoints);
+        }
+
+        validateUpTo(variableId, fpHash, nextTimestamp);
+        tryRunChangeDetection(variableId, testId, fingerprint, fpHash, notify);
+    }
+
+    private Instant fetchNextTimestamp(int variableId, Integer fpHash, UpTo valid) {
+        return session.createNativeQuery(
                 "SELECT MIN(timestamp) FROM datapoint dp LEFT JOIN fingerprint fp ON dp.dataset_id = fp.dataset_id " +
                         "WHERE dp.variable_id = :variableId " +
                         "AND (timestamp > :validTimestamp OR (timestamp = :validTimestamp AND :exclusive)) " +
@@ -641,46 +705,38 @@ public class AlertingServiceImpl implements AlertingService {
                 .setParameter("exclusive", valid == null || !valid.inclusive)
                 .setParameter("fpHash", fpHash)
                 .getResultStream().filter(Objects::nonNull).findFirst().orElse(null);
-        if (nextTimestamp == null) {
-            // this is the exit clause to stops the recursive invocation
-            Log.debugf("No further datapoints for change detection");
-            return;
-        }
+    }
 
-        // this should happen only after reboot, let's start with last change
-        // FIXME: this is happening also when updating a single label for a schema
-        if (valid != null) {
-            int numDeleted = session.createNativeQuery(DELETE_CHANGES_BY_TIMEFRAME, int.class)
-                    .setParameter("variableId", variableId)
-                    .setParameter("validTimestamp", valid.timestamp, StandardBasicTypes.INSTANT)
-                    .setParameter("exclusive", !valid.inclusive)
-                    .setParameter("fpHash", fpHash)
-                    .executeUpdate();
-            Log.debugf("Deleted %d changes %s %s for variable %d, fingerprint %s", numDeleted, valid.inclusive ? ">" : ">=",
-                    valid.timestamp, variableId, fpHash);
-        }
+    private void deleteChangesByTimeframe(int variableId, Integer fpHash, UpTo valid) {
+        int numDeleted = session.createNativeQuery(DELETE_CHANGES_BY_TIMEFRAME, int.class)
+                .setParameter("variableId", variableId)
+                .setParameter("validTimestamp", valid.timestamp, StandardBasicTypes.INSTANT)
+                .setParameter("exclusive", !valid.inclusive)
+                .setParameter("fpHash", fpHash)
+                .executeUpdate();
+        Log.debugf("Deleted %d changes %s %s for variable %d, fingerprint %s", numDeleted, valid.inclusive ? ">" : ">=",
+                valid.timestamp, variableId, fpHash);
+    }
 
-        var changeQuery = session
-                .createQuery("SELECT c FROM Change c LEFT JOIN Fingerprint fp ON c.dataset.id = fp.datasetId " +
+    private Instant fetchLastChangeTimestamp(int variableId, Integer fpHash, UpTo valid) {
+        var changeQuery = session.createQuery(
+                "SELECT c FROM Change c LEFT JOIN Fingerprint fp ON c.dataset.id = fp.datasetId " +
                         "WHERE c.variable.id = :variableId AND fp.fpHash = :fpHash " +
                         "AND (c.timestamp < :validTimestamp OR (c.timestamp = :validTimestamp AND :exclusive = TRUE)) " +
-                        "ORDER by c.timestamp DESC", ChangeDAO.class);
-        changeQuery
-                .setParameter("variableId", variableId)
+                        "ORDER by c.timestamp DESC",
+                ChangeDAO.class);
+        changeQuery.setParameter("variableId", variableId)
                 .setParameter("validTimestamp", valid != null ? valid.timestamp : VERY_DISTANT_FUTURE)
                 .setParameter("exclusive", valid == null || valid.inclusive)
                 .setParameter("fpHash", fpHash);
         ChangeDAO lastChange = changeQuery.setMaxResults(1).getResultStream().findFirst().orElse(null);
+        return lastChange != null ? lastChange.timestamp : LONG_TIME_AGO;
+    }
 
-        Instant changeTimestamp = LONG_TIME_AGO;
-        if (lastChange != null) {
-            Log.debugf("Filtering DP between %s (change %d) and %s", lastChange.timestamp, lastChange.id, nextTimestamp);
-            changeTimestamp = lastChange.timestamp;
-        }
-
-        List<DataPointDAO> dataPoints = session.createQuery(
+    private List<DataPointDAO> fetchDataPoints(int variableId, Integer fpHash, Instant changeTimestamp, Instant nextTimestamp) {
+        return session.createQuery(
                 "SELECT dp FROM DataPoint dp LEFT JOIN Fingerprint fp ON dp.dataset.id = fp.datasetId " +
-                        "JOIN dp.dataset " + // ignore datapoints (that were not deleted yet) from deleted datasets
+                        "JOIN dp.dataset " +
                         "WHERE dp.variable.id = :variableId AND dp.timestamp BETWEEN :changeTimestamp AND :nextTimestamp " +
                         "AND fp.fpHash = :fpHash " +
                         "ORDER BY dp.timestamp DESC, dp.dataset.id DESC",
@@ -690,50 +746,39 @@ public class AlertingServiceImpl implements AlertingService {
                 .setParameter("nextTimestamp", nextTimestamp)
                 .setParameter("fpHash", fpHash)
                 .getResultList();
-        // Last datapoint is already in the list
-        if (dataPoints.isEmpty()) {
-            if (expectExists) {
-                Log.warn("The published datapoint should be already in the list");
+    }
+
+    private void processChangeDetection(int variableId, int testId, JsonNode fingerprint, boolean notify,
+            boolean lastDatapoint, List<DataPointDAO> dataPoints) {
+        int datasetId = dataPoints.get(0).getDatasetId();
+        for (ChangeDetectionDAO detection : ChangeDetectionDAO.<ChangeDetectionDAO> find("variable.id", variableId).list()) {
+            ChangeDetectionModel model = modelResolver.getModel(ChangeDetectionModelType.fromString(detection.model));
+            if (model == null) {
+                logChangeDetectionMessage(variableId, datasetId, PersistentLogDAO.ERROR,
+                        "Cannot find change detection model %s", detection.model);
+                continue;
             }
-        } else {
-            int datasetId = dataPoints.get(0).getDatasetId();
-            for (ChangeDetectionDAO detection : ChangeDetectionDAO.<ChangeDetectionDAO> find("variable.id", variableId)
-                    .list()) {
-                ChangeDetectionModel model = modelResolver.getModel(ChangeDetectionModelType.fromString(detection.model));
-                if (model == null) {
-                    logChangeDetectionMessage(variableId, datasetId, PersistentLogDAO.ERROR,
-                            "Cannot find change detection model %s", detection.model);
-                    continue;
-                }
-                //Only run bulk models on the last datapoint, otherwise run on every datapoint
-                if (model.getType() == ModelType.CONTINOUS || (model.getType() == ModelType.BULK && lastDatapoint)) {
-                    try {
-                        model.analyze(dataPoints, detection.config, change -> {
-                            logChangeDetectionMessage(testId, datasetId, PersistentLogDAO.DEBUG,
-                                    "Change %s detected using datapoints %s", change, reversedAndLimited(dataPoints));
-                            em.persist(change);
-                            //                            Hibernate.initialize(change.dataset.run.id);
-                            String testName = TestDAO.<TestDAO> findByIdOptional(testId).map(test -> test.name)
-                                    .orElse("<unknown>");
-                            Change.Event event = new Change.Event(ChangeMapper.from(change), testId, testName, notify);
-                            if (mediator.testMode())
-                                Util.registerTxSynchronization(tm, txStatus -> mediator
-                                        .publishEvent(AsyncEventChannels.CHANGE_NEW, change.dataset.testid, event));
-                            mediator.executeBlocking(() -> mediator.newChange(event));
-                        });
-                    } catch (ChangeDetectionException e) {
-                        new ChangeDetectionLogDAO(variableId, fingerprint, PersistentLogDAO.ERROR, e.getLocalizedMessage())
-                                .persist();
-                        Log.error("An error occurred while running change detection!", e);
-                    }
+            if (model.getType() == ModelType.CONTINOUS || (model.getType() == ModelType.BULK && lastDatapoint)) {
+                try {
+                    model.analyze(dataPoints, detection.config, change -> {
+                        logChangeDetectionMessage(testId, datasetId, PersistentLogDAO.DEBUG,
+                                "Change %s detected using datapoints %s", change, reversedAndLimited(dataPoints));
+                        em.persist(change);
+                        String testName = TestDAO.<TestDAO> findByIdOptional(testId).map(test -> test.name).orElse("<unknown>");
+                        Change.Event event = new Change.Event(ChangeMapper.from(change), testId, testName, notify);
+                        if (mediator.testMode()) {
+                            Util.registerTxSynchronization(tm, txStatus -> mediator
+                                    .publishEvent(AsyncEventChannels.CHANGE_NEW, change.dataset.testid, event));
+                        }
+                        mediator.newChange(event);
+                    });
+                } catch (ChangeDetectionException e) {
+                    new ChangeDetectionLogDAO(variableId, fingerprint, PersistentLogDAO.ERROR, e.getLocalizedMessage())
+                            .persist();
+                    Log.error("An error occurred while running change detection!", e);
                 }
             }
         }
-        Util.doAfterCommit(tm, () -> {
-            validateUpTo(variableId, fpHash, nextTimestamp);
-            //assume not last datapoint if we have found more
-            messageBus.executeForTest(testId, () -> tryRunChangeDetection(variableId, testId, fingerprint, fpHash, notify));
-        });
     }
 
     private void validateUpTo(int variableId, int fpHash, Instant timestamp) {
@@ -983,9 +1028,7 @@ public class AlertingServiceImpl implements AlertingService {
             throw ServiceException.forbidden("This user cannot trigger the recalculation");
         }
 
-        messageBus.executeForTest(testId, () -> {
-            startRecalculation(testId, notify, debug, clearDatapoints == null || clearDatapoints, from, to);
-        });
+        startRecalculation(testId, notify, debug, clearDatapoints == null || clearDatapoints, from, to);
     }
 
     // It doesn't make sense to limit access to particular user when doing the recalculation,
@@ -1248,11 +1291,7 @@ public class AlertingServiceImpl implements AlertingService {
         }
         // The recalculations are executed in independent transactions, therefore we need to make sure that
         // this rule is committed in DB before starting to reevaluate it.
-        Util.doAfterCommit(tm, () -> {
-            messageBus.executeForTest(testId, () -> {
-                recalculateMissingDataRules(testId, rule);
-            });
-        });
+        recalculateMissingDataRules(testId, rule);
         return rule.id;
     }
 
@@ -1268,7 +1307,7 @@ public class AlertingServiceImpl implements AlertingService {
     }
 
     @WithRoles(extras = Roles.HORREUM_SYSTEM)
-    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @Transactional
     void recalculateMissingDataRule(int datasetId, Instant timestamp, MissingDataRuleDAO rule) {
         JsonNode value = (JsonNode) em.createNativeQuery(LOOKUP_LABEL_VALUE_FOR_RULE)
                 .setParameter(1, datasetId).setParameter(2, rule.id)

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/EventAggregator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/EventAggregator.java
@@ -51,7 +51,7 @@ public class EventAggregator {
             if (next == null) {
                 return;
             } else if (next.emitTimestamp() <= now) {
-                mediator.executeBlocking(() -> mediator.newDatasetChanges(next));
+                mediator.newDatasetChanges(next);
                 datasetChanges.remove(next.dataset.id);
             } else {
                 if (timerId >= 0) {

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/SchemaServiceImpl.java
@@ -55,7 +55,6 @@ import io.hyperfoil.tools.horreum.api.data.SchemaExport;
 import io.hyperfoil.tools.horreum.api.data.Transformer;
 import io.hyperfoil.tools.horreum.api.services.SchemaService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
-import io.hyperfoil.tools.horreum.bus.BlockingTaskDispatcher;
 import io.hyperfoil.tools.horreum.entity.ValidationErrorDAO;
 import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
 import io.hyperfoil.tools.horreum.entity.data.LabelDAO;
@@ -126,8 +125,6 @@ public class SchemaServiceImpl implements SchemaService {
     @Inject
     ServiceMediator mediator;
 
-    @Inject
-    BlockingTaskDispatcher messageBus;
     @Inject
     Session session;
 

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.horreum.svc;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -247,13 +248,13 @@ public class ServiceMediator {
     @ActivateRequestContext
     public void processChangeDetectionEvent(ChangeDetectionEvent event) {
         alertingService.runChangeDetection(
-                event.testId, event.datasetId, event.variableId, event.timestamp, event.notification, true, true);
+                event.testId, event.datasetId, event.variableIds, event.timestamp, event.notification, true, true);
     }
 
     @Transactional(Transactional.TxType.NOT_SUPPORTED)
     void queueChangeDetectionEvent(ChangeDetectionEvent event) {
         OutgoingAmqpMetadata meta = OutgoingAmqpMetadata.builder()
-                .withGroupId(event.testId + "v" + event.variableId) // serialize messages on a combination of test and variable
+                .withGroupId(event.testId.toString()) // serialize messages on a combination of test and variable
                 .build();
         changeDetectionEmitter.send(Message.of(event).addMetadata(meta));
     }
@@ -368,6 +369,6 @@ public class ServiceMediator {
     }
 
     public record ChangeDetectionEvent(
-            Integer testId, Integer datasetId, Integer variableId, Instant timestamp, boolean notification) {
+            Integer testId, Integer datasetId, Collection<Integer> variableIds, Instant timestamp, boolean notification) {
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/ServiceMediator.java
@@ -117,10 +117,6 @@ public class ServiceMediator {
     public ServiceMediator() {
     }
 
-    void executeBlocking(Runnable runnable) {
-        Util.executeBlocking(vertx, runnable);
-    }
-
     boolean testMode() {
         return testMode;
     }
@@ -157,6 +153,7 @@ public class ServiceMediator {
         datasetService.deleteDataset(datasetId);
     }
 
+    @Transactional
     void newChange(Change.Event event) {
         actionService.onNewChange(event);
         aggregator.onNewChange(event);

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/TestServiceImpl.java
@@ -707,21 +707,19 @@ public class TestServiceImpl implements TestService {
                 Log.debugf("Recalculate Datasets for run %d - forcing recalculation for test %d (%s)", runId, testId,
                         test.name);
 
-                mediator.executeBlocking(() -> {
-                    int newDatasets = 0;
-                    try {
-                        newDatasets = mediator.transform(runId, true);
-                    } finally {
-                        synchronized (status) {
-                            status.finished++;
-                            status.datasets += newDatasets;
-                            if (status.finished == status.totalRuns) {
-                                Log.infof("Datasets recalculation for test %d (%s) completed", testId, test.name);
-                                recalculations.remove(testId, status);
-                            }
+                int newDatasets = 0;
+                try {
+                    newDatasets = mediator.transform(runId, true);
+                } finally {
+                    synchronized (status) {
+                        status.finished++;
+                        status.datasets += newDatasets;
+                        if (status.finished == status.totalRuns) {
+                            Log.infof("Datasets recalculation for test %d (%s) completed", testId, test.name);
+                            recalculations.remove(testId, status);
                         }
                     }
-                });
+                }
             }
         }
     }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/svc/Util.java
@@ -528,20 +528,6 @@ public class Util {
         return causes.toString();
     }
 
-    public static void executeBlocking(Vertx vertx, Runnable runnable) {
-        Runnable wrapped = wrapForBlockingExecution(runnable);
-        vertx.executeBlocking(promise -> {
-            try {
-                wrapped.run();
-            } catch (Exception e) {
-                Log.error("Failed to execute blocking task", e);
-            } finally {
-                promise.complete();
-            }
-        }, result -> {
-        });
-    }
-
     public static Runnable wrapForBlockingExecution(Runnable runnable) {
         // CDI needs to be propagated - without that the interceptors wouldn't run.
         // Without thread context propagation we would get an exception in Run.findById, though the interceptors would be invoked correctly.

--- a/horreum-backend/src/main/resources/application.properties
+++ b/horreum-backend/src/main/resources/application.properties
@@ -34,6 +34,7 @@ quarkus.datasource.jdbc.initial-size=3
 
 # thread pool sizes
 smallrye.messaging.worker.horreum.dataset.pool.max-concurrency=10
+smallrye.messaging.worker.horreum.change-detection.pool.max-concurrency=5
 smallrye.messaging.worker.horreum.run.pool.max-concurrency=6
 smallrye.messaging.worker.horreum.schema.pool.max-concurrency=5
 
@@ -54,6 +55,21 @@ mp.messaging.outgoing.dataset-event-out.durable=true
 mp.messaging.outgoing.dataset-event-out.container-id=horreum-broker
 mp.messaging.outgoing.dataset-event-out.link-name=dataset-event
 mp.messaging.outgoing.dataset-event-out.failure-strategy=modified-failed
+
+# change-detection-event incoming
+mp.messaging.incoming.change-detection-event-in.connector=smallrye-amqp
+mp.messaging.incoming.change-detection-event-in.address=change-detection-event
+mp.messaging.incoming.change-detection-event-in.durable=true
+mp.messaging.incoming.change-detection-event-in.container-id=horreum-broker
+mp.messaging.incoming.change-detection-event-in.link-name=change-detection-event
+mp.messaging.incoming.change-detection-event-in.failure-strategy=modified-failed
+# change-detection-event outgoing
+mp.messaging.outgoing.change-detection-event-out.connector=smallrye-amqp
+mp.messaging.outgoing.change-detection-event-out.address=change-detection-event
+mp.messaging.outgoing.change-detection-event-out.durable=true
+mp.messaging.outgoing.change-detection-event-out.container-id=horreum-broker
+mp.messaging.outgoing.change-detection-event-out.link-name=change-detection-event
+mp.messaging.outgoing.change-detection-event-out.failure-strategy=modified-failed
 
 # re-calc incoming
 mp.messaging.incoming.run-recalc-in.connector=smallrye-amqp

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/changedetection/EdivisiveTests.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/changedetection/EdivisiveTests.java
@@ -194,7 +194,7 @@ public class EdivisiveTests extends BaseServiceTest {
         int run10 = uploadRun(ts + 4, ts + 4, runWithValue(10, schema), test.name);
         assertValue(datapointQueue, 10);
 
-        Change.Event changeEvent1 = changeQueue.poll(10, TimeUnit.SECONDS);
+        Change.Event changeEvent1 = changeQueue.poll(40, TimeUnit.SECONDS);
         assertNotNull(changeEvent1);
 
         testSerialization(changeEvent1, Change.Event.class);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/AlertingServiceTest.java
@@ -153,7 +153,7 @@ public class AlertingServiceTest extends BaseServiceTest {
         int run4 = uploadRun(ts + 3, ts + 3, runWithValue(2, schema), test.name);
         assertValue(datapointQueue, 2);
 
-        assertNull(changeQueue.poll(50, TimeUnit.MILLISECONDS));
+        assertNull(changeQueue.poll(500, TimeUnit.MILLISECONDS));
 
         uploadRun(ts + 4, ts + 4, runWithValue(3, schema), test.name);
         assertValue(datapointQueue, 3);
@@ -186,7 +186,7 @@ public class AlertingServiceTest extends BaseServiceTest {
         assertValue(datapointQueue, 1.5);
 
         // mean of previous values is 1.5, now the min is 1.5 => no change
-        assertNull(changeQueue.poll(50, TimeUnit.MILLISECONDS));
+        assertNull(changeQueue.poll(500, TimeUnit.MILLISECONDS));
 
         uploadRun(ts + 6, ts + 6, runWithValue(2, schema), test.name);
         assertValue(datapointQueue, 2);

--- a/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
+++ b/horreum-backend/src/test/java/io/hyperfoil/tools/horreum/svc/BaseServiceTest.java
@@ -62,7 +62,6 @@ import io.hyperfoil.tools.horreum.api.services.ExperimentService;
 import io.hyperfoil.tools.horreum.api.services.RunService;
 import io.hyperfoil.tools.horreum.api.services.TestService;
 import io.hyperfoil.tools.horreum.bus.AsyncEventChannels;
-import io.hyperfoil.tools.horreum.bus.BlockingTaskDispatcher;
 import io.hyperfoil.tools.horreum.entity.ExperimentProfileDAO;
 import io.hyperfoil.tools.horreum.entity.FingerprintDAO;
 import io.hyperfoil.tools.horreum.entity.alerting.*;
@@ -99,9 +98,6 @@ public class BaseServiceTest {
 
     @Inject
     protected RoleManager roleManager;
-
-    @Inject
-    BlockingTaskDispatcher messageBus;
 
     @Inject
     ObjectMapper mapper;


### PR DESCRIPTION
## Fixes Issue

Improves how the change detection is performed.

This PR incorporates #2559  

## Changes proposed

A new event and queue is used to decouple change detection from datapoint creation. 
Change detection now is done in one go, instead of the previous algorithm.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
