### PR TITLE
[0.19] fix: SlackPluginBase port parsing fails for URLs without explicit port

### DIFF
--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/SlackPluginBase.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/SlackPluginBase.java
@@ -55,7 +55,7 @@ public abstract class SlackPluginBase {
         }
         RequestOptions options = new RequestOptions()
                 .setHost(url.getHost())
-                .setPort(url.getPort())
+                .setPort(url.getPort() > 0 ? url.getPort() : url.getDefaultPort())
                 .setURI(url.getPath())
                 .setSsl("https".equalsIgnoreCase(url.getProtocol()));
         return client.httpClient().request(HttpMethod.POST, options)


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2618

## Summary

- `SlackPluginBase.java:58` passes `url.getPort()` directly to `RequestOptions.setPort()`
- `URL.getPort()` returns `-1` when the URL has no explicit port (e.g. `https://api.slack.com/api/chat.postMessage`)
- Vert.x validates port range `0 <= p <= 65535` and throws `IllegalArgumentException` on `-1`
- This causes all Slack channel message actions to fail with: `Failed to post message to <channel>: port p must be in range 0 <= p <= 65535`

## Solution

Fall back to `url.getDefaultPort()` when `getPort()` returns `-1`, matching the pattern already used in `HttpAction.java`.

## Changes

- Modified `SlackPluginBase.java` to use `getDefaultPort()` as fallback for missing explicit port