### PR TITLE
[0.19] Feat: add ChangeToSlackWebhook formatter for HttpAction

### DIFF
--- a/docs/site/content/en/openapi/openapi.yaml
+++ b/docs/site/content/en/openapi/openapi.yaml
@@ -1023,6 +1023,10 @@ components:
         url:
           type: string
           description: HTTP address
+        formatter:
+          type: string
+          description: "Optional formatter to transform payload before sending; when\
+            \ set, wraps formatted text in {\"text\": \"...\"}"
     IndexedLabelValueMap:
       type: object
       additionalProperties:

--- a/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/ActionConfig/HttpActionConfig.java
+++ b/horreum-api/src/main/java/io/hyperfoil/tools/horreum/api/data/ActionConfig/HttpActionConfig.java
@@ -7,6 +7,9 @@ public class HttpActionConfig extends BaseActionConfig {
     @Schema(type = SchemaType.STRING, required = true, description = "HTTP address")
     public String url;
 
+    @Schema(type = SchemaType.STRING, required = false, description = "Optional formatter to transform payload before sending; when set, wraps formatted text in {\"text\": \"...\"}")
+    public String formatter;
+
     public HttpActionConfig() {
         this.type = ActionType.HTTP.toString();
     }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/ChangeToSlackWebhook.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/ChangeToSlackWebhook.java
@@ -1,0 +1,56 @@
+package io.hyperfoil.tools.horreum.action;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.hyperfoil.tools.horreum.api.alerting.Change;
+import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
+import io.hyperfoil.tools.horreum.svc.Util;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+
+@ApplicationScoped
+public class ChangeToSlackWebhook implements BodyFormatter {
+    @Location("new_issue_from_change")
+    Template template;
+
+    @ConfigProperty(name = "horreum.url")
+    String publicUrl;
+
+    @Override
+    public String name() {
+        return "changeToSlackWebhook";
+    }
+
+    @Override
+    public String format(JsonNode config, Object payload) {
+        if (!(payload instanceof Change.Event)) {
+            throw new IllegalArgumentException("This formatter accepts only Change.Event!");
+        }
+        Change.Event event = (Change.Event) payload;
+        Change change = event.change;
+        String fingerprint = DatasetDAO.getEntityManager().getReference(DatasetDAO.class, change.dataset.id).getFingerprint();
+        String text = template
+                .data("testName", event.testName)
+                .data("testNameEncoded", URLEncoder.encode(event.testName, StandardCharsets.UTF_8))
+                .data("fingerprint", URLEncoder.encode(fingerprint, StandardCharsets.UTF_8))
+                .data("publicUrl", publicUrl)
+                .data("testId", String.valueOf(change.variable.testId))
+                .data("variable", change.variable.name)
+                .data("group", change.variable.group)
+                .data("runId", event.change.dataset.runId)
+                .data("datasetOrdinal", event.change.dataset.ordinal)
+                .data("description", change.description)
+                .render();
+        ObjectNode body = Util.OBJECT_MAPPER.createObjectNode();
+        body.put("text", text);
+        return body.toString();
+    }
+}

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/ChangeToSlackWebhook.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/ChangeToSlackWebhook.java
@@ -8,17 +8,15 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.api.alerting.Change;
 import io.hyperfoil.tools.horreum.entity.data.DatasetDAO;
-import io.hyperfoil.tools.horreum.svc.Util;
 import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 
 @ApplicationScoped
 public class ChangeToSlackWebhook implements BodyFormatter {
-    @Location("new_issue_from_change")
+    @Location("slack_from_change")
     Template template;
 
     @ConfigProperty(name = "horreum.url")
@@ -49,8 +47,6 @@ public class ChangeToSlackWebhook implements BodyFormatter {
                 .data("datasetOrdinal", event.change.dataset.ordinal)
                 .data("description", change.description)
                 .render();
-        ObjectNode body = Util.OBJECT_MAPPER.createObjectNode();
-        body.put("text", text);
-        return body.toString();
+        return text;
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
@@ -5,11 +5,13 @@ import java.net.URL;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.entity.data.AllowedSiteDAO;
 import io.hyperfoil.tools.horreum.svc.ServiceException;
@@ -31,6 +33,9 @@ public class HttpAction implements ActionPlugin {
 
     @Inject
     Vertx reactiveVertx;
+
+    @Inject
+    Instance<BodyFormatter> formatters;
 
     @ConfigProperty(name = "horreum.hook.tls.insecure", defaultValue = "false")
     boolean insecureTls;
@@ -88,10 +93,12 @@ public class HttpAction implements ActionPlugin {
                 .setPort(url.getPort() >= 0 ? url.getPort() : url.getDefaultPort())
                 .setURI(url.getFile())
                 .setSsl("https".equalsIgnoreCase(url.getProtocol()));
+        Buffer requestBody = buildBody(config, payload, body);
+
         Log.infof("Sending event to %s", url);
         return http1xClient.request(HttpMethod.POST, options)
                 .putHeader("Content-Type", "application/json")
-                .sendBuffer(Buffer.buffer(body.toString()))
+                .sendBuffer(requestBody)
                 .onItem().transform(response -> {
                     if (response.statusCode() < 400) {
                         return "Successfully(" + response.statusCode() + ") notified hook: " + url;
@@ -100,5 +107,20 @@ public class HttpAction implements ActionPlugin {
                                 + ": " + response.bodyAsString());
                     }
                 }).onFailure().transform(t -> new RuntimeException("Failed to POST " + url + ": " + t.getMessage()));
+    }
+
+    private Buffer buildBody(JsonNode config, Object payload, JsonNode rawBody) {
+        String formatterName = config.path("formatter").asText(null);
+        if (formatterName == null || formatterName.isBlank()) {
+            return Buffer.buffer(rawBody.toString());
+        }
+        BodyFormatter formatter = formatters.stream()
+                .filter(f -> f.name().equals(formatterName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown formatter '" + formatterName + "'"));
+        String text = formatter.format(config, payload);
+        ObjectNode slackPayload = Util.OBJECT_MAPPER.createObjectNode();
+        slackPayload.put("text", text);
+        return Buffer.buffer(slackPayload.toString());
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.entity.data.AllowedSiteDAO;
 import io.hyperfoil.tools.horreum.svc.ServiceException;
@@ -117,6 +118,13 @@ public class HttpAction implements ActionPlugin {
                 .filter(f -> f.name().equals(formatterName))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown formatter '" + formatterName + "'"));
-        return Buffer.buffer(formatter.format(config, payload));
+        String text = formatter.format(config, payload);
+        String url=config.path("url").asText("");
+        if (url.contains("hooks.slack.com")) {
+            ObjectNode slackPayload = Util.OBJECT_MAPPER.createObjectNode();
+            slackPayload.put("text", text);
+            return Buffer.buffer(slackPayload.toString());
+        }
+        return Buffer.buffer(text);
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
@@ -11,7 +11,6 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.hyperfoil.tools.horreum.entity.data.AllowedSiteDAO;
 import io.hyperfoil.tools.horreum.svc.ServiceException;
@@ -118,9 +117,6 @@ public class HttpAction implements ActionPlugin {
                 .filter(f -> f.name().equals(formatterName))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown formatter '" + formatterName + "'"));
-        String text = formatter.format(config, payload);
-        ObjectNode slackPayload = Util.OBJECT_MAPPER.createObjectNode();
-        slackPayload.put("text", text);
-        return Buffer.buffer(slackPayload.toString());
+        return Buffer.buffer(formatter.format(config, payload));
     }
 }

--- a/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
+++ b/horreum-backend/src/main/java/io/hyperfoil/tools/horreum/action/HttpAction.java
@@ -119,7 +119,7 @@ public class HttpAction implements ActionPlugin {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown formatter '" + formatterName + "'"));
         String text = formatter.format(config, payload);
-        String url=config.path("url").asText("");
+        String url = config.path("url").asText("");
         if (url.contains("hooks.slack.com")) {
             ObjectNode slackPayload = Util.OBJECT_MAPPER.createObjectNode();
             slackPayload.put("text", text);

--- a/horreum-backend/src/main/resources/templates/slack_from_change.md
+++ b/horreum-backend/src/main/resources/templates/slack_from_change.md
@@ -1,0 +1,8 @@
+There has been a recent change in results for test <{publicUrl}/test/{testId}|{testName}>,
+change detection variable {#if group != null}{group}/{/if}{variable},
+introduced with dataset <{publicUrl}/run/{runId}#dataset{datasetOrdinal}|{runId}#{datasetOrdinal + 1}>.
+
+This is the current explanation for the change:
+> {description}
+
+Please <{publicUrl}/changes?test={testNameEncoded}&fingerprint={fingerprint}|check it out> and provide an explanatory description.

--- a/horreum-web/src/domain/actions/ActionComponentForm.tsx
+++ b/horreum-web/src/domain/actions/ActionComponentForm.tsx
@@ -118,15 +118,36 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                 </FormHelperText>
             </FormGroup>
             {props.action.type === "http" && (
-                <HttpActionUrlSelector
-                    active={props.isTester}
-                    value={(props.action.config as Http)?.url || ""}
-                    setValue={value => {
-                        updateConfig({ url: value })
-                    }}
-                    isReadOnly={!props.isTester}
-                    setValid={props.setValid}
-                />
+                <>
+                    <HttpActionUrlSelector
+                        active={props.isTester}
+                        value={(props.action.config as Http)?.url || ""}
+                        setValue={value => {
+                            updateConfig({ url: value })
+                        }}
+                        isReadOnly={!props.isTester}
+                        setValid={props.setValid}
+                    />
+                    <FormGroup label="Formatter" fieldId="formatter">
+                        <SimpleSelect
+                            initialOptions={
+                                (props.action.event === CHANGE_NEW
+                                    ? [{value: "changeToMarkdown", content: "Change to Markdown"}]
+                                    : props.action.event === EXPERIMENT_RESULT_NEW
+                                        ? [{value: "experimentsResultToMarkdown", content: "Experiment result to Markdown"}]
+                                        : props.action.event === TEST_NEW
+                                            ? [{value: "testToSlack", content: "Test to Slack Markdown"}]
+                                            : []
+                                ).map(o => ({...o, selected: o.value === (props.action.config as Http).formatter}))
+                            }
+                            placeholderText="None (send raw JSON)"
+                            selected={(props.action.config as Http).formatter}
+                            onSelect={(_, value) => updateConfig({formatter: value as string})}
+                            isDisabled={!props.isTester}
+                            toggleWidth="100%"
+                        />
+                    </FormGroup>
+                </>
             )}
             {props.action.type === "github-issue-comment" && (
                 <>

--- a/horreum-web/src/domain/actions/ActionComponentForm.tsx
+++ b/horreum-web/src/domain/actions/ActionComponentForm.tsx
@@ -132,7 +132,10 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                         <SimpleSelect
                             initialOptions={
                                 (props.action.event === CHANGE_NEW
-                                    ? [{value: "changeToMarkdown", content: "Change to Markdown"}]
+                                    ? [
+                                        {value: "changeToMarkdown", content: "Change to Markdown"},
+                                        {value: "changeToSlackWebhook", content: "Change to Slack Webhook"}
+                                      ]
                                     : props.action.event === EXPERIMENT_RESULT_NEW
                                         ? [{value: "experimentsResultToMarkdown", content: "Experiment result to Markdown"}]
                                         : props.action.event === TEST_NEW
@@ -140,7 +143,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                             : []
                                 ).map(o => ({...o, selected: o.value === (props.action.config as Http).formatter}))
                             }
-                            placeholderText="None (send raw JSON)"
+                            placeholder="None (send raw JSON)"
                             selected={(props.action.config as Http).formatter}
                             onSelect={(_, value) => updateConfig({formatter: value as string})}
                             isDisabled={!props.isTester}

--- a/horreum-web/src/domain/actions/ActionComponentForm.tsx
+++ b/horreum-web/src/domain/actions/ActionComponentForm.tsx
@@ -137,7 +137,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                         {value: "changeToSlackWebhook", content: "Change to Slack Webhook"}
                                       ]
                                     : props.action.event === EXPERIMENT_RESULT_NEW
-                                        ? [{value: "experimentsResultToMarkdown", content: "Experiment result to Markdown"}]
+                                        ? [{value: "experimentResultToMarkdown", content: "Experiment result to Markdown"}]
                                         : props.action.event === TEST_NEW
                                             ? [{value: "testToSlack", content: "Test to Slack Markdown"}]
                                             : []
@@ -221,7 +221,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                         <SimpleSelect
                             initialOptions={
                                 (props.action.event === EXPERIMENT_RESULT_NEW
-                                        ? [{value: "experimentsResultToMarkdown", content: "Experiment result to Markdown"}]
+                                        ? [{value: "experimentResultToMarkdown", content: "Experiment result to Markdown"}]
                                         : []
                                 ).map(
                                     o => ({...o, selected: o.value == (props.action.config as GithubIssueComment).formatter})
@@ -299,7 +299,7 @@ export default function ActionComponentForm(props: ActionComponentFormProps) {
                                 (props.action.event === CHANGE_NEW
                                         ? [{value: "changeToMarkdown", content: "Change to Markdown"}]
                                         : props.action.event === EXPERIMENT_RESULT_NEW
-                                            ? [{value: "experimentsResultToMarkdown", content: "Experiment result to Markdown"}]
+                                            ? [{value: "experimentResultToMarkdown", content: "Experiment result to Markdown"}]
                                             : props.action.event === TEST_NEW
                                                 ? [{value: "testToSlack", content: "Test to Slack Markdown"}]
                                                 : []


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Horreum/pull/2620

## Problem

  The `slack-channel-message` action requires a bot token with `chat:write` scope.
  In enterprise Slack workspaces, adding this scope requires an IT approval process
  that can take weeks.

  Users who already have a Slack app with `incoming-webhook` (auto-approved) cannot
  use the `http` action as a fallback — it sends raw Horreum JSON that Slack's
  Incoming Webhook API rejects.

  ## Solution

  Add an optional `formatter` field to the `http` action. When set, the payload is
  formatted and wrapped in `{"text": "..."}` before posting — exactly what Slack
  webhooks expect. When absent, behavior is unchanged (raw JSON).

  ```json
  {
    "event": "change/new",
    "type": "http",
    "config": {
      "url": "https://hooks.slack.com/services/...",
      "formatter": "changeToMarkdown"
    }
  }
```

 ## Changes

  - HttpActionConfig.java — optional formatter field
  - HttpAction.java — format and wrap payload when formatter is configured
  - ActionComponentForm.tsx — formatter dropdown for http action in UI

## Backwards compatibility

  Fully backwards compatible — existing http actions without formatter are unaffected.
